### PR TITLE
Draft: Define URL scheme and support deep links

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		E1DF24D085572A55C9758A2D /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E89E530A8E92EC44301CA1 /* Bundle.swift */; };
 		E5895C74615CBE8462FB840F /* SessionVerificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF86010A0A719A9A50EEC59 /* SessionVerificationCoordinator.swift */; };
 		E81EEC1675F2371D12A880A3 /* MockRoomTimelineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ADFB893DEF81E58DF3FAB9 /* MockRoomTimelineController.swift */; };
+		E9AA5AE428997FDB00418E90 /* DeeplinkDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AA5AE328997FDB00418E90 /* DeeplinkDestination.swift */; };
 		EA1E7949533E19C6D862680A /* MediaProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885D8C42DD17625B5261BEFF /* MediaProvider.swift */; };
 		EA31DD9043B91ECB8E45A9A6 /* ScreenshotDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03C9D319676F3C0DC6B0203 /* ScreenshotDetectorTests.swift */; };
 		EA65360A0EC026DD83AC0CF5 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CA5F386C7701C129398945 /* AuthenticationCoordinator.swift */; };
@@ -677,6 +678,7 @@
 		E5F2B6443D1ED8602F328539 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ru; path = ru.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		E8294DB9E95C0C0630418466 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E8CA187FE656EE5A3F6C7DE5 /* UIFont+AttributedStringBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIFont+AttributedStringBuilder.m"; sourceTree = "<group>"; };
+		E9AA5AE328997FDB00418E90 /* DeeplinkDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkDestination.swift; sourceTree = "<group>"; };
 		E9D059BFE329BE09B6D96A9F /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ro; path = ro.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		EBE5502760CF6CA2D7201883 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ja; path = ja.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		ED1D792EB82506A19A72C8DE /* RoomTimelineItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemProtocol.swift; sourceTree = "<group>"; };
@@ -1604,6 +1606,7 @@
 		FE50232944F9E67ADD7A2D21 /* Routers */ = {
 			isa = PBXGroup;
 			children = (
+				E9AA5AE328997FDB00418E90 /* DeeplinkDestination.swift */,
 				5F77E8010D41AA3F5F9A1FCA /* NavigationModule.swift */,
 				B4173A48FD8542CD4AD3645C /* NavigationRouter.swift */,
 				D29EBCBFEC6FD0941749404D /* NavigationRouterStore.swift */,
@@ -1974,6 +1977,7 @@
 				E0A4DCA633D174EB43AD599F /* BackgroundTaskProtocol.swift in Sources */,
 				6D046D653DA28ADF1E6E59A4 /* BackgroundTaskServiceProtocol.swift in Sources */,
 				CB326BAB54E9B68658909E36 /* Benchmark.swift in Sources */,
+				E9AA5AE428997FDB00418E90 /* DeeplinkDestination.swift in Sources */,
 				38546A6010A2CF240EC9AF73 /* BindableState.swift in Sources */,
 				B6DF6B6FA8734B70F9BF261E /* BlurHashDecode.swift in Sources */,
 				A32517FB1CA0BBCE2BC75249 /* BugReportCoordinator.swift in Sources */,
@@ -2380,8 +2384,10 @@
 		62E1B7866DF0ED442C39A83B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_SCHEME = elementx;
 				APP_GROUP_IDENTIFIER = group.io.element;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BASE_BUNDLE_IDENTIFIER = io.element.elementx;
 				CODE_SIGN_ENTITLEMENTS = ElementX/SupportingFiles/ElementX.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2403,8 +2409,10 @@
 		6897D5BC19A2EA6ABD57DE7E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_SCHEME = elementx;
 				APP_GROUP_IDENTIFIER = group.io.element;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BASE_BUNDLE_IDENTIFIER = io.element.elementx;
 				CODE_SIGN_ENTITLEMENTS = ElementX/SupportingFiles/ElementX.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;

--- a/ElementX/Sources/AppCoordinator.swift
+++ b/ElementX/Sources/AppCoordinator.swift
@@ -82,6 +82,22 @@ class AppCoordinator: AuthenticationCoordinatorDelegate, Coordinator {
         stateMachine.processEvent(userSessionStore.hasSessions ? .startWithExistingSession : .startWithAuthentication)
     }
     
+    func openDeeplinkURL(_ url: URL) -> Bool {
+        guard let destination = DeeplinkDestination(urlPathComponents: url.pathComponents) else {
+            return false
+        }
+        
+        switch destination {
+        case .room(let roomId):
+            MXLog.debug("open URL with roomId \(roomId)")
+            stateMachine.processEvent(.showRoomScreen(roomId: roomId))
+        case .user(let userId):
+            MXLog.debug("open URL with userId \(userId)")
+        }
+        
+        return true
+    }
+    
     // MARK: - AuthenticationCoordinatorDelegate
     
     func authenticationCoordinator(_ authenticationCoordinator: AuthenticationCoordinator, didLoginWithSession userSession: UserSessionProtocol) {

--- a/ElementX/Sources/AppDelegate.swift
+++ b/ElementX/Sources/AppDelegate.swift
@@ -29,6 +29,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
     
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        appCoordinator.openDeeplinkURL(url)
+    }
+    
     private var isRunningUnitTests: Bool {
         #if DEBUG
         ProcessInfo.processInfo.environment["IS_RUNNING_UNIT_TESTS"] == "1"

--- a/ElementX/Sources/Generated/InfoPlist.swift
+++ b/ElementX/Sources/Generated/InfoPlist.swift
@@ -19,6 +19,7 @@ internal enum ElementInfoPlist {
   internal static let cfBundleName: String = _document["CFBundleName"]
   internal static let cfBundlePackageType: String = _document["CFBundlePackageType"]
   internal static let cfBundleShortVersionString: String = _document["CFBundleShortVersionString"]
+  internal static let cfBundleURLTypes: [[String: Any]] = _document["CFBundleURLTypes"]
   internal static let cfBundleVersion: String = _document["CFBundleVersion"]
   internal static let uiLaunchStoryboardName: String = _document["UILaunchStoryboardName"]
   internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]

--- a/ElementX/Sources/Other/Coordinator.swift
+++ b/ElementX/Sources/Other/Coordinator.swift
@@ -36,6 +36,11 @@ protocol Coordinator: AnyObject {
     ///
     /// - Parameter childCoordinator: Child coordinator to remove.
     func remove(childCoordinator: Coordinator)
+    
+    /// Opens a deeplink URL.
+    ///
+    /// - Parameter url: The URL to open.
+    func openDeeplinkURL(_ url: URL) -> Bool
 }
 
 // `Coordinator` default implementation
@@ -46,5 +51,9 @@ extension Coordinator {
     
     func remove(childCoordinator: Coordinator) {
         childCoordinators = childCoordinators.filter { $0 !== childCoordinator }
+    }
+    
+    func openDeeplinkURL(_ url: URL) -> Bool {
+        true
     }
 }

--- a/ElementX/Sources/Other/Routers/DeeplinkDestination.swift
+++ b/ElementX/Sources/Other/Routers/DeeplinkDestination.swift
@@ -1,0 +1,41 @@
+//
+//  DeeplinkDestination.swift
+//  ElementX
+//
+//  Created by vollkorntomate on 2022-08-02.
+//  Copyright © 2022 Element. All rights reserved.
+//
+
+import Foundation
+
+enum DeeplinkDestination {
+    case room(_ roomId: String)
+    case user(_ userId: String)
+    
+    init?(urlPathComponents: [String]) {
+        guard urlPathComponents[safe: 0] == "/" else {
+            return nil
+        }
+        let match = (urlPathComponents[safe: 1],
+                     urlPathComponents[safe: 2],
+                     urlPathComponents[safe: 3],
+                     urlPathComponents[safe: 4])
+        
+        switch match {
+        case ("room", let roomId, _, _):
+            guard let roomId = roomId else { return nil }
+            self = .room(roomId)
+        case ("user", let userId, _, _):
+            guard let userId = userId, userId.isMatrixUserID else { return nil }
+            self = .user(userId)
+        default:
+            return nil
+        }
+    }
+}
+
+extension Collection {
+    subscript(safe index: Self.Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/ElementX/SupportingFiles/Info.plist
+++ b/ElementX/SupportingFiles/Info.plist
@@ -16,6 +16,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>${BASE_BUNDLE_IDENTIFIER}</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>${APPLICATION_SCHEME}</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
I looked at #54 and drafted a way to support deep links that I would like to discuss.

In my opinion, there is no real need for a 3rd party library, since iOS handles most of it and the current architecture (with `AppDelegate` and `Coordinator`s) is also beneficial for that.

For the basic URL scheme, I adapted the existing approach from element-ios, so that an example link (e.g. to join a room) could look like that: `elementx://io.element.elementx/room/%23element-ios:matrix.org`.
The `%23` encodes a `#` character, which has a different purpose in URLs (see [RFC 1808](https://datatracker.ietf.org/doc/html/rfc1808#section-2.1)). It will be decoded automatically by Swift.

Note that this is just a draft and I am open to discussing it. There are certainly things that need refinement.