### PR TITLE
AppStore release scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ version_changes.md
 
 build
 Tools/Scripts/element-android
+vendor/
 
 ## macOS Files
 .DS_Store

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,50 @@
+## Changes in 1.0.3 (2022-09-23)
+
+✨ Features
+
+- UITests: Add screenshot tests. ([#9](https://github.com/vector-im/element-x-ios/issues/9))
+- Logout from the server & implement soft logout flow. ([#104](https://github.com/vector-im/element-x-ios/issues/104))
+- Implemented timeline item repyling ([#114](https://github.com/vector-im/element-x-ios/issues/114))
+- Room: New bubbles design implementation. ([#177](https://github.com/vector-im/element-x-ios/issues/177))
+- HomeScreen: Add user options menu to avatar and display name. ([#179](https://github.com/vector-im/element-x-ios/issues/179))
+- Settings screen: Implement new design. ([#180](https://github.com/vector-im/element-x-ios/issues/180))
+
+🙌 Improvements
+
+- Use unstable MSC2967 values for OIDC scopes + client registration metadata updates. ([#154](https://github.com/vector-im/element-x-ios/pull/154))
+- DesignKit: Update design tokens and add system colours to a local copy of ElementColors. ([#186](https://github.com/vector-im/element-x-ios/pull/186))
+- DesignKit: Update fonts to match Figma. ([#187](https://github.com/vector-im/element-x-ios/pull/187))
+- Include redacted events in the timeline. ([#199](https://github.com/vector-im/element-x-ios/pull/199))
+- Rename RoomTimelineProviderItem to TimelineItemProxy for clarity. ([#162](https://github.com/vector-im/element-x-ios/issues/162))
+- Style the session verification banner to match Figma. ([#181](https://github.com/vector-im/element-x-ios/issues/181))
+
+🐛 Bugfixes
+
+- Replace blocking detached tasks with Task.dispatch(on:). ([#201](https://github.com/vector-im/element-x-ios/pull/201))
+
+🧱 Build
+
+- Disable danger for external forks due to missing secret and run SwiftFormat as a pre-build step to fail early on CI. ([#157](https://github.com/vector-im/element-x-ios/pull/157))
+- Run SwiftFormat as a post-build script locally, with an additional pre-build step on CI. ([#167](https://github.com/vector-im/element-x-ios/pull/167))
+- Add validate-lfs.sh check from Element Android. ([#203](https://github.com/vector-im/element-x-ios/pull/203))
+- Python 3 support for localizer script. ([#191](https://github.com/vector-im/element-x-ios/issues/191))
+
+📄 Documentation
+
+- CONTRIBUTING.md: Fix broken link to the `createScreen.sh` script. ([#153](https://github.com/vector-im/element-x-ios/pull/153))
+
+🚧 In development 🚧
+
+- Begin adding the same Analytics used in Element iOS. ([#106](https://github.com/vector-im/element-x-ios/issues/106))
+- Add isEdited and reactions properties to timeline items. ([#111](https://github.com/vector-im/element-x-ios/issues/111))
+- Add a redactions context menu item (disabled for now whilst waiting for SDK releases). ([#178](https://github.com/vector-im/element-x-ios/issues/178))
+
+Others
+
+- Add a pull request template. ([#156](https://github.com/vector-im/element-x-ios/pull/156))
+- Use standard file headers. ([#150](https://github.com/vector-im/element-x-ios/issues/150))
+
+
 ## Changes in 1.0.2 (2022-07-28)
 
 ✨ Features

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -573,7 +573,6 @@
 		68232D336E2B546AD95B78B5 /* XCUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElement.swift; sourceTree = "<group>"; };
 		68706A66BBA04268F7747A2F /* ActivityIndicatorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorPresenter.swift; sourceTree = "<group>"; };
 		6920A4869821BF72FFC58842 /* MockMediaProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaProvider.swift; sourceTree = "<group>"; };
-		695AD3FAEAFEE32A6C73E8CB /* element-x-ios copy */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "element-x-ios copy"; path = .; sourceTree = SOURCE_ROOT; };
 		6A1AAC8EB2992918D01874AC /* rue */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = rue; path = rue.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6A6C4BE591FE5C38CE9C7EF3 /* UserProperties+Element.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserProperties+Element.swift"; sourceTree = "<group>"; };
 		6A901D95158B02CA96C79C7F /* InfoPlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPlist.swift; sourceTree = "<group>"; };
@@ -765,6 +764,7 @@
 		D0A45283CF1DB96E583BECA6 /* ImageRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRoomTimelineView.swift; sourceTree = "<group>"; };
 		D1A9CCCF53495CF3D7B19FCE /* MockSessionVerificationControllerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionVerificationControllerProxy.swift; sourceTree = "<group>"; };
 		D29EBCBFEC6FD0941749404D /* NavigationRouterStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouterStore.swift; sourceTree = "<group>"; };
+		D31DC8105C6233E5FFD9B84C /* element-x-ios */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "element-x-ios"; path = .; sourceTree = SOURCE_ROOT; };
 		D33116993D54FADC0C721C1F /* Application.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
 		D4DA544B2520BFA65D6DB4BB /* target.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = target.yml; sourceTree = "<group>"; };
 		D653265D006E708E4E51AD64 /* HomeScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenCoordinator.swift; sourceTree = "<group>"; };
@@ -1474,7 +1474,7 @@
 		9413F680ECDFB2B0DDB0DEF2 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
-				695AD3FAEAFEE32A6C73E8CB /* element-x-ios copy */,
+				D31DC8105C6233E5FFD9B84C /* element-x-ios */,
 			);
 			name = Packages;
 			sourceTree = SOURCE_ROOT;
@@ -2802,7 +2802,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.element.elementx;
 				PRODUCT_NAME = ElementX;
 				SDKROOT = iphoneos;
@@ -2826,7 +2826,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.element.elementx;
 				PRODUCT_NAME = ElementX;
 				SDKROOT = iphoneos;

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -51,7 +51,7 @@ targets:
         PRODUCT_NAME: ElementX
         PRODUCT_BUNDLE_IDENTIFIER: io.element.elementx
         APP_GROUP_IDENTIFIER: group.io.element
-        MARKETING_VERSION: 1.0.3
+        MARKETING_VERSION: 1.0.4
         CURRENT_PROJECT_VERSION: 1
         DEVELOPMENT_TEAM: 7J4U792NQT
         CODE_SIGN_ENTITLEMENTS: ElementX/SupportingFiles/ElementX.entitlements 

--- a/changelog.d/104.feature
+++ b/changelog.d/104.feature
@@ -1,1 +1,0 @@
-Logout from the server & implement soft logout flow.

--- a/changelog.d/106.wip
+++ b/changelog.d/106.wip
@@ -1,1 +1,0 @@
-Begin adding the same Analytics used in Element iOS.

--- a/changelog.d/111.wip
+++ b/changelog.d/111.wip
@@ -1,1 +1,0 @@
-Add isEdited and reactions properties to timeline items.

--- a/changelog.d/114.feature
+++ b/changelog.d/114.feature
@@ -1,1 +1,0 @@
-Implemented timeline item repyling

--- a/changelog.d/150.misc
+++ b/changelog.d/150.misc
@@ -1,1 +1,0 @@
-Use standard file headers.

--- a/changelog.d/162.change
+++ b/changelog.d/162.change
@@ -1,1 +1,0 @@
-Rename RoomTimelineProviderItem to TimelineItemProxy for clarity.

--- a/changelog.d/177.feature
+++ b/changelog.d/177.feature
@@ -1,1 +1,0 @@
-Room: New bubbles design implementation.

--- a/changelog.d/178.wip
+++ b/changelog.d/178.wip
@@ -1,1 +1,0 @@
-Add a redactions context menu item (disabled for now whilst waiting for SDK releases).

--- a/changelog.d/179.feature
+++ b/changelog.d/179.feature
@@ -1,1 +1,0 @@
-HomeScreen: Add user options menu to avatar and display name.

--- a/changelog.d/180.feature
+++ b/changelog.d/180.feature
@@ -1,1 +1,0 @@
-Settings screen: Implement new design.

--- a/changelog.d/181.change
+++ b/changelog.d/181.change
@@ -1,1 +1,0 @@
-Style the session verification banner to match Figma.

--- a/changelog.d/191.build
+++ b/changelog.d/191.build
@@ -1,1 +1,0 @@
-Python 3 support for localizer script.

--- a/changelog.d/9.feature
+++ b/changelog.d/9.feature
@@ -1,1 +1,0 @@
-UITests: Add screenshot tests.

--- a/changelog.d/pr-153.doc
+++ b/changelog.d/pr-153.doc
@@ -1,1 +1,0 @@
-CONTRIBUTING.md: Fix broken link to the `createScreen.sh` script.

--- a/changelog.d/pr-154.change
+++ b/changelog.d/pr-154.change
@@ -1,1 +1,0 @@
-Use unstable MSC2967 values for OIDC scopes + client registration metadata updates.

--- a/changelog.d/pr-156.misc
+++ b/changelog.d/pr-156.misc
@@ -1,1 +1,0 @@
-Add a pull request template.

--- a/changelog.d/pr-157.build
+++ b/changelog.d/pr-157.build
@@ -1,1 +1,0 @@
-Disable danger for external forks due to missing secret and run SwiftFormat as a pre-build step to fail early on CI.

--- a/changelog.d/pr-167.build
+++ b/changelog.d/pr-167.build
@@ -1,1 +1,0 @@
-Run SwiftFormat as a post-build script locally, with an additional pre-build step on CI.

--- a/changelog.d/pr-186.change
+++ b/changelog.d/pr-186.change
@@ -1,1 +1,0 @@
-DesignKit: Update design tokens and add system colours to a local copy of ElementColors.

--- a/changelog.d/pr-187.change
+++ b/changelog.d/pr-187.change
@@ -1,1 +1,0 @@
-DesignKit: Update fonts to match Figma.

--- a/changelog.d/pr-199.change
+++ b/changelog.d/pr-199.change
@@ -1,1 +1,0 @@
-Include redacted events in the timeline.

--- a/changelog.d/pr-201.bugfix
+++ b/changelog.d/pr-201.bugfix
@@ -1,1 +1,0 @@
-Replace blocking detached tasks with Task.dispatch(on:).

--- a/changelog.d/pr-203.build
+++ b/changelog.d/pr-203.build
@@ -1,1 +1,0 @@
-Add validate-lfs.sh check from Element Android.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,6 +29,8 @@ lane :alpha do
 
   update_app_icon(caption_text: "PR #{version}")
 
+  bump_build_number()
+
   build_ios_app(
     scheme: "ElementX",
     clean: true,
@@ -45,8 +47,8 @@ lane :alpha do
 
 end
 
-lane :release do
-  adhoc()
+lane :github_release do
+  build_adhoc()
 
   upload_to_diawi()
 
@@ -55,21 +57,45 @@ lane :release do
   prepare_next_release()
 
   upload_dsyms_to_sentry()
-
 end
 
-lane :adhoc do
+lane :app_store_release do
+  build_release()
+
+  release_to_github()
+
+  prepare_next_release()
+
+  upload_dsyms_to_sentry()
+end
+
+
+lane :build_adhoc do
+  bump_build_number()
+
   build_ios_app(
-      scheme: "ElementX",
-      clean: true,
-      export_method: "ad-hoc",
-      output_directory: "build",
-      export_options: {
-        provisioningProfiles: { 
-          "io.element.elementx" => "ElementX Ad Hoc",
-        }
+    scheme: "ElementX",
+    clean: true,
+    export_method: "ad-hoc",
+    output_directory: "build",
+    export_options: {
+      provisioningProfiles: { 
+        "io.element.elementx" => "ElementX Ad Hoc",
       }
-    )
+    }
+  )
+end
+
+lane :build_release do
+  bump_build_number()
+
+  build_ios_app(
+    scheme: "ElementX",
+    clean: true,
+    export_method: "app-store",
+    output_directory: "build",
+    xcargs: "-allowProvisioningUpdates",
+  )
 end
 
 lane :unit_tests do
@@ -109,6 +135,12 @@ lane :integration_tests do
     devices: ["iPhone 13 Pro"],
     ensure_devices_found: true,
   )
+end
+
+private_lane :bump_build_number do
+  # Increment build number to current date
+  build_number = Time.now.strftime("%Y%m%d%H%M")
+  increment_build_number(build_number: build_number)
 end
 
 private_lane :config_xcodegen_alpha do
@@ -152,17 +184,22 @@ private_lane :release_to_github do
   # Get the Diawi link from Diawi action shared value
   diawi_link = lane_context[SharedValues::UPLOADED_FILE_LINK_TO_DIAWI]
 
-  # Generate the Diawi QR code file link
-  diawi_app_id = URI(diawi_link).path.split('/').last
-  diawi_qr_code_link = "https://www.diawi.com/qrcode/link/#{diawi_app_id}"
-
-  # Increment build number to current date
-  build_number = Time.now.strftime("%Y%m%d%H%M")
-  increment_build_number(build_number: build_number)
-
   release_version = get_version_number()
 
   changes = export_version_changes(version: release_version)
+
+  description = ""
+  if diawi_link.nil?
+    description = "#{changes}"
+  else
+    # Generate the Diawi QR code file link
+    diawi_app_id = URI(diawi_link).path.split('/').last
+    diawi_qr_code_link = "https://www.diawi.com/qrcode/link/#{diawi_app_id}"
+
+    "[iOS AdHoc Release - Diawi Link](#{diawi_link})
+    ![QR code](#{diawi_qr_code_link})
+    #{changes}"
+  end
 
   github_release = set_github_release(
     repository_name: "vector-im/element-x-ios",
@@ -170,9 +207,7 @@ private_lane :release_to_github do
     name: release_version,
     tag_name: release_version,
     is_generate_release_notes: false,
-    description: "[iOS AdHoc Release - Diawi Link](#{diawi_link})
-    ![QR code](#{diawi_qr_code_link})
-    #{changes}"
+    description: description
   )
 
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -21,18 +21,34 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 
 
-### release
+### github_release
 
 ```sh
-[bundle exec] fastlane release
+[bundle exec] fastlane github_release
 ```
 
 
 
-### adhoc
+### app_store_release
 
 ```sh
-[bundle exec] fastlane adhoc
+[bundle exec] fastlane app_store_release
+```
+
+
+
+### build_adhoc
+
+```sh
+[bundle exec] fastlane build_adhoc
+```
+
+
+
+### build_release
+
+```sh
+[bundle exec] fastlane build_release
 ```
 
 


### PR DESCRIPTION
* tweaked existing scripts to support real releases
* automatic code signing through the `build_ios_app` lane `xcargs: "-allowProvisioningUpdates"` parameter
* ignore the `vendor` folder
* next version prep