### PR TITLE
Add a sync limit of 20 and prefill rooms when loading the last message.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -2707,7 +2707,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "1.0.12-alpha";
+				version = "1.0.13-alpha";
 			};
 		};
 		9A472EE0218FE7DCF5283429 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "3dbb1533d1c27dcd311a8c9751de7c020ccf2d8c",
-        "version" : "1.0.12-alpha"
+        "revision" : "1358c9c2a85cfb5fc1bfadce13565e02618725d4",
+        "version" : "1.0.13-alpha"
       }
     },
     {

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
@@ -119,7 +119,7 @@ final class HomeScreenCoordinator: Coordinator, Presentable {
     
     func updateRoomsList() {
         roomSummaries = parameters.userSession.clientProxy.rooms.compactMap { roomProxy in
-            guard !roomProxy.isSpace, !roomProxy.isTombstoned else {
+            guard roomProxy.isJoined, !roomProxy.isSpace, !roomProxy.isTombstoned else {
                 return nil
             }
             

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -24,6 +24,9 @@ private class WeakClientProxyWrapper: ClientDelegate {
 }
 
 class ClientProxy: ClientProxyProtocol {
+    /// The maximum number of timeline events required during a sync request.
+    static let syncLimit: UInt16 = 20
+    
     private let client: Client
     private let backgroundTaskService: BackgroundTaskServiceProtocol
     private var sessionVerificationControllerProxy: SessionVerificationControllerProxy?
@@ -48,7 +51,7 @@ class ClientProxy: ClientProxyProtocol {
         client.setDelegate(delegate: WeakClientProxyWrapper(clientProxy: self))
         
         Benchmark.startTrackingForIdentifier("ClientSync", message: "Started sync.")
-        client.startSync()
+        client.startSync(timelineLimit: ClientProxy.syncLimit)
         
         Task { await updateRooms() }
     }

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -67,6 +67,10 @@ class RoomProxy: RoomProxyProtocol {
         room.topic()
     }
     
+    var isJoined: Bool {
+        room.membership() == .joined
+    }
+    
     var isDirect: Bool {
         room.isDirect()
     }

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummary.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummary.swift
@@ -141,7 +141,8 @@ class RoomSummary: RoomSummaryProtocol {
             return
         }
         
-        switch await roomProxy.paginateBackwards(count: 1) {
+        // Pre-fill the room with some messages and use the last message in the response.
+        switch await roomProxy.paginateBackwards(count: UInt(ClientProxy.syncLimit)) {
         case .success:
             lastMessage = await eventBriefFactory.buildEventBriefFor(message: roomProxy.messages.last)
         case .failure(let error):

--- a/changelog.d/93.bugfix
+++ b/changelog.d/93.bugfix
@@ -1,0 +1,1 @@
+Add a sync limit of 20 timeline items and prefill rooms with this number of events when calculating the last message.

--- a/project.yml
+++ b/project.yml
@@ -31,7 +31,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.12-alpha
+    exactVersion: 1.0.13-alpha
     # path: ../matrix-rust-components-swift
   DesignKit:
     path: ./


### PR DESCRIPTION
This PR also filters rooms in the home screen to only show joined rooms as we were showing invited/left rooms too without differentiating them in anyway (and when trying to back-paginate in a left room the SDK would end up stuck in a loop that blocked other requests).

Updates the SDK to 1.0.13-alpha for the `timeline_limit` and `membership` options.

Fixes #93.