### PR TITLE
Run SwiftFormat (non-lenient) separately on CI.

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -36,6 +36,10 @@ jobs:
         run:
           brew update && brew bundle && brew upgrade
 
+      - name: SwiftFormat
+        run:
+          swiftformat --lint .
+
       - name: Bundle install
         run: |
           bundle config path vendor/bundle

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -1761,11 +1761,11 @@
 			buildConfigurationList = B15427F8699AD5A5FC75C17E /* Build configuration list for PBXNativeTarget "ElementX" */;
 			buildPhases = (
 				A7130911BCB2DF3D249A1836 /* 🛠 SwiftGen */,
-				B35AB66424BB30087EEE408C /* 🧹 SwiftFormat */,
 				9797D588420FCBBC228A63C9 /* Sources */,
 				215E1D91B98672C856F559D0 /* Resources */,
 				EE878EAA342710DB973E0A87 /* Frameworks */,
 				98CA896D84BFD53B2554E891 /* ⚠️ SwiftLint */,
+				B35AB66424BB30087EEE408C /* 🧹 SwiftFormat */,
 			);
 			buildRules = (
 			);
@@ -2066,7 +2066,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat >/dev/null; then\n  if [ $CONFIGURATION = \"Debug\" ]; then \n    swiftformat --lint --lenient \"$PROJECT_DIR\"\n  else \n    swiftformat --lint \"$PROJECT_DIR\"\n  fi\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat >/dev/null; then\n  swiftformat --lint --lenient \"$PROJECT_DIR\"\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -2066,7 +2066,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat >/dev/null; then\n  swiftformat --lint --lenient \"$PROJECT_DIR\"\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat >/dev/null; then\n    swiftformat --lint --lenient \"$PROJECT_DIR\"\nelse\n    echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ElementX.xcodeproj/xcshareddata/xcschemes/IntegrationTests.xcscheme
+++ b/ElementX.xcodeproj/xcshareddata/xcschemes/IntegrationTests.xcscheme
@@ -115,16 +115,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D3DB351B7FBE0F49649171FC"
-            BuildableName = "IntegrationTests.xctest"
-            BlueprintName = "IntegrationTests"
-            ReferencedContainer = "container:ElementX.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
       <CommandLineArguments>
       </CommandLineArguments>
       <EnvironmentVariables>
@@ -144,6 +134,15 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D3DB351B7FBE0F49649171FC"
+            BuildableName = "IntegrationTests.xctest"
+            BlueprintName = "IntegrationTests"
+            ReferencedContainer = "container:ElementX.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/ElementX.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
+++ b/ElementX.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
@@ -77,8 +77,9 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0E28CD62691FDBC63147D5E3"
@@ -86,9 +87,7 @@
             BlueprintName = "UITests"
             ReferencedContainer = "container:ElementX.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/ElementX.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/ElementX.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -99,8 +99,9 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "32C23C8D224D46EFE62AFAD0"
@@ -108,9 +109,7 @@
             BlueprintName = "UnitTests"
             ReferencedContainer = "container:ElementX.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -69,21 +69,6 @@ targets:
             echo "warning: SwiftGen not installed, download from https://github.com/SwiftGen/SwiftGen"
         fi
 
-    - name: 🧹 SwiftFormat
-      runOnlyWhenInstalling: false
-      shell: /bin/sh
-      script: |
-        export PATH="$PATH:/opt/homebrew/bin"
-        if which swiftformat >/dev/null; then
-          if [ $CONFIGURATION = "Debug" ]; then 
-            swiftformat --lint --lenient "$PROJECT_DIR"
-          else 
-            swiftformat --lint "$PROJECT_DIR"
-          fi
-        else
-          echo "warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat"
-        fi
-
     postBuildScripts:
     - name: ⚠️ SwiftLint
       runOnlyWhenInstalling: false
@@ -94,6 +79,16 @@ targets:
             swiftlint
         else
             echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
+        fi
+    - name: 🧹 SwiftFormat
+      runOnlyWhenInstalling: false
+      shell: /bin/sh
+      script: |
+        export PATH="$PATH:/opt/homebrew/bin"
+        if which swiftformat >/dev/null; then
+          swiftformat --lint --lenient "$PROJECT_DIR"
+        else
+          echo "warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat"
         fi
 
     dependencies:

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -86,9 +86,9 @@ targets:
       script: |
         export PATH="$PATH:/opt/homebrew/bin"
         if which swiftformat >/dev/null; then
-          swiftformat --lint --lenient "$PROJECT_DIR"
+            swiftformat --lint --lenient "$PROJECT_DIR"
         else
-          echo "warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat"
+            echo "warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat"
         fi
 
     dependencies:

--- a/changelog.d/pr-167.build
+++ b/changelog.d/pr-167.build
@@ -1,1 +1,1 @@
-Use unstable MSC2967 values for OIDC scopes + client registration metadata updates.
+Run SwiftFormat as a post-build script locally, with an additional pre-build step on CI.

--- a/changelog.d/pr-167.build
+++ b/changelog.d/pr-167.build
@@ -1,0 +1,1 @@
+Use unstable MSC2967 values for OIDC scopes + client registration metadata updates.


### PR DESCRIPTION
This PR allows Xcode to run SwiftFormat as a post build step which helps development when there are compile errors.

We will run a non-lenient lint in the Alpha build so that CI still fails early with bad formatting, but without impacting devx.