### PR TITLE
Attempt fixing flakey unit test

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,17 +1,19 @@
 name: Alpha release
 
 on:
-
-  # Triggers the workflow on any pull request
   pull_request:
+    types: [ labeled, synchronized, opened, reopened ]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   build:
     # Don't run for forks as secrets are unavailable.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Trigger-PR-Build')))
+
     name: Release
     runs-on: macos-12
     

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -18,11 +18,6 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
-        with:
-          xcode-version: '13.4'
-
       - uses: actions/checkout@v3
         with:
           lfs: true

--- a/ElementX/Sources/Services/SessionVerification/MockSessionVerificationControllerProxy.swift
+++ b/ElementX/Sources/Services/SessionVerification/MockSessionVerificationControllerProxy.swift
@@ -42,7 +42,8 @@ struct MockSessionVerificationControllerProxy: SessionVerificationControllerProx
     }
     
     func declineVerification() async -> Result<Void, SessionVerificationControllerProxyError> {
-        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 2.0) {
+        Task.detached {
+            try await Task.sleep(nanoseconds: 2_000_000_000)
             callbacks.send(.cancelled)
         }
         
@@ -50,7 +51,8 @@ struct MockSessionVerificationControllerProxy: SessionVerificationControllerProx
     }
     
     func cancelVerification() async -> Result<Void, SessionVerificationControllerProxyError> {
-        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 2.0) {
+        Task.detached {
+            try await Task.sleep(nanoseconds: 2_000_000_000)
             callbacks.send(.cancelled)
         }
         

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@
 source "https://rubygems.org"
 
 gem 'fastlane'
+gem "xcode-install"
 gem 'slather'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,13 +174,15 @@ GEM
     mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.16.2)
     multi_json (1.15.0)
     multipart-post (2.0.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.13.8-x86_64-linux)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     optparse (0.1.1)
     os (1.1.4)
@@ -234,6 +236,9 @@ GEM
     unicode-display_width (1.8.0)
     webrick (1.7.0)
     word_wrap (1.0.0)
+    xcode-install (2.8.1)
+      claide (>= 0.9.1)
+      fastlane (>= 2.1.0, < 3.0.0)
     xcodeproj (1.22.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
@@ -256,6 +261,7 @@ DEPENDENCIES
   fastlane-plugin-sentry
   fastlane-plugin-xcodegen
   slather
+  xcode-install
 
 BUNDLED WITH
    2.1.4

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,10 @@
 require 'yaml'
 require_relative 'changelog'
 
+before_all do
+  xcversion(version: "~> 13.4")
+end
+
 lane :alpha do
 
   config_xcodegen_alpha()


### PR DESCRIPTION
* switches from DispatchQueue.asyncAfter to Task.sleep
* pins the Xcode version on all fastlane actions
* makes Alpha builds only be triggered on PRs labelled as `Trigger-PR-Build`