### PR TITLE
Use standard file headers everywhere.

### DIFF
--- a/DesignKit/Sources/Buttons/ElementActionButtonStyle.swift
+++ b/DesignKit/Sources/Buttons/ElementActionButtonStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/DesignKit/Sources/Buttons/ElementGhostButtonStyle.swift
+++ b/DesignKit/Sources/Buttons/ElementGhostButtonStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/DesignKit/Sources/Common/ElementControlSize.swift
+++ b/DesignKit/Sources/Common/ElementControlSize.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/DesignKit/Sources/Fonts/ElementFonts.swift
+++ b/DesignKit/Sources/Fonts/ElementFonts.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/DesignKit/Sources/Fonts/ElementSharedFonts.swift
+++ b/DesignKit/Sources/Fonts/ElementSharedFonts.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/DesignKit/Sources/Fonts/ElementUIFonts.swift
+++ b/DesignKit/Sources/Fonts/ElementUIFonts.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/DesignKit/Sources/Fonts/Fonts.swift
+++ b/DesignKit/Sources/Fonts/Fonts.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/DesignKit/Sources/Fonts/UIFont.swift
+++ b/DesignKit/Sources/Fonts/UIFont.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/DesignKit/Sources/Shapes/RoundedCornerShape.swift
+++ b/DesignKit/Sources/Shapes/RoundedCornerShape.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/DesignKit/Sources/TextFields/BorderedInputFieldStyle.swift
+++ b/DesignKit/Sources/TextFields/BorderedInputFieldStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/DesignKit/Sources/TextFields/ElementTextFieldStyle.swift
+++ b/DesignKit/Sources/TextFields/ElementTextFieldStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/ElementX.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string> 
+// Copyright ___YEAR___ New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//</string>
+</dict>
+</plist>

--- a/ElementX.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/ElementX.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>FILEHEADER</key>
-    <string> 
+    <string>
 // Copyright ___YEAR___ New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/AppCoordinator.swift
+++ b/ElementX/Sources/AppCoordinator.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/AppCoordinator.swift
+++ b/ElementX/Sources/AppCoordinator.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  AppCoordinator.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11.02.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/AppCoordinatorStateMachine.swift
+++ b/ElementX/Sources/AppCoordinatorStateMachine.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/AppCoordinatorStateMachine.swift
+++ b/ElementX/Sources/AppCoordinatorStateMachine.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  AppCoordinatorStateMachine.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 30/05/2022.
-//  Copyright © 2022 element.io. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/AppDelegate.swift
+++ b/ElementX/Sources/AppDelegate.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/AppDelegate.swift
+++ b/ElementX/Sources/AppDelegate.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  AppDelegate.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11.02.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import UIKit

--- a/ElementX/Sources/BuildSettings.swift
+++ b/ElementX/Sources/BuildSettings.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/BuildSettings.swift
+++ b/ElementX/Sources/BuildSettings.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  BuildSettings.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 2.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Other/Benchmark.swift
+++ b/ElementX/Sources/Other/Benchmark.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Other/Benchmark.swift
+++ b/ElementX/Sources/Other/Benchmark.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  Benchmark.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 04/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Other/ElementNavigationController.swift
+++ b/ElementX/Sources/Other/ElementNavigationController.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Other/ElementNavigationController.swift
+++ b/ElementX/Sources/Other/ElementNavigationController.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ElementNavigationController.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 20.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import UIKit

--- a/ElementX/Sources/Other/ElementSettings.swift
+++ b/ElementX/Sources/Other/ElementSettings.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Other/ElementSettings.swift
+++ b/ElementX/Sources/Other/ElementSettings.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ElementSettings.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 24.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Other/Extensions/Bundle.swift
+++ b/ElementX/Sources/Other/Extensions/Bundle.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Other/Extensions/Bundle.swift
+++ b/ElementX/Sources/Other/Extensions/Bundle.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  Bundle.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 15.04.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Other/Extensions/String.swift
+++ b/ElementX/Sources/Other/Extensions/String.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  AttributedStringBuilder.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 22/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import DTCoreText

--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilderProtocol.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilderProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilderProtocol.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilderProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  AttributedStringBuilderProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 24/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  DTHTMLElement+AttributedStringBuilder.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 24/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import DTCoreText

--- a/ElementX/Sources/Other/HTMLParsing/ElementXAttributeScope.swift
+++ b/ElementX/Sources/Other/HTMLParsing/ElementXAttributeScope.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Other/HTMLParsing/ElementXAttributeScope.swift
+++ b/ElementX/Sources/Other/HTMLParsing/ElementXAttributeScope.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ElementXAttributeScope.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 23/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Other/HTMLParsing/UIFont+AttributedStringBuilder.h
+++ b/ElementX/Sources/Other/HTMLParsing/UIFont+AttributedStringBuilder.h
@@ -1,9 +1,17 @@
 //
-//  UIFont+AttributedStringBuilder.h
-//  ElementX
+// Copyright 2022 New Vector Ltd
 //
-//  Created by Stefan Ceriu on 23/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 @import UIKit;

--- a/ElementX/Sources/Other/HTMLParsing/UIFont+AttributedStringBuilder.m
+++ b/ElementX/Sources/Other/HTMLParsing/UIFont+AttributedStringBuilder.m
@@ -1,9 +1,17 @@
 //
-//  UIFont+AttributedStringBuilder.h
-//  ElementX
+// Copyright 2022 New Vector Ltd
 //
-//  Created by Stefan Ceriu on 23/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 #import "UIFont+AttributedStringBuilder.h"

--- a/ElementX/Sources/Other/ImageAnonymizer.swift
+++ b/ElementX/Sources/Other/ImageAnonymizer.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Other/ImageAnonymizer.swift
+++ b/ElementX/Sources/Other/ImageAnonymizer.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  UIImage+.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 20.05.2022.
-//  Copyright © 2022 element.io. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Other/MatrixEntityRegex.swift
+++ b/ElementX/Sources/Other/MatrixEntityRegex.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Other/MatrixEntityRegex.swift
+++ b/ElementX/Sources/Other/MatrixEntityRegex.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MatrixEntitityRegex.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 26/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Other/Routers/NavigationModule.swift
+++ b/ElementX/Sources/Other/Routers/NavigationModule.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/Routers/NavigationRouterStore.swift
+++ b/ElementX/Sources/Other/Routers/NavigationRouterStore.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/Routers/NavigationRouterStoreProtocol.swift
+++ b/ElementX/Sources/Other/Routers/NavigationRouterStoreProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/SwiftUI/ErrorHandling/AlertInfo.swift
+++ b/ElementX/Sources/Other/SwiftUI/ErrorHandling/AlertInfo.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/SwiftUI/Layout/FramePreferenceKey.swift
+++ b/ElementX/Sources/Other/SwiftUI/Layout/FramePreferenceKey.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/SwiftUI/Layout/ViewFrameReader.swift
+++ b/ElementX/Sources/Other/SwiftUI/Layout/ViewFrameReader.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/SwiftUI/ViewModel/BindableState.swift
+++ b/ElementX/Sources/Other/SwiftUI/ViewModel/BindableState.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/SwiftUI/ViewModel/StateStoreViewModel.swift
+++ b/ElementX/Sources/Other/SwiftUI/ViewModel/StateStoreViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/SwiftUI/Views/ElementToggleStyle.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/ElementToggleStyle.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Other/SwiftUI/Views/ElementToggleStyle.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/ElementToggleStyle.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ElementToggleStyle.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 2.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import SwiftUI

--- a/ElementX/Sources/Other/UserIndicators/FullscreenLoadingViewPresenter.swift
+++ b/ElementX/Sources/Other/UserIndicators/FullscreenLoadingViewPresenter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/UserIndicators/LabelledActivityIndicatorView.swift
+++ b/ElementX/Sources/Other/UserIndicators/LabelledActivityIndicatorView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/UserIndicators/RectangleToastView.swift
+++ b/ElementX/Sources/Other/UserIndicators/RectangleToastView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/UserIndicators/RoundedToastView.swift
+++ b/ElementX/Sources/Other/UserIndicators/RoundedToastView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/UserIndicators/ToastViewPresenter.swift
+++ b/ElementX/Sources/Other/UserIndicators/ToastViewPresenter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/UserIndicators/ToastViewState.swift
+++ b/ElementX/Sources/Other/UserIndicators/ToastViewState.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/UserIndicators/UserIndicator.swift
+++ b/ElementX/Sources/Other/UserIndicators/UserIndicator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/UserIndicators/UserIndicatorDismissal.swift
+++ b/ElementX/Sources/Other/UserIndicators/UserIndicatorDismissal.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/UserIndicators/UserIndicatorPresenter.swift
+++ b/ElementX/Sources/Other/UserIndicators/UserIndicatorPresenter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/UserIndicators/UserIndicatorQueue.swift
+++ b/ElementX/Sources/Other/UserIndicators/UserIndicatorQueue.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/UserIndicators/UserIndicatorRequest.swift
+++ b/ElementX/Sources/Other/UserIndicators/UserIndicatorRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Other/UserIndicators/UserIndicatorViewPresentable.swift
+++ b/ElementX/Sources/Other/UserIndicators/UserIndicatorViewPresentable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/AuthenticationCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/AuthenticationCoordinator.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/Authentication/AuthenticationCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/AuthenticationCoordinator.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  AuthenticationCoordinator.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11.02.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import MatrixRustSDK

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginCoordinator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginModels.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginModels.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginViewModelProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginScreen.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/MockServerSelectionScreenState.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/MockServerSelectionScreenState.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionCoordinator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionModels.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionModels.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModelProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/View/ServerSelectionScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/View/ServerSelectionScreen.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Authentication/UIConstants.swift
+++ b/ElementX/Sources/Screens/Authentication/UIConstants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/BugReport/BugReportCoordinator.swift
+++ b/ElementX/Sources/Screens/BugReport/BugReportCoordinator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/BugReport/BugReportModels.swift
+++ b/ElementX/Sources/Screens/BugReport/BugReportModels.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/BugReport/BugReportViewModel.swift
+++ b/ElementX/Sources/Screens/BugReport/BugReportViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/BugReport/BugReportViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/BugReport/BugReportViewModelProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/BugReport/View/BugReportScreen.swift
+++ b/ElementX/Sources/Screens/BugReport/View/BugReportScreen.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModelProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/RoomScreen/View/ListTableViewAdapter.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/ListTableViewAdapter.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/ListTableViewAdapter.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/ListTableViewAdapter.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ListTableViewAdapter.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 15/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MessageComposer.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 15/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import SwiftUI

--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MessageComposerTextField.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 15/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import SwiftUI

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomHeaderView.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 21.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TimelineItemStyleView.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 21.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TimelineItemStyleView.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 21.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyle.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyle.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyle.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyle.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TimelineStyle.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 24.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyler.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyler.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyler.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyler.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TimelineStyler.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 24.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/EmoteRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/EmoteRoomTimelineView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/EmoteRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/EmoteRoomTimelineView.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  EmoteRoomTimelineView.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  FormattedBodyText.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 24/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/ImageRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/ImageRoomTimelineView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/ImageRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/ImageRoomTimelineView.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ImageRoomTimelineView.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/NoticeRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/NoticeRoomTimelineView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/NoticeRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/NoticeRoomTimelineView.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  NoticeRoomTimelineView.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/SeparatorRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/SeparatorRoomTimelineView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/SeparatorRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/SeparatorRoomTimelineView.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  SeparatorRoomTimelineView.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TextRoomTimelineView.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemContextMenu.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemContextMenu.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemContextMenu.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemContextMenu.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TimelineItemContextMenu.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 18/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import SwiftUI

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemList.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemList.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemList.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemList.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TimelineItemList.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 15/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineSenderAvatarView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineSenderAvatarView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineSenderAvatarView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineSenderAvatarView.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TimelineSenderAvatarView.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 24.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TimelineView.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 30/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Screens/SessionVerification/SessionVerificationCoordinator.swift
+++ b/ElementX/Sources/Screens/SessionVerification/SessionVerificationCoordinator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/SessionVerification/SessionVerificationModels.swift
+++ b/ElementX/Sources/Screens/SessionVerification/SessionVerificationModels.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/SessionVerification/SessionVerificationStateMachine.swift
+++ b/ElementX/Sources/Screens/SessionVerification/SessionVerificationStateMachine.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/SessionVerification/SessionVerificationStateMachine.swift
+++ b/ElementX/Sources/Screens/SessionVerification/SessionVerificationStateMachine.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  SessionVerificationStateMachine.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 15/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Screens/SessionVerification/SessionVerificationViewModel.swift
+++ b/ElementX/Sources/Screens/SessionVerification/SessionVerificationViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/SessionVerification/SessionVerificationViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/SessionVerification/SessionVerificationViewModelProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Settings/SettingsCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsCoordinator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Settings/SettingsModels.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsModels.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Settings/SettingsViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Settings/SettingsViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsViewModelProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/Splash/SplashViewController.swift
+++ b/ElementX/Sources/Screens/Splash/SplashViewController.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Screens/Splash/SplashViewController.swift
+++ b/ElementX/Sources/Screens/Splash/SplashViewController.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  SplashViewController.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 14.02.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import UIKit

--- a/ElementX/Sources/Screens/SplashScreen/SplashScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/SplashScreen/SplashScreenCoordinator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/SplashScreen/SplashScreenModels.swift
+++ b/ElementX/Sources/Screens/SplashScreen/SplashScreenModels.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/SplashScreen/SplashScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SplashScreen/SplashScreenViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/SplashScreen/SplashScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/SplashScreen/SplashScreenViewModelProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/SplashScreen/View/SplashScreen.swift
+++ b/ElementX/Sources/Screens/SplashScreen/View/SplashScreen.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/SplashScreen/View/SplashScreenPageIndicator.swift
+++ b/ElementX/Sources/Screens/SplashScreen/View/SplashScreenPageIndicator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Screens/SplashScreen/View/SplashScreenPageView.swift
+++ b/ElementX/Sources/Screens/SplashScreen/View/SplashScreenPageView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  AuthenticationService.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Doug on 29/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import AppAuth

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  AuthenticationServiceProxyProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Doug on 29/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import AppAuth

--- a/ElementX/Sources/Services/Authentication/MockAuthenticationServiceProxy.swift
+++ b/ElementX/Sources/Services/Authentication/MockAuthenticationServiceProxy.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Authentication/MockAuthenticationServiceProxy.swift
+++ b/ElementX/Sources/Services/Authentication/MockAuthenticationServiceProxy.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MockAuthenticationService.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Doug on 29/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import AppAuth

--- a/ElementX/Sources/Services/Authentication/OIDCService.swift
+++ b/ElementX/Sources/Services/Authentication/OIDCService.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Authentication/OIDCService.swift
+++ b/ElementX/Sources/Services/Authentication/OIDCService.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  OIDCAuthenticationService.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Doug on 07/07/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import AppAuth

--- a/ElementX/Sources/Services/Background/ApplicationProtocol.swift
+++ b/ElementX/Sources/Services/Background/ApplicationProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Background/ApplicationProtocol.swift
+++ b/ElementX/Sources/Services/Background/ApplicationProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ApplicationProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 28.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Background/BackgroundTaskProtocol.swift
+++ b/ElementX/Sources/Services/Background/BackgroundTaskProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Background/BackgroundTaskProtocol.swift
+++ b/ElementX/Sources/Services/Background/BackgroundTaskProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  BackgroundTaskProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 28.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Background/BackgroundTaskServiceProtocol.swift
+++ b/ElementX/Sources/Services/Background/BackgroundTaskServiceProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Background/BackgroundTaskServiceProtocol.swift
+++ b/ElementX/Sources/Services/Background/BackgroundTaskServiceProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  BackgroundTaskServiceProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 28.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Background/UIKitBackgroundTask.swift
+++ b/ElementX/Sources/Services/Background/UIKitBackgroundTask.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Background/UIKitBackgroundTask.swift
+++ b/ElementX/Sources/Services/Background/UIKitBackgroundTask.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  UIKitBackgroundTask.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 28.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Background/UIKitBackgroundTaskService.swift
+++ b/ElementX/Sources/Services/Background/UIKitBackgroundTaskService.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Background/UIKitBackgroundTaskService.swift
+++ b/ElementX/Sources/Services/Background/UIKitBackgroundTaskService.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  UIKitBackgroundTaskService.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 28.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  BugReportService.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 16.05.2022.
-//  Copyright © 2022 element.io. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  BugReportServiceProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 16.05.2022.
-//  Copyright © 2022 element.io. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/BugReport/MockBugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/MockBugReportService.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/BugReport/MockBugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/MockBugReportService.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MockBugReportService.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 16.05.2022.
-//  Copyright © 2022 element.io. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/BugReport/ScreenshotDetector.swift
+++ b/ElementX/Sources/Services/BugReport/ScreenshotDetector.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/BugReport/ScreenshotDetector.swift
+++ b/ElementX/Sources/Services/BugReport/ScreenshotDetector.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ScreenshotObserver.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 31.05.2022.
-//  Copyright © 2022 element.io. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Client/ClientError.swift
+++ b/ElementX/Sources/Services/Client/ClientError.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Client/ClientError.swift
+++ b/ElementX/Sources/Services/Client/ClientError.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ClientError.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Doug on 30/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ClientProxy.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 14.02.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ClientProxyProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 26/05/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MockClientProxy.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Doug on 29/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Media/MediaProvider.swift
+++ b/ElementX/Sources/Services/Media/MediaProvider.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Media/MediaProvider.swift
+++ b/ElementX/Sources/Services/Media/MediaProvider.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MediaProvider.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 16/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Kingfisher

--- a/ElementX/Sources/Services/Media/MediaProviderProtocol.swift
+++ b/ElementX/Sources/Services/Media/MediaProviderProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Media/MediaProviderProtocol.swift
+++ b/ElementX/Sources/Services/Media/MediaProviderProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MediaProviderProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 17/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Media/MediaSource.swift
+++ b/ElementX/Sources/Services/Media/MediaSource.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Media/MediaSource.swift
+++ b/ElementX/Sources/Services/Media/MediaSource.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MediaSource.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 06/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Media/MockMediaProvider.swift
+++ b/ElementX/Sources/Services/Media/MockMediaProvider.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Media/MockMediaProvider.swift
+++ b/ElementX/Sources/Services/Media/MockMediaProvider.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MockMediaProvider.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 17/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/Members/MemberDetailProviderManager.swift
+++ b/ElementX/Sources/Services/Room/Members/MemberDetailProviderManager.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/Members/MemberDetailProviderManager.swift
+++ b/ElementX/Sources/Services/Room/Members/MemberDetailProviderManager.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MemberDetailProviderManager.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 01/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/Members/MemberDetailsProvider.swift
+++ b/ElementX/Sources/Services/Room/Members/MemberDetailsProvider.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/Members/MemberDetailsProvider.swift
+++ b/ElementX/Sources/Services/Room/Members/MemberDetailsProvider.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MemberDetailProvider.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 18/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/Members/MemberDetailsProviderProtocol.swift
+++ b/ElementX/Sources/Services/Room/Members/MemberDetailsProviderProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/Members/MemberDetailsProviderProtocol.swift
+++ b/ElementX/Sources/Services/Room/Members/MemberDetailsProviderProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MemberDetailProviderProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 18/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/Messages/EmoteRoomMessage.swift
+++ b/ElementX/Sources/Services/Room/Messages/EmoteRoomMessage.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/Messages/EmoteRoomMessage.swift
+++ b/ElementX/Sources/Services/Room/Messages/EmoteRoomMessage.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  EmoteRoomMessage.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 16/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/Messages/ImageRoomMessage.swift
+++ b/ElementX/Sources/Services/Room/Messages/ImageRoomMessage.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/Messages/ImageRoomMessage.swift
+++ b/ElementX/Sources/Services/Room/Messages/ImageRoomMessage.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ImageRoomMessage.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 16/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import MatrixRustSDK

--- a/ElementX/Sources/Services/Room/Messages/NoticeRoomMessage.swift
+++ b/ElementX/Sources/Services/Room/Messages/NoticeRoomMessage.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/Messages/NoticeRoomMessage.swift
+++ b/ElementX/Sources/Services/Room/Messages/NoticeRoomMessage.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  NoticeRoomMessage.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 16/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/Messages/RoomMessageProtocol.swift
+++ b/ElementX/Sources/Services/Room/Messages/RoomMessageProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/Messages/RoomMessageProtocol.swift
+++ b/ElementX/Sources/Services/Room/Messages/RoomMessageProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomMessageProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 16/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/Messages/TextRoomMessage.swift
+++ b/ElementX/Sources/Services/Room/Messages/TextRoomMessage.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/Messages/TextRoomMessage.swift
+++ b/ElementX/Sources/Services/Room/Messages/TextRoomMessage.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TextRoomMessage.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 16/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/MockRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/MockRoomProxy.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/MockRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/MockRoomProxy.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MockRoomProxy.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 17.02.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Room/RoomMessageFactory.swift
+++ b/ElementX/Sources/Services/Room/RoomMessageFactory.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/RoomMessageFactory.swift
+++ b/ElementX/Sources/Services/Room/RoomMessageFactory.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomMessageFactory.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 16/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/RoomMessageFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomMessageFactoryProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/RoomMessageFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomMessageFactoryProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomMessageFactoryProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 26/05/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomProxy.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 14.02.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomProxyProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 17.02.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Room/RoomSummary/EventBrief.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/EventBrief.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/RoomSummary/EventBrief.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/EventBrief.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  EventBrief.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 01/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/RoomSummary/EventBriefFactory.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/EventBriefFactory.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/RoomSummary/EventBriefFactory.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/EventBriefFactory.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  EventBriefFactory.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 01/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/RoomSummary/EventBriefFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/EventBriefFactoryProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/RoomSummary/EventBriefFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/EventBriefFactoryProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  EventBriefFactoryProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 01/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummary.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummary.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummary.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummary.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MockRoomSummary.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 01/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummary.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummary.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummary.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummary.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomSummary.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 01/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomSummaryProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 01/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Session/MockUserSession.swift
+++ b/ElementX/Sources/Services/Session/MockUserSession.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Session/MockUserSession.swift
+++ b/ElementX/Sources/Services/Session/MockUserSession.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MockUserSession.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Doug on 29/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Session/UserSession.swift
+++ b/ElementX/Sources/Services/Session/UserSession.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Session/UserSession.swift
+++ b/ElementX/Sources/Services/Session/UserSession.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  UserSession.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 27/05/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Session/UserSessionProtocol.swift
+++ b/ElementX/Sources/Services/Session/UserSessionProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Session/UserSessionProtocol.swift
+++ b/ElementX/Sources/Services/Session/UserSessionProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  UserSessionProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 27/05/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/SessionVerification/MockSessionVerificationControllerProxy.swift
+++ b/ElementX/Sources/Services/SessionVerification/MockSessionVerificationControllerProxy.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/SessionVerification/MockSessionVerificationControllerProxy.swift
+++ b/ElementX/Sources/Services/SessionVerification/MockSessionVerificationControllerProxy.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MockSessionVerificationControllerProxy.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 07/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
+++ b/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
+++ b/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  SessionVerificationControllerProxy.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 06/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxyProtocol.swift
+++ b/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxyProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxyProtocol.swift
+++ b/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxyProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  SessionVerificationControllerProxyProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 07/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Timeline/MockRoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/MockRoomTimelineController.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/MockRoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/MockRoomTimelineController.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  MockRoomTimelineController.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 04.03.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Timeline/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineController.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineController.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomTimelineController.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 04.03.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Timeline/RoomTimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineControllerProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/RoomTimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineControllerProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomTimelineControllerProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 04.03.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomTimeline.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 04.03.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProviderProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProviderProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProviderProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProviderProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomTimelineProviderProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 18/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Combine

--- a/ElementX/Sources/Services/Timeline/TimelineItems/DecorationTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/DecorationTimelineItemProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/DecorationTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/DecorationTimelineItemProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  DecorationTimelineItemProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 18/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  EventBasedTimelineItemProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 18/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/EmoteRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/EmoteRoomTimelineItem.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/EmoteRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/EmoteRoomTimelineItem.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  EmoteRoomTimelineItem.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/ImageRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/ImageRoomTimelineItem.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/ImageRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/ImageRoomTimelineItem.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ImageRoomTimelineItem.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/NoticeRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/NoticeRoomTimelineItem.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/NoticeRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/NoticeRoomTimelineItem.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  NoticeRoomTimelineItem.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/SeparatorRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/SeparatorRoomTimelineItem.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/SeparatorRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/SeparatorRoomTimelineItem.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  SectionSeparatorTimelineItem.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/TextRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/TextRoomTimelineItem.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/TextRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/TextRoomTimelineItem.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TextRoomTimelineItem.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomTimelineItemFactory.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 16/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactoryProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactoryProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomTimelineItemFactoryProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 26/05/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomTimelineItemProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 16/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewFactory.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewFactory.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomTimelineViewFactory.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 16/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewFactoryProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewFactoryProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  RoomTimelineViewFactoryProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 26/05/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewProvider.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewProvider.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewProvider.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewProvider.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  TextRoomTimelineItem.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 04.03.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/UserSessionStore/FileManager.swift
+++ b/ElementX/Sources/Services/UserSessionStore/FileManager.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/UserSessionStore/FileManager.swift
+++ b/ElementX/Sources/Services/UserSessionStore/FileManager.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  FileManager.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Doug on 19/07/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/UserSessionStore/KeychainController.swift
+++ b/ElementX/Sources/Services/UserSessionStore/KeychainController.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/UserSessionStore/KeychainController.swift
+++ b/ElementX/Sources/Services/UserSessionStore/KeychainController.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  KeychainController.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 14.02.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/Services/UserSessionStore/KeychainControllerProtocol.swift
+++ b/ElementX/Sources/Services/UserSessionStore/KeychainControllerProtocol.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/Services/UserSessionStore/KeychainControllerProtocol.swift
+++ b/ElementX/Sources/Services/UserSessionStore/KeychainControllerProtocol.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  KeychainControllerProtocol.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 14.02.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/UITestScreenIdentifier.swift
+++ b/ElementX/Sources/UITestScreenIdentifier.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/UITestScreenIdentifier.swift
+++ b/ElementX/Sources/UITestScreenIdentifier.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ScreenIdentifier.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 21.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/ElementX/Sources/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITestsAppCoordinator.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITestsAppCoordinator.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  UITestsAppCoordinator.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 29/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import SwiftUI

--- a/ElementX/Sources/UITestsRootView.swift
+++ b/ElementX/Sources/UITestsRootView.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/ElementX/Sources/UITestsRootView.swift
+++ b/ElementX/Sources/UITestsRootView.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  UITestsRootView.swift
-//  ElementX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 29/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import SwiftUI

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateCoordinator.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateCoordinator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateModels.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateModels.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateViewModel.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateViewModelProtocol.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateViewModelProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tools/Scripts/Templates/SimpleScreenExample/Tests/UI/TemplateScreenUITests.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/Tests/UI/TemplateScreenUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateViewModelTests.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/Tests/Unit/TemplateViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tools/XcodeGen/IDETemplateMacros.plist
+++ b/Tools/XcodeGen/IDETemplateMacros.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string> 
+// Copyright ___YEAR___ New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//</string>
+</dict>
+</plist>

--- a/Tools/XcodeGen/IDETemplateMacros.plist
+++ b/Tools/XcodeGen/IDETemplateMacros.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>FILEHEADER</key>
-    <string> 
+    <string>
 // Copyright ___YEAR___ New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/Tools/XcodeGen/postGenCommand.sh
+++ b/Tools/XcodeGen/postGenCommand.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This script is invoked by xcodegen for running post commands
+
+# Move file header template in project shared data folder
+cp IDETemplateMacros.plist ../../ElementX.xcodeproj/xcshareddata/

--- a/UITests/Sources/Application.swift
+++ b/UITests/Sources/Application.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/UITests/Sources/Application.swift
+++ b/UITests/Sources/Application.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  Application.swift
-//  UITests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 13/04/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import XCTest

--- a/UITests/Sources/AuthenticationCoordinatorUITests.swift
+++ b/UITests/Sources/AuthenticationCoordinatorUITests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/UITests/Sources/AuthenticationCoordinatorUITests.swift
+++ b/UITests/Sources/AuthenticationCoordinatorUITests.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  AuthenticationCoordinatorUITests.swift
-//  UITests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Doug on 30/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import XCTest

--- a/UITests/Sources/BugReportUITests.swift
+++ b/UITests/Sources/BugReportUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UITests/Sources/HomeScreenUITests.swift
+++ b/UITests/Sources/HomeScreenUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UITests/Sources/LoginScreenUITests.swift
+++ b/UITests/Sources/LoginScreenUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UITests/Sources/RoomScreenUITests.swift
+++ b/UITests/Sources/RoomScreenUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UITests/Sources/ServerSelectionUITests.swift
+++ b/UITests/Sources/ServerSelectionUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UITests/Sources/SessionVerificationUITests.swift
+++ b/UITests/Sources/SessionVerificationUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UITests/Sources/SettingsUITests.swift
+++ b/UITests/Sources/SettingsUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UITests/Sources/SplashScreenUITests.swift
+++ b/UITests/Sources/SplashScreenUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/AttributedStringBuilderTests.swift
+++ b/UnitTests/Sources/AttributedStringBuilderTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/UnitTests/Sources/AttributedStringBuilderTests.swift
+++ b/UnitTests/Sources/AttributedStringBuilderTests.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  AttributedStringBuilderTests.swift
-//  ElementXTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 28/03/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 @testable import ElementX

--- a/UnitTests/Sources/BackgroundTaskTests.swift
+++ b/UnitTests/Sources/BackgroundTaskTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/UnitTests/Sources/BackgroundTaskTests.swift
+++ b/UnitTests/Sources/BackgroundTaskTests.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  BackgroundTaskTests.swift
-//  UnitTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 28.06.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import XCTest

--- a/UnitTests/Sources/BugReportServiceTests.swift
+++ b/UnitTests/Sources/BugReportServiceTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/UnitTests/Sources/BugReportServiceTests.swift
+++ b/UnitTests/Sources/BugReportServiceTests.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  BugReportServiceTests.swift
-//  UnitTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 31.05.2022.
-//  Copyright © 2022 element.io. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 @testable import ElementX

--- a/UnitTests/Sources/BugReportViewModelTests.swift
+++ b/UnitTests/Sources/BugReportViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/ElementXTests.swift
+++ b/UnitTests/Sources/ElementXTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/UnitTests/Sources/ElementXTests.swift
+++ b/UnitTests/Sources/ElementXTests.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ElementXTests.swift
-//  ElementXTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 11.02.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 @testable import ElementX

--- a/UnitTests/Sources/HomeScreenViewModelTests.swift
+++ b/UnitTests/Sources/HomeScreenViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/ImageAnonymizerTests.swift
+++ b/UnitTests/Sources/ImageAnonymizerTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/UnitTests/Sources/ImageAnonymizerTests.swift
+++ b/UnitTests/Sources/ImageAnonymizerTests.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ImageExtensionTests.swift
-//  UnitTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 31.05.2022.
-//  Copyright © 2022 element.io. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 @testable import ElementX

--- a/UnitTests/Sources/KeychainControllerTests.swift
+++ b/UnitTests/Sources/KeychainControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/LocalizationTests.swift
+++ b/UnitTests/Sources/LocalizationTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/UnitTests/Sources/LocalizationTests.swift
+++ b/UnitTests/Sources/LocalizationTests.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  LocalizationTests.swift
-//  UnitTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 19.04.2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 @testable import ElementX

--- a/UnitTests/Sources/LoggingTests.swift
+++ b/UnitTests/Sources/LoggingTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/UnitTests/Sources/LoggingTests.swift
+++ b/UnitTests/Sources/LoggingTests.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  LoggingTests.swift
-//  UnitTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 31.05.2022.
-//  Copyright © 2022 element.io. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 @testable import ElementX

--- a/UnitTests/Sources/LoginViewModelTests.swift
+++ b/UnitTests/Sources/LoginViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/RoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomScreenViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/ScreenshotDetectorTests.swift
+++ b/UnitTests/Sources/ScreenshotDetectorTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/UnitTests/Sources/ScreenshotDetectorTests.swift
+++ b/UnitTests/Sources/ScreenshotDetectorTests.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  ScreenshotDetectorTests.swift
-//  UnitTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Ismail on 31.05.2022.
-//  Copyright © 2022 element.io. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 @testable import ElementX

--- a/UnitTests/Sources/ServerSelectionViewModelTests.swift
+++ b/UnitTests/Sources/ServerSelectionViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/SessionVerificationStateMachineTests.swift
+++ b/UnitTests/Sources/SessionVerificationStateMachineTests.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/UnitTests/Sources/SessionVerificationStateMachineTests.swift
+++ b/UnitTests/Sources/SessionVerificationStateMachineTests.swift
@@ -1,9 +1,17 @@
+// 
+// Copyright 2022 New Vector Ltd
 //
-//  SessionVerificationStateMachineTests.swift
-//  UnitTests
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Stefan Ceriu on 28/06/2022.
-//  Copyright © 2022 Element. All rights reserved.
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import XCTest

--- a/UnitTests/Sources/SessionVerificationViewModelTests.swift
+++ b/UnitTests/Sources/SessionVerificationViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/SettingsViewModelTests.swift
+++ b/UnitTests/Sources/SettingsViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/SplashScreenViewModelTests.swift
+++ b/UnitTests/Sources/SplashScreenViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/UserIndicators/UserIndicatorPresenterSpy.swift
+++ b/UnitTests/Sources/UserIndicators/UserIndicatorPresenterSpy.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/UserIndicators/UserIndicatorQueueTests.swift
+++ b/UnitTests/Sources/UserIndicators/UserIndicatorQueueTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/UnitTests/Sources/UserIndicators/UserIndicatorTests.swift
+++ b/UnitTests/Sources/UserIndicators/UserIndicatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 New Vector Ltd
+// Copyright 2022 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/changelog.d/150.misc
+++ b/changelog.d/150.misc
@@ -1,0 +1,1 @@
+Use standard file headers.

--- a/project.yml
+++ b/project.yml
@@ -17,6 +17,7 @@ options:
       order: [Sources, Resources, SupportingFiles]
     - pattern: Sources
       order: [Services, Screens, Other]
+  postGenCommand: cd Tools/XcodeGen && sh postGenCommand.sh
 
 settings:
   CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED: YES


### PR DESCRIPTION
This PR contains 2 commits to align the headers in ElementX with those in Element iOS:
- Add a `IDETemplateMacros.plist` file so that new files always have the default file header added.
- A regex replacement of Xcode headers → the default file header (and a find and replace for 2021 → 2022 on existing files).

Fixes #150.

Edit: Last commit fixes an issue where the first line has an extra ` ` in the header.