### PR TITLE
Run unit test on pull request HEAD

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Brew bundle
         run:


### PR DESCRIPTION
… instead of on a merge commit.

This should make the coverage diffs more reliable since they will report the difference of the base to the actual latest commit of the PR, rather than to what the repo would look like if the PR was merged.
