### PR TITLE
Update snapshotting library to 1.10.0

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -3253,7 +3253,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.9.0;
+				minimumVersion = 1.10.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "f8a9c997c3c1dab4e216a8ec9014e23144cbab37",
-        "version" : "1.9.0"
+        "revision" : "f29e2014f6230cf7d5138fc899da51c7f513d467",
+        "version" : "1.10.0"
       }
     },
     {

--- a/UITests/Sources/Application.swift
+++ b/UITests/Sources/Application.swift
@@ -43,7 +43,7 @@ extension XCUIApplication {
     /// - Parameter identifier: Identifier of the UI test screen
     func assertScreenshot(_ identifier: UITestScreenIdentifier) {
         let failure = verifySnapshot(matching: screenshot().image,
-                                     as: .image(precision: 0.98, scale: nil),
+                                     as: .image(precision: 0.98, perceptualPrecision: 0.98, scale: nil),
                                      named: identifier.rawValue,
                                      testName: testName)
 

--- a/UITests/Sources/RoomScreenUITests.swift
+++ b/UITests/Sources/RoomScreenUITests.swift
@@ -34,7 +34,7 @@ class RoomScreenUITests: XCTestCase {
         app.goToScreenWithIdentifier(.roomEncryptedWithAvatar)
 
         XCTAssert(app.staticTexts["roomNameLabel"].exists)
-        XCTAssert(app.images["roomAvatarImage"].exists)
+        XCTAssert(app.images["roomAvatarImage"].waitForExistence(timeout: 1))
 
         app.assertScreenshot(.roomEncryptedWithAvatar)
     }

--- a/project.yml
+++ b/project.yml
@@ -72,4 +72,4 @@ packages:
     majorVersion: 7.15.0
   SnapshotTesting:
     url: https://github.com/pointfreeco/swift-snapshot-testing
-    majorVersion: 1.9.0
+    majorVersion: 1.10.0


### PR DESCRIPTION
Updates snapshotting library to [1.10.0](https://github.com/pointfreeco/swift-snapshot-testing/releases/tag/1.10.0) and enable usage of `perceptualPrecision` as `0.98`.