### PR TITLE
Flatten room list

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -36,20 +36,12 @@ struct HomeScreenViewState: BindableState {
     
     var isLoadingRooms: Bool = false
     
-    var unencryptedDMs: [HomeScreenRoom] {
-        searchFilteredRooms.filter { $0.isDirect && !$0.isEncrypted }
+    var visibleDMs: [HomeScreenRoom] {
+        searchFilteredRooms.filter { $0.isDirect }
     }
-    
-    var encryptedDMs: [HomeScreenRoom] {
-        searchFilteredRooms.filter { $0.isDirect && $0.isEncrypted}
-    }
-    
-    var unencryptedRooms: [HomeScreenRoom] {
-        searchFilteredRooms.filter { !$0.isDirect && !$0.isEncrypted }
-    }
-    
-    var encryptedRooms: [HomeScreenRoom] {
-        searchFilteredRooms.filter { !$0.isDirect && $0.isEncrypted }
+
+    var visibleRooms: [HomeScreenRoom] {
+        searchFilteredRooms.filter { !$0.isDirect }
     }
     
     private var searchFilteredRooms: LazyFilterSequence<LazySequence<[HomeScreenRoom]>.Elements> {

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -41,6 +41,7 @@ struct HomeScreen: View {
                     Section(ElementL10n.bottomActionPeople) {
                         ForEach(context.viewState.visibleDMs) { room in
                             RoomCell(room: room, context: context)
+                                .listRowBackground(Color.clear)
                         }
                     }
                 }
@@ -55,39 +56,46 @@ struct HomeScreen: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                HStack {
-                    ZStack {
-                        if let avatar = context.viewState.userAvatar {
-                            Button { context.send(viewAction: .tapUserAvatar) } label: {
-                                Image(uiImage: avatar)
-                                    .resizable()
-                                    .scaledToFill()
-                                    .frame(width: 40, height: 40, alignment: .center)
-                                    .mask(Circle())
-                            }
-                        } else {
-                            EmptyView()
-                        }
-                    }
-                    .animation(.default, value: context.viewState.userAvatar)
-                    .transition(.opacity)
-                    
-                    ZStack {
-                        if let displayName = context.viewState.userDisplayName {
-                            Button { context.send(viewAction: .tapUserAvatar) } label: {
-                                Text(displayName)
-                                    .font(.subheadline)
-                                    .fontWeight(.bold)
-                                    .foregroundColor(.primary)
-                            }
-                        } else {
-                            EmptyView()
-                        }
-                    }
-                    .animation(.default, value: context.viewState.userDisplayName)
-                    .transition(.opacity)
+                HStack(spacing: 0) {
+                    userAvatarImage
+                        .animation(.default, value: context.viewState.userAvatar)
+                        .transition(.opacity)
+
+                    userDisplayNameView
+                        .animation(.default, value: context.viewState.userDisplayName)
+                        .transition(.opacity)
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private var userAvatarImage: some View {
+        if let avatar = context.viewState.userAvatar {
+            Button { context.send(viewAction: .tapUserAvatar) } label: {
+                Image(uiImage: avatar)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 32, height: 32, alignment: .center)
+                    .clipShape(Circle())
+                    .accessibilityIdentifier("userAvatarImage")
+            }
+        } else {
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var userDisplayNameView: some View {
+        if let displayName = context.viewState.userDisplayName {
+            Button { context.send(viewAction: .tapUserAvatar) } label: {
+                Text(displayName)
+                    .font(.headline)
+                    .fontWeight(.bold)
+                    .foregroundColor(.primary)
+            }
+        } else {
+            EmptyView()
         }
     }
 }
@@ -107,7 +115,7 @@ struct RoomCell: View {
                         .resizable()
                         .scaledToFill()
                         .frame(width: 40, height: 40)
-                        .mask(Circle())
+                        .clipShape(Circle())
                 } else {
                     PlaceholderAvatarImage(text: room.displayName ?? room.id)
                         .clipShape(Circle())
@@ -170,11 +178,14 @@ struct HomeScreen_Previews: PreviewProvider {
                              MockRoomSummary(displayName: "Omega", lastMessage: eventBrief)]
         
         viewModel.updateWithRoomSummaries(roomSummaries)
+        viewModel.updateWithUserDisplayName("username")
         
-        if let avatarImage = UIImage(systemName: "person.fill.questionmark") {
+        if let avatarImage = UIImage(systemName: "person.fill") {
             viewModel.updateWithUserAvatar(avatarImage)
         }
         
-        return HomeScreen(context: viewModel.context)
+        return NavigationView {
+            HomeScreen(context: viewModel.context)
+        }
     }
 }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -26,43 +26,21 @@ struct HomeScreen: View {
         VStack(spacing: 16.0) {
             if context.viewState.isLoadingRooms {
                 VStack {
-                    Text("Loading rooms")
+                    Text(ElementL10n.loading)
                     ProgressView()
                 }
             } else {
                 List {
-                    Section("Rooms") {
-                        ForEach(context.viewState.unencryptedRooms) { room in
+                    Section(ElementL10n.rooms) {
+                        ForEach(context.viewState.visibleRooms) { room in
                             RoomCell(room: room, context: context)
                                 .listRowBackground(Color.clear)
                         }
-                        
-                        let other = context.viewState.encryptedRooms
-                        
-                        if other.count > 0 {
-                            DisclosureGroup("Encrypted") {
-                                ForEach(other) { room in
-                                    RoomCell(room: room, context: context)
-                                }
-                            }
-                            .listRowBackground(Color.clear)
-                        }
                     }
                     
-                    Section("People") {
-                        ForEach(context.viewState.unencryptedDMs) { room in
+                    Section(ElementL10n.bottomActionPeople) {
+                        ForEach(context.viewState.visibleDMs) { room in
                             RoomCell(room: room, context: context)
-                        }
-                        
-                        let other = context.viewState.encryptedDMs
-                        
-                        if other.count > 0 {
-                            DisclosureGroup("Encrypted") {
-                                ForEach(other) { room in
-                                    RoomCell(room: room, context: context)
-                                }
-                            }
-                            .listRowBackground(Color.clear)
                         }
                     }
                 }
@@ -97,7 +75,7 @@ struct HomeScreen: View {
                     ZStack {
                         if let displayName = context.viewState.userDisplayName {
                             Button { context.send(viewAction: .tapUserAvatar) } label: {
-                                Text("Hello, \(displayName)!")
+                                Text(displayName)
                                     .font(.subheadline)
                                     .fontWeight(.bold)
                                     .foregroundColor(.primary)

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -56,14 +56,16 @@ struct HomeScreen: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                HStack(spacing: 0) {
-                    userAvatarImage
-                        .animation(.default, value: context.viewState.userAvatar)
-                        .transition(.opacity)
+                Button { context.send(viewAction: .tapUserAvatar) } label: {
+                    HStack {
+                        userAvatarImage
+                            .animation(.default, value: context.viewState.userAvatar)
+                            .transition(.opacity)
 
-                    userDisplayNameView
-                        .animation(.default, value: context.viewState.userDisplayName)
-                        .transition(.opacity)
+                        userDisplayNameView
+                            .animation(.default, value: context.viewState.userDisplayName)
+                            .transition(.opacity)
+                    }
                 }
             }
         }
@@ -72,14 +74,12 @@ struct HomeScreen: View {
     @ViewBuilder
     private var userAvatarImage: some View {
         if let avatar = context.viewState.userAvatar {
-            Button { context.send(viewAction: .tapUserAvatar) } label: {
-                Image(uiImage: avatar)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: 32, height: 32, alignment: .center)
-                    .clipShape(Circle())
-                    .accessibilityIdentifier("userAvatarImage")
-            }
+            Image(uiImage: avatar)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 32, height: 32, alignment: .center)
+                .clipShape(Circle())
+                .accessibilityIdentifier("userAvatarImage")
         } else {
             EmptyView()
         }
@@ -88,12 +88,10 @@ struct HomeScreen: View {
     @ViewBuilder
     private var userDisplayNameView: some View {
         if let displayName = context.viewState.userDisplayName {
-            Button { context.send(viewAction: .tapUserAvatar) } label: {
-                Text(displayName)
-                    .font(.headline)
-                    .fontWeight(.bold)
-                    .foregroundColor(.primary)
-            }
+            Text(displayName)
+                .font(.headline)
+                .fontWeight(.bold)
+                .foregroundColor(.primary)
         } else {
             EmptyView()
         }

--- a/changelog.d/pr-121.change
+++ b/changelog.d/pr-121.change
@@ -1,0 +1,1 @@
+Flatten the room list by removing the encrypted groups.


### PR DESCRIPTION
Flattens the room list by removing encrypted groups. Also styles the screen a bit.

![Simulator Screen Shot - iPhone 13 Pro Max - 2022-06-30 at 02 32 20](https://user-images.githubusercontent.com/3072286/176563023-2c6ad8fe-8a2f-411e-8916-41afb78ade67.png)
