### PR TITLE
Coordinator stops

### DIFF
--- a/ElementX/Sources/AppCoordinator.swift
+++ b/ElementX/Sources/AppCoordinator.swift
@@ -105,6 +105,10 @@ class AppCoordinator: Coordinator {
         stateMachine.processEvent(userSessionStore.hasSessions ? .startWithExistingSession : .startWithAuthentication)
     }
 
+    func stop() {
+        hideLoadingIndicator()
+    }
+
     // MARK: - Private
     
     private func setupLogging() {

--- a/ElementX/Sources/Other/Coordinator.swift
+++ b/ElementX/Sources/Other/Coordinator.swift
@@ -37,7 +37,7 @@ protocol Coordinator: AnyObject {
     /// - Parameter childCoordinator: Child coordinator to remove.
     func remove(childCoordinator: Coordinator)
 
-    /// Stops job of the coordinator. Can be used to clear some resources.
+    /// Stops job of the coordinator. Can be used to clear some resources. Will be automatically called when the coordinator removed.
     func stop()
 }
 

--- a/ElementX/Sources/Other/Coordinator.swift
+++ b/ElementX/Sources/Other/Coordinator.swift
@@ -36,6 +36,9 @@ protocol Coordinator: AnyObject {
     ///
     /// - Parameter childCoordinator: Child coordinator to remove.
     func remove(childCoordinator: Coordinator)
+
+    /// Stops job of the coordinator. Can be used to clear some resources.
+    func stop()
 }
 
 // `Coordinator` default implementation

--- a/ElementX/Sources/Other/Coordinator.swift
+++ b/ElementX/Sources/Other/Coordinator.swift
@@ -48,6 +48,7 @@ extension Coordinator {
     }
     
     func remove(childCoordinator: Coordinator) {
+        childCoordinator.stop()
         childCoordinators = childCoordinators.filter { $0 !== childCoordinator }
     }
 }

--- a/ElementX/Sources/Screens/AnalyticsPrompt/AnalyticsPromptCoordinator.swift
+++ b/ElementX/Sources/Screens/AnalyticsPrompt/AnalyticsPromptCoordinator.swift
@@ -70,4 +70,6 @@ final class AnalyticsPromptCoordinator: Coordinator, Presentable {
     }
     
     func toPresentable() -> UIViewController { analyticsPromptHostingController }
+
+    func stop() { }
 }

--- a/ElementX/Sources/Screens/Authentication/AuthenticationCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/AuthenticationCoordinator.swift
@@ -47,6 +47,10 @@ class AuthenticationCoordinator: Coordinator, Presentable {
     func toPresentable() -> UIViewController {
         navigationRouter.toPresentable()
     }
+
+    func stop() {
+        stopLoading()
+    }
     
     // MARK: - Private
     

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginCoordinator.swift
@@ -99,6 +99,10 @@ final class LoginCoordinator: Coordinator, Presentable {
     func toPresentable() -> UIViewController {
         loginHostingController
     }
+
+    func stop() {
+        stopLoading()
+    }
     
     // MARK: - Private
     

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionCoordinator.swift
@@ -82,6 +82,10 @@ final class ServerSelectionCoordinator: Coordinator, Presentable {
     func toPresentable() -> UIViewController {
         serverSelectionHostingController
     }
+
+    func stop() {
+        stopLoading()
+    }
     
     // MARK: - Private
     

--- a/ElementX/Sources/Screens/Authentication/SoftLogout/SoftLogoutCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/SoftLogout/SoftLogoutCoordinator.swift
@@ -108,6 +108,10 @@ final class SoftLogoutCoordinator: Coordinator, Presentable {
     func toPresentable() -> UIViewController {
         softLogoutHostingController
     }
+
+    func stop() {
+        stopLoading()
+    }
     
     // MARK: - Private
     

--- a/ElementX/Sources/Screens/BugReport/BugReportCoordinator.swift
+++ b/ElementX/Sources/Screens/BugReport/BugReportCoordinator.swift
@@ -77,6 +77,10 @@ final class BugReportCoordinator: Coordinator, Presentable {
     func toPresentable() -> UIViewController {
         bugReportHostingController
     }
+
+    func stop() {
+        stopLoading()
+    }
     
     // MARK: - Private
     

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenCoordinator.swift
@@ -79,6 +79,8 @@ final class HomeScreenCoordinator: Coordinator, Presentable {
     func toPresentable() -> UIViewController {
         hostingController
     }
+
+    func stop() { }
     
     // MARK: - Private
     

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -58,4 +58,6 @@ final class RoomScreenCoordinator: Coordinator, Presentable {
     func toPresentable() -> UIViewController {
         roomScreenHostingController
     }
+
+    func stop() { }
 }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -60,6 +60,6 @@ final class RoomScreenCoordinator: Coordinator, Presentable {
     }
 
     func stop() {
-        roomScreenViewModel.context.send(viewAction: .stop)
+        roomScreenViewModel.stop()
     }
 }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -59,5 +59,7 @@ final class RoomScreenCoordinator: Coordinator, Presentable {
         roomScreenHostingController
     }
 
-    func stop() { }
+    func stop() {
+        roomScreenViewModel.context.send(viewAction: .stop)
+    }
 }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -40,7 +40,6 @@ enum RoomScreenViewAction {
     case sendMessage
     case sendReaction(key: String, eventID: String)
     case cancelReply
-    case stop
 }
 
 struct RoomScreenViewState: BindableState {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -40,7 +40,7 @@ enum RoomScreenViewAction {
     case sendMessage
     case sendReaction(key: String, eventID: String)
     case cancelReply
-    case viewDisappeared
+    case stop
 }
 
 struct RoomScreenViewState: BindableState {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -90,7 +90,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             MXLog.warning("React with \(key) failed. Not implemented.")
         case .cancelReply:
             state.composerMode = .default
-        case .viewDisappeared:
+        case .stop:
             cancellables.forEach { $0.cancel() }
             cancellables.removeAll()
             state.contextMenuBuilder = nil

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -90,11 +90,13 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             MXLog.warning("React with \(key) failed. Not implemented.")
         case .cancelReply:
             state.composerMode = .default
-        case .stop:
-            cancellables.forEach { $0.cancel() }
-            cancellables.removeAll()
-            state.contextMenuBuilder = nil
         }
+    }
+
+    func stop() {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+        state.contextMenuBuilder = nil
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
@@ -19,4 +19,6 @@ import Foundation
 @MainActor
 protocol RoomScreenViewModelProtocol {
     var context: RoomScreenViewModelType.Context { get }
+
+    func stop()
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -41,9 +41,6 @@ struct RoomScreen: View {
             }
         }
         .alert(item: $context.alertInfo) { $0.alert }
-        .onDisappear {
-            context.send(viewAction: .viewDisappeared)
-        }
     }
     
     private func sendMessage() {

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/PlaceholderAvatarImage.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/PlaceholderAvatarImage.swift
@@ -26,7 +26,8 @@ struct PlaceholderAvatarImage: View {
             Text(textForImage)
                 .padding(4)
                 .foregroundColor(.white)
-                .font(.title2.bold())
+                .font(.system(size: 200).weight(.semibold))
+                .minimumScaleFactor(0.001)
         }
         .aspectRatio(1, contentMode: .fill)
     }

--- a/ElementX/Sources/Screens/SessionVerification/SessionVerificationCoordinator.swift
+++ b/ElementX/Sources/Screens/SessionVerification/SessionVerificationCoordinator.swift
@@ -63,4 +63,6 @@ final class SessionVerificationCoordinator: Coordinator, Presentable {
     func toPresentable() -> UIViewController {
         sessionVerificationHostingController
     }
+
+    func stop() { }
 }

--- a/ElementX/Sources/Screens/Settings/SettingsCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsCoordinator.swift
@@ -87,6 +87,8 @@ final class SettingsCoordinator: Coordinator, Presentable {
     func toPresentable() -> UIViewController {
         settingsHostingController
     }
+
+    func stop() { }
     
     // MARK: - Private
     

--- a/ElementX/Sources/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITestsAppCoordinator.swift
@@ -60,6 +60,8 @@ class UITestsAppCoordinator: Coordinator {
     private func mockScreens() -> [MockScreen] {
         UITestScreenIdentifier.allCases.map { MockScreen(id: $0, navigationRouter: navigationRouter) }
     }
+
+    func stop() { }
 }
 
 @MainActor

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateCoordinator.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/TemplateCoordinator.swift
@@ -75,6 +75,10 @@ final class TemplateCoordinator: Coordinator, Presentable {
     func toPresentable() -> UIViewController {
         templateHostingController
     }
+
+    func stop() {
+        stopLoading()
+    }
     
     // MARK: - Private
     


### PR DESCRIPTION
Adds `stop` method on `Coordinator`s. Calling `stopLoading` by default made sense to me.