### PR TITLE
Add Screen suffix to all screens.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		0033481EE363E4914295F188 /* LocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C070FD43DC6BF4E50217965A /* LocalizationTests.swift */; };
 		004561D297DC8B9786AE136F /* UITestScreenIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD9D66B75292F2CC11AA4D2 /* UITestScreenIdentifier.swift */; };
-		00AC53151BA23A90FAAE9FBF /* BugReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D607F47FDEF16CC63684BE0 /* BugReport.swift */; };
 		00F3059B1E0CFCA019710C3E /* BugReportModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B516212D9FE785DDD5E490D1 /* BugReportModels.swift */; };
 		01CB8ACFA5E143E89C168CA8 /* TimelineItemContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43AF03660F5FD4FFFA7F1CE /* TimelineItemContextMenu.swift */; };
 		01F4A40C1EDCEC8DC4EC9CFA /* WeakDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109C0201D8CB3F947340DC80 /* WeakDictionary.swift */; };
@@ -64,7 +63,7 @@
 		2BAA5B222856068158D0B3C6 /* MatrixRustSDK in Frameworks */ = {isa = PBXBuildFile; productRef = B1E8B697DF78FE7F61FC6CA4 /* MatrixRustSDK */; };
 		2C0CE61E5DC177938618E0B1 /* RootRouterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90733775209F4D4D366A268F /* RootRouterType.swift */; };
 		2E59008365E01F0AFB3A6B24 /* ImageRoomMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF686BA36D0C2FA3C63DFDF /* ImageRoomMessage.swift */; };
-		2E68C57E7D644E94778743D5 /* TemplateSimpleScreenUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B66E05B6009B0EB1BDBFA6E /* TemplateSimpleScreenUITests.swift */; };
+		2E68C57E7D644E94778743D5 /* TemplateScreenUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B66E05B6009B0EB1BDBFA6E /* TemplateScreenUITests.swift */; };
 		2F1CF90A3460C153154427F0 /* RoomScreenUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086B997409328F091EBA43CE /* RoomScreenUITests.swift */; };
 		2F30EFEB7BD39242D1AD96F3 /* LoginViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E1FB768A24FDD2A5CA16E3C /* LoginViewModelProtocol.swift */; };
 		2F94054F50E312AF30BE07F3 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B21E611DADDEF00307E7AC /* String.swift */; };
@@ -75,10 +74,11 @@
 		344AF4CBB6D8786214878642 /* NavigationRouterStoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9D5F812E5AD6DC786DBC9B /* NavigationRouterStoreProtocol.swift */; };
 		34966D4C1C2C6D37FE3F7F50 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD2D50A7EAA4FC78417730E /* SettingsCoordinator.swift */; };
 		352C439BE0F75E101EF11FB1 /* RoomScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2886615BEBAE33A0AA4D5F8 /* RoomScreenModels.swift */; };
+		3588F34D05B4D731A73214C6 /* BugReportScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED59F9EFF273BFA2055FFDF /* BugReportScreen.swift */; };
 		35E975CFDA60E05362A7CF79 /* target.yml in Resources */ = {isa = PBXBuildFile; fileRef = 1222DB76B917EB8A55365BA5 /* target.yml */; };
 		368C8758FCD079E6AAA18C2C /* NoticeRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B243E7818E5E9F6A4EDC7A /* NoticeRoomTimelineView.swift */; };
 		36AC963F2F04069B7FF1AA0C /* UIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6D88E8AFFBF2C1D589C0FA /* UIConstants.swift */; };
-		3772354754450F2B54107E17 /* TemplateSimpleScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4EDB32B97910AAAFE632B2 /* TemplateSimpleScreenViewModelProtocol.swift */; };
+		3772354754450F2B54107E17 /* TemplateViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4EDB32B97910AAAFE632B2 /* TemplateViewModelProtocol.swift */; };
 		38546A6010A2CF240EC9AF73 /* BindableState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA1D2CBAEA5D0BD00B90D1B /* BindableState.swift */; };
 		388FD50AC66E9E684DDFA9D8 /* ServerSelectionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D2C0950F8196232D88045C /* ServerSelectionScreen.swift */; };
 		38C76D586404C1FDED095F3A /* LoginModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B01468022EC826CB2FD2C0 /* LoginModels.swift */; };
@@ -90,7 +90,6 @@
 		418B4AEFD03DC7A6D2C9D5C8 /* EventBriefFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36322DD0D4E29D31B0945ADC /* EventBriefFactory.swift */; };
 		41DFDD212D1BE57CA50D783B /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 7731767AE437BA3BD2CC14A8 /* Sentry */; };
 		438FB9BC535BC95948AA5F34 /* SettingsViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2F9D5C39A4494D19F33E38 /* SettingsViewModelProtocol.swift */; };
-		45EE94D927EA75C2CF70A96A /* SplashScreenPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE03C54FC7AAE0FC03EC8976 /* SplashScreenPage.swift */; };
 		462813B93C39DF93B1249403 /* RoundedToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFABDF2E19D349DAAAC18C65 /* RoundedToastView.swift */; };
 		46562110EE202E580A5FFD9C /* RoomScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CF7B19FFCF8EFBE0A8696A /* RoomScreenViewModelTests.swift */; };
 		4669804D0369FBED4E8625D1 /* ToastViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4470B8CB654B097D807AA713 /* ToastViewPresenter.swift */; };
@@ -117,7 +116,7 @@
 		59C41313AED7566C3AC51163 /* RoomSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A953B6C0C431DBF4DD00B4 /* RoomSummary.swift */; };
 		5B2C4C17888FC095ED6880B2 /* SplashViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 48971F1FFD7FC5C466889FC7 /* SplashViewController.xib */; };
 		5C8AFBF168A41E20835F3B86 /* LoginScreenUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB34B0C74CD242FED9DD069 /* LoginScreenUITests.swift */; };
-		5CABC57F620FBB39F4EC127C /* TemplateSimpleScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BA045DC4CA12D030ACF558 /* TemplateSimpleScreen.swift */; };
+		5CABC57F620FBB39F4EC127C /* TemplateScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BA045DC4CA12D030ACF558 /* TemplateScreen.swift */; };
 		5D430CDE11EAC3E8E6B80A66 /* RoomTimelineViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEE631F3A4AFDC6652DD9DA /* RoomTimelineViewFactory.swift */; };
 		5E0F2E612718BB4397A6D40A /* TextRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E785D5137510481733A3E8 /* TextRoomTimelineView.swift */; };
 		5E1FCC43B738941D5A5F1794 /* SplashScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B73A8C3118EAC7BF3F3EE7A /* SplashScreenViewModelProtocol.swift */; };
@@ -132,13 +131,13 @@
 		69BCBB4FB2DC3D61A28D3FD8 /* TimelineStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC2C9E0E15C79BBDA80F0A2 /* TimelineStyle.swift */; };
 		6A367F3D7A437A79B7D9A31C /* FullscreenLoadingViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4112D04077F6709C5CA0A13E /* FullscreenLoadingViewPresenter.swift */; };
 		6AC1DC1EAD9F7568360DA1BA /* ServerSelectionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30A1758E2B73EF38E7C42F8 /* ServerSelectionModels.swift */; };
-		6C72F66DA26A0956E9A9077A /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEB3259B2208E5AE5BB3F65 /* Settings.swift */; };
 		6D046D653DA28ADF1E6E59A4 /* BackgroundTaskServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE73D571D4F9C36DD45255A /* BackgroundTaskServiceProtocol.swift */; };
 		6EA61FCA55D950BDE326A1A7 /* ImageAnonymizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12A626D74BBE9F4A60763B45 /* ImageAnonymizer.swift */; };
 		6F2AB43A1EFAD8A97AF41A15 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 0DD568A494247444A4B56031 /* Kingfisher */; };
 		6FC10A00D268FCD48B631E37 /* ViewFrameReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF7BF82A950B91BC5469E91 /* ViewFrameReader.swift */; };
 		7002C55A4C917F3715765127 /* MediaProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C888BCD78E2A55DCE364F160 /* MediaProviderProtocol.swift */; };
 		706F79A39BDB32F592B8C2C7 /* UIKitBackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FCD9116ADDE820E4E30F92 /* UIKitBackgroundTask.swift */; };
+		72F6E890820FF606A7E276C8 /* SplashScreenPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A534A4619D8FEFB6439FCC /* SplashScreenPageView.swift */; };
 		7405B4824D45BA7C3D943E76 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0CBC76C80E04345E11F2DB /* Application.swift */; };
 		74604ACFDBE7F54260E7B617 /* ApplicationProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8903A9F615BBD0E6D7CD133 /* ApplicationProtocol.swift */; };
 		758BF44CA565AB0AB84F2185 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7109E709A7738E6BCC4553E6 /* Localizable.strings */; };
@@ -150,7 +149,6 @@
 		7963F98CDFDEAC75E072BD81 /* TextRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A8C632CEF4600107792899 /* TextRoomTimelineItem.swift */; };
 		79A6E08ADE6E7C460A8A17A5 /* UserSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C37FB986891D90BEAA93EAE /* UserSessionStore.swift */; };
 		7A54700193DC1F264368746A /* UserIndicatorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E077F76026C85ED96FEBB810 /* UserIndicatorPresenter.swift */; };
-		7B3D3AFD511D496DED18910B /* TemplateSimpleScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C485C186CEC78443DA96BDC8 /* TemplateSimpleScreenViewModelTests.swift */; };
 		7BB31E67648CF32D2AB5E502 /* RoomScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE3C90E487B255B735D73C8 /* RoomScreenViewModel.swift */; };
 		7C1A7B594B2F8143F0DD0005 /* ElementXAttributeScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = C024C151639C4E1B91FCC68B /* ElementXAttributeScope.swift */; };
 		7D1DAAA364A9A29D554BD24E /* PlaceholderAvatarImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0950733DD4BA83EEE752E259 /* PlaceholderAvatarImage.swift */; };
@@ -158,6 +156,7 @@
 		7F19E97E7985F518C9018B83 /* RootRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF47564C584F614B7287F3EB /* RootRouter.swift */; };
 		7F61F9ACD5EC9E845EF3EFBF /* BugReportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD3200F9960D4996159F10 /* BugReportServiceTests.swift */; };
 		7FA4227B2BAAA71560252866 /* UserIndicatorDismissal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D1532B5D9FB0C8461A1453 /* UserIndicatorDismissal.swift */; };
+		7FED310F6AB7A70CBFB7C8A3 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C483956FA3D665E3842E319A /* SettingsScreen.swift */; };
 		80E04BE80A89A78FBB4863BB /* UserIndicatorViewPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193FB285430D3956B6E61E4D /* UserIndicatorViewPresentable.swift */; };
 		83E5054739949181CA981193 /* LoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD667C4BB98CF4F3FE2CE3B0 /* LoginCoordinator.swift */; };
 		85AFBB433AD56704A880F8A0 /* FramePreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4798B3B7A1E8AE3901CEE8C6 /* FramePreferenceKey.swift */; };
@@ -205,7 +204,7 @@
 		AB34401E4E1CAD5D2EC3072B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9760103CF316DF68698BCFE6 /* LaunchScreen.storyboard */; };
 		ABF3FAB234AD3565B214309B /* TimelineSenderAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC588051E6572A1AF51D738 /* TimelineSenderAvatarView.swift */; };
 		B037C365CF8A58A0D149A2DB /* AuthenticationIconImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97755C01C3971474EFAD5367 /* AuthenticationIconImage.swift */; };
-		B0EDAF55877DE19B67837C22 /* TemplateSimpleScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C29670CEC77346F31EE94C /* TemplateSimpleScreenModels.swift */; };
+		B0EDAF55877DE19B67837C22 /* TemplateModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C29670CEC77346F31EE94C /* TemplateModels.swift */; };
 		B245583C63F8F90357B87FAE /* SwiftState in Frameworks */ = {isa = PBXBuildFile; productRef = 3853B78FB8531B83936C5DA6 /* SwiftState */; };
 		B3357B00F1AA930E54F76609 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47EBB5D698CE9A25BB553A2D /* Strings.swift */; };
 		B3FDB1D9CF40777695DBBD1D /* AppCoordinatorStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9AB74614131D6706894E0C /* AppCoordinatorStateMachine.swift */; };
@@ -222,7 +221,7 @@
 		BEEC06EFD30BFCA02F0FD559 /* UserIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D8EA85D4F10D7445BB6368A /* UserIndicatorTests.swift */; };
 		BF35062D06888FA80BD139FF /* Presentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB7F9D6FC121204D59E18DF /* Presentable.swift */; };
 		C052A8CDC7A8E7A2D906674F /* UserIndicatorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FAA6438B00FDB130F404E31 /* UserIndicatorStore.swift */; };
-		C1156BBE4F977AEEE1E80C48 /* TemplateSimpleScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2869CFFF6CD2A642AB4B743 /* TemplateSimpleScreenCoordinator.swift */; };
+		C1156BBE4F977AEEE1E80C48 /* TemplateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2869CFFF6CD2A642AB4B743 /* TemplateCoordinator.swift */; };
 		C2CF93B067FD935E4F82FE44 /* SplashScreenPageIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850064FF8D7DB9C875E7AA1A /* SplashScreenPageIndicator.swift */; };
 		C4F69156C31A447FEFF2A47C /* DTHTMLElement+AttributedStringBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E508AB0EDEE017FF4F6F8D1 /* DTHTMLElement+AttributedStringBuilder.swift */; };
 		C55A44C99F64A479ABA85B46 /* RoomScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5221DFDF809142A2D6AC82B9 /* RoomScreen.swift */; };
@@ -250,12 +249,13 @@
 		DFF7D6A6C26DDD40D00AE579 /* target.yml in Resources */ = {isa = PBXBuildFile; fileRef = F012CB5EE3F2B67359F6CC52 /* target.yml */; };
 		E0A4DCA633D174EB43AD599F /* BackgroundTaskProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA028DCD4157F9A1F999827 /* BackgroundTaskProtocol.swift */; };
 		E1DF24D085572A55C9758A2D /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E89E530A8E92EC44301CA1 /* Bundle.swift */; };
+		E75CE800B3E64D0F7F8E228D /* TemplateViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08E9043618AE5B0BF7B07E1 /* TemplateViewModelTests.swift */; };
 		E81EEC1675F2371D12A880A3 /* MockRoomTimelineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ADFB893DEF81E58DF3FAB9 /* MockRoomTimelineController.swift */; };
 		EA1E7949533E19C6D862680A /* MediaProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885D8C42DD17625B5261BEFF /* MediaProvider.swift */; };
 		EA31DD9043B91ECB8E45A9A6 /* ScreenshotDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03C9D319676F3C0DC6B0203 /* ScreenshotDetectorTests.swift */; };
 		EA65360A0EC026DD83AC0CF5 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CA5F386C7701C129398945 /* AuthenticationCoordinator.swift */; };
 		EBD6C79705B3DDB2F7E5F554 /* UserSessionStoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1B52D0ABBA7091A991CAFE /* UserSessionStoreProtocol.swift */; };
-		ED4F663C783E9A8C0E80B983 /* TemplateSimpleScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47543EB19F3DCF308751F53C /* TemplateSimpleScreenViewModel.swift */; };
+		ED4F663C783E9A8C0E80B983 /* TemplateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47543EB19F3DCF308751F53C /* TemplateViewModel.swift */; };
 		EE8491AD81F47DF3C192497B /* DecorationTimelineItemProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184CF8C196BE143AE226628D /* DecorationTimelineItemProtocol.swift */; };
 		EEC40663922856C65D1E0DF5 /* KeychainControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB9C37196A4C79F24CE80C6 /* KeychainControllerTests.swift */; };
 		EF99A92701E401C4CD5ADC50 /* SplashScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE978A6118C131D7F2A04B3 /* SplashScreenModels.swift */; };
@@ -342,6 +342,7 @@
 		21BA866267F84BF4350B0CB7 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "pt-BR"; path = "pt-BR.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		22B384D54464FA39C6C7F6E7 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ca; path = ca.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		233D5F7E5E9F49ABF3413291 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = hr; path = hr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		24A534A4619D8FEFB6439FCC /* SplashScreenPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreenPageView.swift; sourceTree = "<group>"; };
 		24B0C97D2F560BCB72BE73B1 /* RoomTimelineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineController.swift; sourceTree = "<group>"; };
 		24F5530B2212862FA4BEFF2D /* HomeScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		2583416C8974272ADBADDBE1 /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-TW"; path = "zh-TW.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
@@ -351,7 +352,6 @@
 		29A953B6C0C431DBF4DD00B4 /* RoomSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSummary.swift; sourceTree = "<group>"; };
 		2A5C6FBF97B6EED3D4FA5EFF /* AttributedStringBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedStringBuilder.swift; sourceTree = "<group>"; };
 		2AE83A3DD63BCFBB956FE5CB /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = nl; path = nl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
-		2BEB3259B2208E5AE5BB3F65 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		2CA028DCD4157F9A1F999827 /* BackgroundTaskProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskProtocol.swift; sourceTree = "<group>"; };
 		2CF9FE7E0CF9F40D1509E63A /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = bg; path = bg.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		2EEB64CC6F3DF5B68736A6B4 /* AlertInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertInfo.swift; sourceTree = "<group>"; };
@@ -392,7 +392,7 @@
 		453E722A43D092C06FB8E3FA /* tzm */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tzm; path = tzm.lproj/Localizable.strings; sourceTree = "<group>"; };
 		47111410B6E659A697D472B5 /* RoomProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomProxyProtocol.swift; sourceTree = "<group>"; };
 		471EB7D96AFEA8D787659686 /* EmoteRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoteRoomTimelineView.swift; sourceTree = "<group>"; };
-		47543EB19F3DCF308751F53C /* TemplateSimpleScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateSimpleScreenViewModel.swift; sourceTree = "<group>"; };
+		47543EB19F3DCF308751F53C /* TemplateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateViewModel.swift; sourceTree = "<group>"; };
 		475EB595D7527E9A8A14043E /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4798B3B7A1E8AE3901CEE8C6 /* FramePreferenceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FramePreferenceKey.swift; sourceTree = "<group>"; };
 		47EBB5D698CE9A25BB553A2D /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
@@ -404,7 +404,7 @@
 		49EAD710A2C16EFF7C3EA16F /* Benchmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Benchmark.swift; sourceTree = "<group>"; };
 		4B40B7F6FCCE2D8C242492D9 /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4B41FABA2B0AEF4389986495 /* LoginMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginMode.swift; sourceTree = "<group>"; };
-		4B66E05B6009B0EB1BDBFA6E /* TemplateSimpleScreenUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateSimpleScreenUITests.swift; sourceTree = "<group>"; };
+		4B66E05B6009B0EB1BDBFA6E /* TemplateScreenUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateScreenUITests.swift; sourceTree = "<group>"; };
 		4C82DAE0B8EB28234E84E6CF /* ToastViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastViewState.swift; sourceTree = "<group>"; };
 		4C8D988E82A8DFA13BE46F7C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = pl; path = pl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		4CD6AC7546E8D7E5C73CEA48 /* ElementX.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = ElementX.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -454,7 +454,6 @@
 		6A152791A2F56BD193BFE986 /* MemberDetailsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberDetailsProvider.swift; sourceTree = "<group>"; };
 		6A901D95158B02CA96C79C7F /* InfoPlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPlist.swift; sourceTree = "<group>"; };
 		6B73A8C3118EAC7BF3F3EE7A /* SplashScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreenViewModelProtocol.swift; sourceTree = "<group>"; };
-		6D607F47FDEF16CC63684BE0 /* BugReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReport.swift; sourceTree = "<group>"; };
 		6DB53055CB130F0651C70763 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6DFCAA239095A116976E32C4 /* BackgroundTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskTests.swift; sourceTree = "<group>"; };
 		6E5E9C044BEB7C70B1378E91 /* UserSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSession.swift; sourceTree = "<group>"; };
@@ -529,7 +528,7 @@
 		A00C7A331B72C0F05C00392F /* RoomScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		A05707BF550D770168A406DB /* LoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModelTests.swift; sourceTree = "<group>"; };
 		A0A20AE75FF4FF35B1FF6CA7 /* MockServerSelectionScreenState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockServerSelectionScreenState.swift; sourceTree = "<group>"; };
-		A1C29670CEC77346F31EE94C /* TemplateSimpleScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateSimpleScreenModels.swift; sourceTree = "<group>"; };
+		A1C29670CEC77346F31EE94C /* TemplateModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateModels.swift; sourceTree = "<group>"; };
 		A1ED7E89865201EE7D53E6DA /* SeparatorRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorRoomTimelineItem.swift; sourceTree = "<group>"; };
 		A2B6433F516F1E6DFA0E2D89 /* vls */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vls; path = vls.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A30A1758E2B73EF38E7C42F8 /* ServerSelectionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionModels.swift; sourceTree = "<group>"; };
@@ -575,15 +574,15 @@
 		B8A56EA2A5AE726F445CB2E3 /* eo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = eo; path = eo.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		B902EA6CD3296B0E10EE432B /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
 		BC9B05D6B293A039EB963CA7 /* az */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = az; path = az.lproj/Localizable.strings; sourceTree = "<group>"; };
-		BE03C54FC7AAE0FC03EC8976 /* SplashScreenPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreenPage.swift; sourceTree = "<group>"; };
 		BE6C10032A77AE7DC5AA4C50 /* MessageComposerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerTextField.swift; sourceTree = "<group>"; };
 		BEE6BF9BA63FF42F8AF6EEEA /* sr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = sr; path = sr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		BF1B52D0ABBA7091A991CAFE /* UserSessionStoreProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionStoreProtocol.swift; sourceTree = "<group>"; };
 		C024C151639C4E1B91FCC68B /* ElementXAttributeScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementXAttributeScope.swift; sourceTree = "<group>"; };
 		C070FD43DC6BF4E50217965A /* LocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationTests.swift; sourceTree = "<group>"; };
+		C08E9043618AE5B0BF7B07E1 /* TemplateViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateViewModelTests.swift; sourceTree = "<group>"; };
 		C21ECC295F4DE8DAA86D62AC /* RoomSummaryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSummaryProtocol.swift; sourceTree = "<group>"; };
 		C2886615BEBAE33A0AA4D5F8 /* RoomScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreenModels.swift; sourceTree = "<group>"; };
-		C485C186CEC78443DA96BDC8 /* TemplateSimpleScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateSimpleScreenViewModelTests.swift; sourceTree = "<group>"; };
+		C483956FA3D665E3842E319A /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		C6FEA87EA3752203065ECE27 /* BugReportUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportUITests.swift; sourceTree = "<group>"; };
 		C88508B6F7974CFABEC4B261 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C888BCD78E2A55DCE364F160 /* MediaProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProviderProtocol.swift; sourceTree = "<group>"; };
@@ -617,11 +616,12 @@
 		DCE978A6118C131D7F2A04B3 /* SplashScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreenModels.swift; sourceTree = "<group>"; };
 		DD667C4BB98CF4F3FE2CE3B0 /* LoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinator.swift; sourceTree = "<group>"; };
 		DD73FAAA4A76CE4A1F3014D9 /* UserIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIndicator.swift; sourceTree = "<group>"; };
+		DED59F9EFF273BFA2055FFDF /* BugReportScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportScreen.swift; sourceTree = "<group>"; };
 		E077F76026C85ED96FEBB810 /* UserIndicatorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIndicatorPresenter.swift; sourceTree = "<group>"; };
 		E0FCA0957FAA0E15A9F5579D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Untranslated.stringsdict; sourceTree = "<group>"; };
 		E157152B11E347F735C3FD6E /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = tr; path = tr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		E18CF12478983A5EB390FB26 /* MessageComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposer.swift; sourceTree = "<group>"; };
-		E2869CFFF6CD2A642AB4B743 /* TemplateSimpleScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateSimpleScreenCoordinator.swift; sourceTree = "<group>"; };
+		E2869CFFF6CD2A642AB4B743 /* TemplateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateCoordinator.swift; sourceTree = "<group>"; };
 		E3E29F98CF0E960689A410E3 /* SettingsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUITests.swift; sourceTree = "<group>"; };
 		E45C57120F28F8D619150219 /* sr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr; path = sr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E5272BC4A60B6AD7553BACA1 /* BlurHashDecode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurHashDecode.swift; sourceTree = "<group>"; };
@@ -651,12 +651,12 @@
 		F73FF1A33198F5FAE9D34B1F /* FormattedBodyText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattedBodyText.swift; sourceTree = "<group>"; };
 		F77C060C2ACC4CB7336A29E7 /* EmoteRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoteRoomTimelineItem.swift; sourceTree = "<group>"; };
 		F7B81C8227BBEA95CCE86037 /* MatrixEntitityRegex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixEntitityRegex.swift; sourceTree = "<group>"; };
-		F9BA045DC4CA12D030ACF558 /* TemplateSimpleScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateSimpleScreen.swift; sourceTree = "<group>"; };
+		F9BA045DC4CA12D030ACF558 /* TemplateScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateScreen.swift; sourceTree = "<group>"; };
 		F9E785D5137510481733A3E8 /* TextRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRoomTimelineView.swift; sourceTree = "<group>"; };
 		FA154570F693D93513E584C1 /* RoomMessageFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMessageFactory.swift; sourceTree = "<group>"; };
 		FDB9C37196A4C79F24CE80C6 /* KeychainControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainControllerTests.swift; sourceTree = "<group>"; };
 		FE2DF459F1737A594667CC46 /* EmoteRoomMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoteRoomMessage.swift; sourceTree = "<group>"; };
-		FF4EDB32B97910AAAFE632B2 /* TemplateSimpleScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateSimpleScreenViewModelProtocol.swift; sourceTree = "<group>"; };
+		FF4EDB32B97910AAAFE632B2 /* TemplateViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateViewModelProtocol.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -886,7 +886,7 @@
 		4541090DFE1A5499BD67BD14 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				2BEB3259B2208E5AE5BB3F65 /* Settings.swift */,
+				C483956FA3D665E3842E319A /* SettingsScreen.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -915,7 +915,7 @@
 		4AC3BA2B379A928301E21004 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				F9BA045DC4CA12D030ACF558 /* TemplateSimpleScreen.swift */,
+				F9BA045DC4CA12D030ACF558 /* TemplateScreen.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -948,7 +948,7 @@
 		58F951CB7BD7F96C37BE5CAD /* View */ = {
 			isa = PBXGroup;
 			children = (
-				6D607F47FDEF16CC63684BE0 /* BugReport.swift */,
+				DED59F9EFF273BFA2055FFDF /* BugReportScreen.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1020,7 +1020,7 @@
 		73AB116809AE89292624CD8E /* Unit */ = {
 			isa = PBXGroup;
 			children = (
-				C485C186CEC78443DA96BDC8 /* TemplateSimpleScreenViewModelTests.swift */,
+				C08E9043618AE5B0BF7B07E1 /* TemplateViewModelTests.swift */,
 			);
 			path = Unit;
 			sourceTree = "<group>";
@@ -1073,10 +1073,10 @@
 		789DD6B31BA8BB4B3A40EF7C /* ElementX */ = {
 			isa = PBXGroup;
 			children = (
-				E2869CFFF6CD2A642AB4B743 /* TemplateSimpleScreenCoordinator.swift */,
-				A1C29670CEC77346F31EE94C /* TemplateSimpleScreenModels.swift */,
-				47543EB19F3DCF308751F53C /* TemplateSimpleScreenViewModel.swift */,
-				FF4EDB32B97910AAAFE632B2 /* TemplateSimpleScreenViewModelProtocol.swift */,
+				E2869CFFF6CD2A642AB4B743 /* TemplateCoordinator.swift */,
+				A1C29670CEC77346F31EE94C /* TemplateModels.swift */,
+				47543EB19F3DCF308751F53C /* TemplateViewModel.swift */,
+				FF4EDB32B97910AAAFE632B2 /* TemplateViewModelProtocol.swift */,
 				4AC3BA2B379A928301E21004 /* View */,
 			);
 			path = ElementX;
@@ -1266,8 +1266,8 @@
 			isa = PBXGroup;
 			children = (
 				32CE6D4FF64C9A3C18619224 /* SplashScreen.swift */,
-				BE03C54FC7AAE0FC03EC8976 /* SplashScreenPage.swift */,
 				850064FF8D7DB9C875E7AA1A /* SplashScreenPageIndicator.swift */,
+				24A534A4619D8FEFB6439FCC /* SplashScreenPageView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1296,7 +1296,7 @@
 		AD5FCF9340D670C526AD17E4 /* UI */ = {
 			isa = PBXGroup;
 			children = (
-				4B66E05B6009B0EB1BDBFA6E /* TemplateSimpleScreenUITests.swift */,
+				4B66E05B6009B0EB1BDBFA6E /* TemplateScreenUITests.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -1810,7 +1810,7 @@
 				93875ADD456142D20823ED24 /* ServerSelectionViewModelTests.swift in Sources */,
 				206F0DBAB6AF042CA1FF2C0D /* SettingsViewModelTests.swift in Sources */,
 				94E062D08E27B0387658E364 /* SplashScreenViewModelTests.swift in Sources */,
-				7B3D3AFD511D496DED18910B /* TemplateSimpleScreenViewModelTests.swift in Sources */,
+				E75CE800B3E64D0F7F8E228D /* TemplateViewModelTests.swift in Sources */,
 				226027BE23AF64FA61C7A4C0 /* TimelineStyle.swift in Sources */,
 				1151DCC5EC2C6585826545EC /* UserIndicatorPresenterSpy.swift in Sources */,
 				4B8A2C45FF906ADBB1F5C3B4 /* UserIndicatorQueueTests.swift in Sources */,
@@ -1840,9 +1840,9 @@
 				CB326BAB54E9B68658909E36 /* Benchmark.swift in Sources */,
 				38546A6010A2CF240EC9AF73 /* BindableState.swift in Sources */,
 				B6DF6B6FA8734B70F9BF261E /* BlurHashDecode.swift in Sources */,
-				00AC53151BA23A90FAAE9FBF /* BugReport.swift in Sources */,
 				A32517FB1CA0BBCE2BC75249 /* BugReportCoordinator.swift in Sources */,
 				00F3059B1E0CFCA019710C3E /* BugReportModels.swift in Sources */,
+				3588F34D05B4D731A73214C6 /* BugReportScreen.swift in Sources */,
 				3DA57CA0D609A6B37CA1DC2F /* BugReportService.swift in Sources */,
 				172E6E9A612ADCF10A62CF13 /* BugReportServiceProtocol.swift in Sources */,
 				86C2E93920FD15AD17E193A9 /* BugReportViewModel.swift in Sources */,
@@ -1953,16 +1953,16 @@
 				388FD50AC66E9E684DDFA9D8 /* ServerSelectionScreen.swift in Sources */,
 				BB01CC19C3D3322308D1B2CF /* ServerSelectionViewModel.swift in Sources */,
 				19839F3526CE8C35AAF241AD /* ServerSelectionViewModelProtocol.swift in Sources */,
-				6C72F66DA26A0956E9A9077A /* Settings.swift in Sources */,
 				34966D4C1C2C6D37FE3F7F50 /* SettingsCoordinator.swift in Sources */,
 				3B770CB4DED51CC362C66D47 /* SettingsModels.swift in Sources */,
+				7FED310F6AB7A70CBFB7C8A3 /* SettingsScreen.swift in Sources */,
 				4A2E0DBB63919AC8309B6D40 /* SettingsViewModel.swift in Sources */,
 				438FB9BC535BC95948AA5F34 /* SettingsViewModelProtocol.swift in Sources */,
 				684BDE198AE5AA1392288A73 /* SplashScreen.swift in Sources */,
 				CE7A715947ABAB1DEB5C21D7 /* SplashScreenCoordinator.swift in Sources */,
 				EF99A92701E401C4CD5ADC50 /* SplashScreenModels.swift in Sources */,
-				45EE94D927EA75C2CF70A96A /* SplashScreenPage.swift in Sources */,
 				C2CF93B067FD935E4F82FE44 /* SplashScreenPageIndicator.swift in Sources */,
+				72F6E890820FF606A7E276C8 /* SplashScreenPageView.swift in Sources */,
 				53504DF61DBC81ACC9B4D275 /* SplashScreenViewModel.swift in Sources */,
 				5E1FCC43B738941D5A5F1794 /* SplashScreenViewModelProtocol.swift in Sources */,
 				FCB640C576292BEAF7FA3B2E /* SplashViewController.swift in Sources */,
@@ -1970,11 +1970,11 @@
 				2F94054F50E312AF30BE07F3 /* String.swift in Sources */,
 				A7D48E44D485B143AADDB77D /* Strings+Untranslated.swift in Sources */,
 				066A1E9B94723EE9F3038044 /* Strings.swift in Sources */,
-				5CABC57F620FBB39F4EC127C /* TemplateSimpleScreen.swift in Sources */,
-				C1156BBE4F977AEEE1E80C48 /* TemplateSimpleScreenCoordinator.swift in Sources */,
-				B0EDAF55877DE19B67837C22 /* TemplateSimpleScreenModels.swift in Sources */,
-				ED4F663C783E9A8C0E80B983 /* TemplateSimpleScreenViewModel.swift in Sources */,
-				3772354754450F2B54107E17 /* TemplateSimpleScreenViewModelProtocol.swift in Sources */,
+				5CABC57F620FBB39F4EC127C /* TemplateScreen.swift in Sources */,
+				C1156BBE4F977AEEE1E80C48 /* TemplateCoordinator.swift in Sources */,
+				B0EDAF55877DE19B67837C22 /* TemplateModels.swift in Sources */,
+				ED4F663C783E9A8C0E80B983 /* TemplateViewModel.swift in Sources */,
+				3772354754450F2B54107E17 /* TemplateViewModelProtocol.swift in Sources */,
 				D013E70C8E28E43497820444 /* TextRoomMessage.swift in Sources */,
 				7963F98CDFDEAC75E072BD81 /* TextRoomTimelineItem.swift in Sources */,
 				5E0F2E612718BB4397A6D40A /* TextRoomTimelineView.swift in Sources */,
@@ -2030,7 +2030,7 @@
 				A00DFC1DD3567B1EDC9F8D16 /* SplashScreenUITests.swift in Sources */,
 				DD9B70DE54B24E0694A35D8A /* Strings+Untranslated.swift in Sources */,
 				B3357B00F1AA930E54F76609 /* Strings.swift in Sources */,
-				2E68C57E7D644E94778743D5 /* TemplateSimpleScreenUITests.swift in Sources */,
+				2E68C57E7D644E94778743D5 /* TemplateScreenUITests.swift in Sources */,
 				0ED951768EC443A8728DE1D7 /* TimelineStyle.swift in Sources */,
 				75D98001C5AC38B6A5CA897C /* UITestScreenIdentifier.swift in Sources */,
 			);

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,7 +59,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift.git",
       "state" : {
-        "revision" : "4605577f5604b4f2bb1938eb06d69d996eb32a28",
+        "revision" : "7d5bdf05ff97e2229cb504982162fc02c37c58e5",
         "version" : "1.0.11-alpha"
       }
     },

--- a/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
+++ b/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1200"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/ElementX/Sources/Screens/BugReport/BugReportCoordinator.swift
+++ b/ElementX/Sources/Screens/BugReport/BugReportCoordinator.swift
@@ -48,7 +48,7 @@ final class BugReportCoordinator: Coordinator, Presentable {
         
         let viewModel = BugReportViewModel(bugReportService: parameters.bugReportService,
                                            screenshot: parameters.screenshot)
-        let view = BugReport(context: viewModel.context)
+        let view = BugReportScreen(context: viewModel.context)
         bugReportViewModel = viewModel
         bugReportHostingController = UIHostingController(rootView: view)
         

--- a/ElementX/Sources/Screens/BugReport/View/BugReportScreen.swift
+++ b/ElementX/Sources/Screens/BugReport/View/BugReportScreen.swift
@@ -16,7 +16,7 @@
 
 import SwiftUI
 
-struct BugReport: View {
+struct BugReportScreen: View {
 
     // MARK: Private
     
@@ -139,7 +139,7 @@ struct BugReport_Previews: PreviewProvider {
     @ViewBuilder
     static var body: some View {
         let viewModel = BugReportViewModel(bugReportService: MockBugReportService(), screenshot: Asset.Images.appLogo.image)
-        BugReport(context: viewModel.context)
+        BugReportScreen(context: viewModel.context)
             .previewInterfaceOrientation(.portrait)
     }
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
@@ -159,22 +159,18 @@ struct MessageComposerTextField_Previews: PreviewProvider {
     @ViewBuilder
     static var body: some View {
         VStack {
-            PreviewWrapper()
-            PlaceholderPreviewWrapper()
+            PreviewWrapper(text: "123")
+            PreviewWrapper(text: "")
         }
     }
     
     struct PreviewWrapper: View {
-        @State(initialValue: "123") var text: String
-
-        var body: some View {
-            MessageComposerTextField(placeholder: "Placeholder", text: $text, maxHeight: 300)
+        @State var text: String
+        
+        init(text: String) {
+            _text = .init(initialValue: text)
         }
-    }
-    
-    struct PlaceholderPreviewWrapper: View {
-        @State(initialValue: "") var text: String
-
+        
         var body: some View {
             MessageComposerTextField(placeholder: "Placeholder", text: $text, maxHeight: 300)
         }

--- a/ElementX/Sources/Screens/Settings/SettingsCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsCoordinator.swift
@@ -51,7 +51,7 @@ final class SettingsCoordinator: Coordinator, Presentable {
         self.parameters = parameters
         
         let viewModel = SettingsViewModel()
-        let view = Settings(context: viewModel.context)
+        let view = SettingsScreen(context: viewModel.context)
         settingsViewModel = viewModel
         settingsHostingController = UIHostingController(rootView: view)
         

--- a/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
@@ -16,7 +16,7 @@
 
 import SwiftUI
 
-struct Settings: View {
+struct SettingsScreen: View {
 
     // MARK: Private
 
@@ -128,7 +128,7 @@ struct Settings_Previews: PreviewProvider {
     @ViewBuilder
     static var body: some View {
         let viewModel = SettingsViewModel()
-        Settings(context: viewModel.context)
+        SettingsScreen(context: viewModel.context)
             .previewInterfaceOrientation(.portrait)
     }
 }

--- a/ElementX/Sources/Screens/SplashScreen/View/SplashScreen.swift
+++ b/ElementX/Sources/Screens/SplashScreen/View/SplashScreen.swift
@@ -49,12 +49,12 @@ struct SplashScreen: View {
                 HStack(alignment: .top, spacing: 0) {
                     
                     // Add a hidden page at the start of the carousel duplicating the content of the last page
-                    SplashScreenPage(content: context.viewState.content[pageCount - 1])
+                    SplashScreenPageView(content: context.viewState.content[pageCount - 1])
                         .frame(width: geometry.size.width)
                         .accessibilityIdentifier("hiddenPage")
                     
                     ForEach(0..<pageCount, id: \.self) { index in
-                        SplashScreenPage(content: context.viewState.content[index])
+                        SplashScreenPageView(content: context.viewState.content[index])
                             .frame(width: geometry.size.width)
                     }
                     

--- a/ElementX/Sources/Screens/SplashScreen/View/SplashScreenPageView.swift
+++ b/ElementX/Sources/Screens/SplashScreen/View/SplashScreenPageView.swift
@@ -16,7 +16,7 @@
 
 import SwiftUI
 
-struct SplashScreenPage: View {
+struct SplashScreenPageView: View {
     
     // MARK: - Properties
     
@@ -59,7 +59,7 @@ struct SplashScreenPage_Previews: PreviewProvider {
     static let content = SplashScreenViewState().content
     static var previews: some View {
         ForEach(0..<content.count, id: \.self) { index in
-            SplashScreenPage(content: content[index])
+            SplashScreenPageView(content: content[index])
         }
     }
 }

--- a/ElementX/Sources/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITestsAppCoordinator.swift
@@ -62,9 +62,9 @@ struct MockScreen: Identifiable {
             return LoginCoordinator(parameters: .init(navigationRouter: router,
                                                       homeserver: .mockUnsupported))
         case .simpleRegular:
-            return TemplateSimpleScreenCoordinator(parameters: .init(promptType: .regular))
+            return TemplateCoordinator(parameters: .init(promptType: .regular))
         case .simpleUpgrade:
-            return TemplateSimpleScreenCoordinator(parameters: .init(promptType: .upgrade))
+            return TemplateCoordinator(parameters: .init(promptType: .upgrade))
         case .settings:
             let router = NavigationRouter(navigationController: ElementNavigationController())
             return SettingsCoordinator(parameters: .init(navigationRouter: router,

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateCoordinator.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateCoordinator.swift
@@ -36,7 +36,7 @@ final class TemplateCoordinator: Coordinator, Presentable {
     private var templateViewModel: TemplateViewModelProtocol
     
     private var indicatorPresenter: UserIndicatorTypePresenterProtocol
-    private var loadingIndicator: UserIndicator?
+    private var activityIndicator: UserIndicator?
     
     // MARK: Public
 
@@ -84,11 +84,11 @@ final class TemplateCoordinator: Coordinator, Presentable {
     ///   - label: The label to show on the indicator.
     ///   - isInteractionBlocking: Whether the indicator should block any user interaction.
     private func startLoading(label: String = ElementL10n.loading, isInteractionBlocking: Bool = true) {
-        loadingIndicator = indicatorPresenter.present(.loading(label: label, isInteractionBlocking: isInteractionBlocking))
+        activityIndicator = indicatorPresenter.present(.loading(label: label, isInteractionBlocking: isInteractionBlocking))
     }
     
     /// Hide the currently displayed activity indicator.
     private func stopLoading() {
-        loadingIndicator = nil
+        activityIndicator = nil
     }
 }

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateCoordinator.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateCoordinator.swift
@@ -16,24 +16,24 @@
 
 import SwiftUI
 
-struct TemplateSimpleScreenCoordinatorParameters {
-    let promptType: TemplateSimpleScreenPromptType
+struct TemplateCoordinatorParameters {
+    let promptType: TemplatePromptType
 }
 
-enum TemplateSimpleScreenCoordinatorAction {
+enum TemplateCoordinatorAction {
     case accept
     case cancel
 }
 
-final class TemplateSimpleScreenCoordinator: Coordinator, Presentable {
+final class TemplateCoordinator: Coordinator, Presentable {
     
     // MARK: - Properties
     
     // MARK: Private
     
-    private let parameters: TemplateSimpleScreenCoordinatorParameters
-    private let templateSimpleScreenHostingController: UIViewController
-    private var templateSimpleScreenViewModel: TemplateSimpleScreenViewModelProtocol
+    private let parameters: TemplateCoordinatorParameters
+    private let templateHostingController: UIViewController
+    private var templateViewModel: TemplateViewModelProtocol
     
     private var indicatorPresenter: UserIndicatorTypePresenterProtocol
     private var loadingIndicator: UserIndicator?
@@ -42,28 +42,28 @@ final class TemplateSimpleScreenCoordinator: Coordinator, Presentable {
 
     // Must be used only internally
     var childCoordinators: [Coordinator] = []
-    var callback: ((TemplateSimpleScreenCoordinatorAction) -> Void)?
+    var callback: ((TemplateCoordinatorAction) -> Void)?
     
     // MARK: - Setup
     
-    init(parameters: TemplateSimpleScreenCoordinatorParameters) {
+    init(parameters: TemplateCoordinatorParameters) {
         self.parameters = parameters
         
-        let viewModel = TemplateSimpleScreenViewModel(promptType: parameters.promptType)
-        let view = TemplateSimpleScreen(context: viewModel.context)
-        templateSimpleScreenViewModel = viewModel
-        templateSimpleScreenHostingController = UIHostingController(rootView: view)
+        let viewModel = TemplateViewModel(promptType: parameters.promptType)
+        let view = TemplateScreen(context: viewModel.context)
+        templateViewModel = viewModel
+        templateHostingController = UIHostingController(rootView: view)
         
-        indicatorPresenter = UserIndicatorTypePresenter(presentingViewController: templateSimpleScreenHostingController)
+        indicatorPresenter = UserIndicatorTypePresenter(presentingViewController: templateHostingController)
     }
     
     // MARK: - Public
     
     func start() {
-        MXLog.debug("[TemplateSimpleScreenCoordinator] did start.")
-        templateSimpleScreenViewModel.callback = { [weak self] action in
+        MXLog.debug("[TemplateCoordinator] did start.")
+        templateViewModel.callback = { [weak self] action in
             guard let self = self else { return }
-            MXLog.debug("[TemplateSimpleScreenCoordinator] TemplateSimpleScreenViewModel did complete with result: \(action).")
+            MXLog.debug("[TemplateCoordinator] TemplateViewModel did complete with result: \(action).")
             switch action {
             case .accept:
                 self.callback?(.accept)
@@ -74,7 +74,7 @@ final class TemplateSimpleScreenCoordinator: Coordinator, Presentable {
     }
     
     func toPresentable() -> UIViewController {
-        templateSimpleScreenHostingController
+        templateHostingController
     }
     
     // MARK: - Private

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateModels.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateModels.swift
@@ -18,12 +18,12 @@ import Foundation
 
 // MARK: - Coordinator
 
-enum TemplateSimpleScreenPromptType {
+enum TemplatePromptType {
     case regular
     case upgrade
 }
 
-extension TemplateSimpleScreenPromptType: Identifiable, CaseIterable {
+extension TemplatePromptType: Identifiable, CaseIterable {
     var id: Self { self }
     
     var title: String {
@@ -47,19 +47,19 @@ extension TemplateSimpleScreenPromptType: Identifiable, CaseIterable {
 
 // MARK: View model
 
-enum TemplateSimpleScreenViewModelAction {
+enum TemplateViewModelAction {
     case accept
     case cancel
 }
 
 // MARK: View
 
-struct TemplateSimpleScreenViewState: BindableState {
-    var promptType: TemplateSimpleScreenPromptType
+struct TemplateViewState: BindableState {
+    var promptType: TemplatePromptType
     var count: Int
 }
 
-enum TemplateSimpleScreenViewAction {
+enum TemplateViewAction {
     case incrementCount
     case decrementCount
     case accept

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateViewModel.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateViewModel.swift
@@ -16,9 +16,9 @@
 
 import SwiftUI
 
-typealias TemplateSimpleScreenViewModelType = StateStoreViewModel<TemplateSimpleScreenViewState, TemplateSimpleScreenViewAction>
+typealias TemplateViewModelType = StateStoreViewModel<TemplateViewState, TemplateViewAction>
 
-class TemplateSimpleScreenViewModel: TemplateSimpleScreenViewModelType, TemplateSimpleScreenViewModelProtocol {
+class TemplateViewModel: TemplateViewModelType, TemplateViewModelProtocol {
 
     // MARK: - Properties
 
@@ -26,17 +26,17 @@ class TemplateSimpleScreenViewModel: TemplateSimpleScreenViewModelType, Template
 
     // MARK: Public
 
-    var callback: ((TemplateSimpleScreenViewModelAction) -> Void)?
+    var callback: ((TemplateViewModelAction) -> Void)?
 
     // MARK: - Setup
 
-    init(promptType: TemplateSimpleScreenPromptType, initialCount: Int = 0) {
-        super.init(initialViewState: TemplateSimpleScreenViewState(promptType: promptType, count: 0))
+    init(promptType: TemplatePromptType, initialCount: Int = 0) {
+        super.init(initialViewState: TemplateViewState(promptType: promptType, count: 0))
     }
     
     // MARK: - Public
     
-    override func process(viewAction: TemplateSimpleScreenViewAction) async {
+    override func process(viewAction: TemplateViewAction) async {
         switch viewAction {
         case .accept:
             callback?(.accept)

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateViewModelProtocol.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateViewModelProtocol.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 @MainActor
-protocol TemplateSimpleScreenViewModelProtocol {
-    var callback: ((TemplateSimpleScreenViewModelAction) -> Void)? { get set }
-    var context: TemplateSimpleScreenViewModelType.Context { get }
+protocol TemplateViewModelProtocol {
+    var callback: ((TemplateViewModelAction) -> Void)? { get set }
+    var context: TemplateViewModelType.Context { get }
 }

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
@@ -16,35 +16,35 @@
 
 import SwiftUI
 
-struct TemplateSimpleScreen: View {
+struct TemplateScreen: View {
 
     // MARK: Private
     
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.colorScheme) private var colorScheme
     
-    private var horizontalPadding: CGFloat {
-        horizontalSizeClass == .regular ? 50 : 16
+    var counterColor: Color {
+        colorScheme == .light ? .element.secondaryContent : .element.tertiaryContent
     }
     
     // MARK: Public
     
-    @ObservedObject var context: TemplateSimpleScreenViewModel.Context
+    @ObservedObject var context: TemplateViewModel.Context
     
     // MARK: Views
     
     var body: some View {
-        GeometryReader { geometry in
-            VStack {
-                ScrollView {
-                    mainContent
-                        .padding(.top, 50)
-                        .padding(.horizontal, horizontalPadding)
-                }
-                
-                buttons
-                    .padding(.horizontal, horizontalPadding)
-                    .padding(.bottom, geometry.safeAreaInsets.bottom > 0 ? 0 : 16)
-            }
+        ScrollView {
+            mainContent
+                .padding(.top, 50)
+                .padding(.horizontal)
+                .readableFrame()
+        }
+        .safeAreaInset(edge: .bottom) {
+            buttons
+                .padding(.horizontal)
+                .padding(.vertical)
+                .readableFrame()
+                .background(.regularMaterial)
         }
     }
     
@@ -52,6 +52,9 @@ struct TemplateSimpleScreen: View {
     var mainContent: some View {
         VStack(spacing: 36) {
             Text(context.viewState.promptType.title)
+                .font(.element.title2B)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.element.primaryContent)
                 .accessibilityIdentifier("title")
             
             Image(systemName: context.viewState.promptType.imageSystemName)
@@ -61,14 +64,19 @@ struct TemplateSimpleScreen: View {
             
             HStack {
                 Text("Counter: \(context.viewState.count)")
+                    .font(.element.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(counterColor)
                 
-                Button("-") {
+                Button("−") {
                     context.send(viewAction: .decrementCount)
                 }
+                .buttonStyle(.elementGhost())
                 
                 Button("+") {
                     context.send(viewAction: .incrementCount)
                 }
+                .buttonStyle(.elementGhost())
             }
         }
     }
@@ -79,7 +87,7 @@ struct TemplateSimpleScreen: View {
             Button { context.send(viewAction: .accept) } label: {
                 Text("Accept")
             }
-            .frame(maxWidth: .infinity)
+            .buttonStyle(.elementAction(.xLarge))
             
             Button { context.send(viewAction: .cancel) } label: {
                 Text("Cancel")
@@ -91,15 +99,15 @@ struct TemplateSimpleScreen: View {
 
 // MARK: - Previews
 
-struct TemplateSimpleScreen_Previews: PreviewProvider {
+struct Template_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            let viewModel = TemplateSimpleScreenViewModel(promptType: .regular)
-            TemplateSimpleScreen(context: viewModel.context)
+            let regularViewModel = TemplateViewModel(promptType: .regular)
+            TemplateScreen(context: regularViewModel.context)
+            
+            let upgradeViewModel = TemplateViewModel(promptType: .upgrade)
+            TemplateScreen(context: upgradeViewModel.context)
         }
-        Group {
-            let viewModel = TemplateSimpleScreenViewModel(promptType: .upgrade)
-            TemplateSimpleScreen(context: viewModel.context)
-        }
+        .tint(.element.accent)
     }
 }

--- a/Tools/Scripts/Templates/SimpleScreenExample/Tests/UI/TemplateScreenUITests.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/Tests/UI/TemplateScreenUITests.swift
@@ -17,7 +17,7 @@
 import XCTest
 import ElementX
 
-class TemplateSimpleScreenUITests: XCTestCase {
+class TemplateScreenUITests: XCTestCase {
     func testRegularScreen() {
         let app = Application.launch()
         app.goToScreenWithIdentifier(.simpleRegular)

--- a/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateViewModelTests.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateViewModelTests.swift
@@ -19,16 +19,16 @@ import XCTest
 @testable import ElementX
 
 @MainActor
-class TemplateSimpleScreenViewModelTests: XCTestCase {
+class TemplateScreenViewModelTests: XCTestCase {
     private enum Constants {
         static let counterInitialValue = 0
     }
     
-    var viewModel: TemplateSimpleScreenViewModelProtocol!
-    var context: TemplateSimpleScreenViewModelType.Context!
+    var viewModel: TemplateViewModelProtocol!
+    var context: TemplateViewModelType.Context!
     
     @MainActor override func setUpWithError() throws {
-        viewModel = TemplateSimpleScreenViewModel(promptType: .regular, initialCount: Constants.counterInitialValue)
+        viewModel = TemplateViewModel(promptType: .regular, initialCount: Constants.counterInitialValue)
         context = viewModel.context
     }
 

--- a/Tools/Scripts/createScreen.sh
+++ b/Tools/Scripts/createScreen.sh
@@ -34,10 +34,10 @@ SCREEN_VAR_NAME=`echo $SCREEN_NAME | awk '{ print tolower(substr($0, 1, 1)) subs
 function rename_files {
     for file in $(find * -type f -print)
     do
-      perl -p -i -e "s/TemplateSimpleScreen/"$SCREEN_NAME"/g" $file
-      perl -p -i -e "s/templateSimpleScreen/"$SCREEN_VAR_NAME"/g" $file
+      perl -p -i -e "s/Template/"$SCREEN_NAME"/g" $file
+      perl -p -i -e "s/template/"$SCREEN_VAR_NAME"/g" $file
 
-      mv ${file} ${file/TemplateSimpleScreen/$SCREEN_NAME}
+      mv ${file} ${file/Template/$SCREEN_NAME}
     done
 }
 

--- a/changelog.d/pr-125.misc
+++ b/changelog.d/pr-125.misc
@@ -1,0 +1,1 @@
+Add Screen as a suffix to all screens and tidy up the template.


### PR DESCRIPTION
As discussed, this PR adds `Screen` to the few screens that were missing it and `View` where there isn't a clear SwiftUI option. 2 exceptions I've left as they are are `MessageComposer` `TimelineStyler` as both seem fine to me, but pointing out for discussion.

I've also updated the template so for `./createScreen SessionVerification SessionVerification` the output will be
- SessionVerificationCoordinator
- SessionVerificationModels
- SessionVerificationViewModel
- SessionVerificationViewModelTests
- SessionVerificationViewModelProtocol
- SessionVerificationScreen
- SessionVerificationScreenUITests

And I've tidied up TemplateScreen a bit more so there's less useless stuff in there from the start.

Happy to take feedback on any of this.