### PR TITLE
Add a pull request template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Pull Request Checklist
+
+- [ ] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
+- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
+- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
+
+**UI changes have been tested with:**
+- [ ] iPhone and iPad simulators in portrait and landscape orientations.
+- [ ] Dark mode enabled and disabled.
+- [ ] Various sizes of dynamic type.
+- [ ] Voiceover enabled.

--- a/changelog.d/pr-156.misc
+++ b/changelog.d/pr-156.misc
@@ -1,0 +1,1 @@
+Add a pull request template.


### PR DESCRIPTION
As Danger doesn't currently run for PRs from forks, this adds a basic pull request template based off on the EI one.