### PR TITLE
Small tweaks for CI

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -4,6 +4,8 @@ on: [pull_request]
 
 jobs:
   build:
+    # Don't run for forks as secrets are unavailable.
+    if: github.repository == 'vector-im/element-x-ios'
     runs-on: ubuntu-latest
     name: Danger
     steps:

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -9,21 +9,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-secret:
-    runs-on: macos-12
-    outputs:
-      out-key: ${{ steps.out-key.outputs.defined }}
-    steps:
-        - id: out-key
-          env:
-            P12_KEY: ${{ secrets.ALPHA_CERTIFICATES_P12 }}
-            P12_PASSWORD_KEY: ${{ secrets.ALPHA_CERTIFICATES_P12_PASSWORD }}
-          if: "${{ env.P12_KEY != '' || env.P12_PASSWORD_KEY != '' }}"
-          run: echo "::set-output name=defined::true"
   build:
-    # Run job if secrets are available (not available for forks).
-    needs: [check-secret]
-    if: needs.check-secret.outputs.out-key == 'true'
+    # Don't run for forks as secrets are unavailable.
+    if: github.repository == 'vector-im/element-x-ios'
     name: Release
     runs-on: macos-12
     

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -1671,11 +1671,11 @@
 			buildConfigurationList = B15427F8699AD5A5FC75C17E /* Build configuration list for PBXNativeTarget "ElementX" */;
 			buildPhases = (
 				A7130911BCB2DF3D249A1836 /* 🛠 SwiftGen */,
+				B35AB66424BB30087EEE408C /* 🧹 SwiftFormat */,
 				9797D588420FCBBC228A63C9 /* Sources */,
 				215E1D91B98672C856F559D0 /* Resources */,
 				EE878EAA342710DB973E0A87 /* Frameworks */,
 				98CA896D84BFD53B2554E891 /* ⚠️ SwiftLint */,
-				B35AB66424BB30087EEE408C /* 🧹 SwiftFormat */,
 			);
 			buildRules = (
 			);

--- a/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
+++ b/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
@@ -27,9 +27,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C0FAEB81CFD9776CD78CE489"
+            BuildableName = "ElementX.app"
+            BlueprintName = "ElementX"
+            ReferencedContainer = "container:ElementX.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -52,15 +61,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "C0FAEB81CFD9776CD78CE489"
-            BuildableName = "ElementX.app"
-            BlueprintName = "ElementX"
-            ReferencedContainer = "container:ElementX.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <CommandLineArguments>
       </CommandLineArguments>
       <EnvironmentVariables>

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -70,18 +70,6 @@ targets:
         else
             echo "warning: SwiftGen not installed, download from https://github.com/SwiftGen/SwiftGen"
         fi
-    
-    postBuildScripts:
-    - name: ⚠️ SwiftLint
-      runOnlyWhenInstalling: false
-      shell: /bin/sh
-      script: |
-        export PATH="$PATH:/opt/homebrew/bin"
-        if which swiftlint >/dev/null; then
-            swiftlint
-        else
-            echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
-        fi
 
     - name: 🧹 SwiftFormat
       runOnlyWhenInstalling: false
@@ -97,7 +85,19 @@ targets:
         else
           echo "warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat"
         fi
-      
+
+    postBuildScripts:
+    - name: ⚠️ SwiftLint
+      runOnlyWhenInstalling: false
+      shell: /bin/sh
+      script: |
+        export PATH="$PATH:/opt/homebrew/bin"
+        if which swiftlint >/dev/null; then
+            swiftlint
+        else
+            echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
+        fi
+
     dependencies:
     - package: MatrixRustSDK
     - package: DesignKit

--- a/changelog.d/pr-157.build
+++ b/changelog.d/pr-157.build
@@ -1,0 +1,1 @@
+Disable danger for external forks due to missing secret and run SwiftFormat as a pre-build step to fail early on CI.


### PR DESCRIPTION
This PR makes 2 small tweaks for CI:
- Danger is now disabled for external repos as it fails due to the missing GH secret.
- SwiftFormat is run as a pre-build script to fail early and free up runners quicker.