### PR TITLE
Add validate-lfs.sh check from Android.

### DIFF
--- a/.github/workflows/validate-lfs.yml
+++ b/.github/workflows/validate-lfs.yml
@@ -1,0 +1,15 @@
+name: Validate Git LFS
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Validate
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+
+      - run: |
+          ./Tools/Scripts/validate_lfs.sh

--- a/Tools/Scripts/validate_lfs.sh
+++ b/Tools/Scripts/validate_lfs.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+
+#
+# Copyright (c) 2022 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Based on https://cashapp.github.io/paparazzi/#git-lfs
+
+# Compare the output of `git ls-files ':(attr:filter=lfs)'` against `git lfs ls-files`
+# If there's no diff we assume the files have been committed using git lfs
+diff <(git ls-files ':(attr:filter=lfs)' | sort) <(git lfs ls-files -n | sort) >/dev/null
+
+ret=$?
+if [[ $ret -ne 0 ]]; then
+  echo >&2 "Detected files committed without using Git LFS."
+  echo >&2 "Install git lfs (eg brew install git-lfs) and run 'git lfs install --local' within the root repository directory and re-commit your files."
+  exit 1
+fi

--- a/changelog.d/pr-203.build
+++ b/changelog.d/pr-203.build
@@ -1,0 +1,1 @@
+Add validate-lfs.sh check from Element Android.


### PR DESCRIPTION
Copied across from the EA [workflow](https://github.com/vector-im/element-android/blob/96901c5afe27fdc972d2733bf4db9f779617ae33/.github/workflows/validate-lfs.yml) and [script](https://github.com/vector-im/element-android/blob/96901c5afe27fdc972d2733bf4db9f779617ae33/tools/validate_lfs.sh).

Will test separately once merged with a fresh clone that didn't `git lfs install`