### PR TITLE
Implement new ClientBuilder pattern for login

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -2472,8 +2472,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = exactVersion;
+				version = "1.0.11-alpha";
 			};
 		};
 		61916C63E3F5BD900F08DA0C /* XCRemoteSwiftPackageReference "KeychainAccess" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",
       "state" : {
-        "revision" : "59eb199fdb8dd47733624e8b0277822d0232579e",
-        "version" : "7.2.2"
+        "revision" : "022e4eeb79f817748544b318b991d9a70036bbf8",
+        "version" : "7.2.4"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "43c88a4b0912a1589c2a28cc9bb2df45c70cdcad"
+        "revision" : "4605577f5604b4f2bb1938eb06d69d996eb32a28",
+        "version" : "1.0.11-alpha"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "b34ce9048e6b8b082ea6b15e6b50583d46c936ea",
-        "version" : "7.16.0"
+        "revision" : "f906913c14eadb6fd31988db1ea9ff10aec9f198",
+        "version" : "7.18.1"
       }
     },
     {

--- a/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
+++ b/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1200"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/ElementX/Sources/Screens/Authentication/AuthenticationCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/AuthenticationCoordinator.swift
@@ -108,10 +108,14 @@ class AuthenticationCoordinator: Coordinator {
         delegate?.authenticationCoordinatorDidStartLoading(self)
         
         let basePath = userSessionStore.baseDirectoryPath(for: username)
-        let loginTask = Task.detached {
-            try loginNewClient(basePath: basePath,
-                               username: username,
-                               password: password)
+        let builder = ClientBuilder()
+            .basePath(path: basePath)
+            .username(username: username)
+        
+        let loginTask: Task<Client, Error> = Task.detached {
+            let client = try builder.build()
+            try client.login(username: username, password: password)
+            return client
         }
         
         switch await loginTask.result {

--- a/ElementX/Sources/Services/UserSessionStore/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSessionStore/UserSessionStore.swift
@@ -78,9 +78,14 @@ class UserSessionStore: UserSessionStoreProtocol {
         Benchmark.startTrackingForIdentifier("Login", message: "Started restoring previous login")
         
         let basePath = baseDirectoryPath(for: usernameTokenTuple.username)
-        let loginTask = Task.detached {
-            try loginWithToken(basePath: basePath,
-                               restoreToken: usernameTokenTuple.accessToken)
+        let builder = ClientBuilder()
+            .basePath(path: basePath)
+            .username(username: usernameTokenTuple.username)
+        
+        let loginTask: Task<Client, Error> = Task.detached {
+            let client = try builder.build()
+            try client.restoreLogin(restoreToken: usernameTokenTuple.accessToken)
+            return client
         }
         
         switch await loginTask.result {

--- a/changelog.d/pr-120.change
+++ b/changelog.d/pr-120.change
@@ -1,0 +1,1 @@
+Implement new ClientBuilder pattern for login

--- a/project.yml
+++ b/project.yml
@@ -31,7 +31,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift.git
-    branch: main
+    exactVersion: 1.0.11-alpha
   DesignKit:
     path: ./
   DTCoreText:


### PR DESCRIPTION
After making changes to the [Rust FFI](https://github.com/matrix-org/matrix-rust-sdk/pull/739) adopt the new style of login: first create a configure `ClientBuilder`, then build `Client`, finally login.

Additionally pin the version of Rust SDK