### PR TITLE
Fix strong reference cycle between RoomProxy and RoomTimelineProvider

### DIFF
--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -35,11 +35,6 @@ class RoomProxy: RoomProxyProtocol {
     private(set) var displayName: String?
     
     private var backPaginationOutcome: PaginationOutcome?
-    private(set) lazy var timelineProvider: RoomTimelineProviderProtocol = {
-        let provider = RoomTimelineProvider(roomProxy: self)
-        addTimelineListener(listener: WeakRoomTimelineProviderWrapper(timelineProvider: provider))
-        return provider
-    }()
     
     deinit {
         room.removeTimeline()
@@ -146,7 +141,7 @@ class RoomProxy: RoomProxyProtocol {
         }
     }
     
-    private func addTimelineListener(listener: TimelineListener) {
+    func addTimelineListener(listener: TimelineListener) {
         room.addTimelineListener(listener: listener)
     }
     

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -44,8 +44,6 @@ protocol RoomProxyProtocol {
     
     var avatarURL: String? { get }
     
-    var timelineProvider: RoomTimelineProviderProtocol { get }
-    
     func avatarURLStringForUserId(_ userId: String) -> String?
     
     func loadAvatarURLForUserId(_ userId: String) async -> Result<String?, RoomProxyError>
@@ -55,6 +53,8 @@ protocol RoomProxyProtocol {
     func loadDisplayNameForUserId(_ userId: String) async -> Result<String?, RoomProxyError>
     
     func loadDisplayName() async -> Result<String, RoomProxyError>
+    
+    func addTimelineListener(listener: TimelineListener)
     
     func paginateBackwards(count: UInt) async -> Result<Void, RoomProxyError>
     

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
@@ -41,6 +41,10 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
     init(roomProxy: RoomProxyProtocol) {
         self.roomProxy = roomProxy
         itemProxies = []
+        
+        Task {
+            await roomProxy.addTimelineListener(listener: WeakRoomTimelineProviderWrapper(timelineProvider: self))
+        }
     }
     
     func paginateBackwards(_ count: UInt) async -> Result<Void, RoomTimelineProviderError> {

--- a/ElementX/Sources/UserSession/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/UserSession/UserSessionFlowCoordinator.swift
@@ -126,10 +126,10 @@ class UserSessionFlowCoordinator: Coordinator {
                                                           mediaProvider: userSession.mediaProvider,
                                                           roomProxy: roomProxy,
                                                           attributedStringBuilder: AttributedStringBuilder())
-
+        
         let timelineController = RoomTimelineController(userId: userId,
                                                         roomId: roomIdentifier,
-                                                        timelineProvider: roomProxy.timelineProvider,
+                                                        timelineProvider: RoomTimelineProvider(roomProxy: roomProxy),
                                                         timelineItemFactory: timelineItemFactory,
                                                         mediaProvider: userSession.mediaProvider,
                                                         roomProxy: roomProxy)

--- a/changelog.d/216.bugfix
+++ b/changelog.d/216.bugfix
@@ -1,0 +1,1 @@
+Fix strong reference cycle between RoomProxy and RoomTimelineProvider


### PR DESCRIPTION
Related to vector-im/element-x-ios/pull/217