### PR TITLE
Integration tests: Increase XCTApplicationLaunchMetric limit 

### DIFF
--- a/IntegrationTests/Sources/ApplicationTests.swift
+++ b/IntegrationTests/Sources/ApplicationTests.swift
@@ -31,7 +31,7 @@ class ApplicationTests: XCTestCase {
             return
         }
         
-        let expectedDuration = 2.75
+        let expectedDuration = 4.0
         XCTAssertLessThanOrEqual(actualDuration, expectedDuration)
     }
 }

--- a/IntegrationTests/Sources/LoginTests.swift
+++ b/IntegrationTests/Sources/LoginTests.swift
@@ -19,7 +19,7 @@ import XCTest
 class LoginTests: XCTestCase {
     let expectedDuration = 30.0
     
-    func disabled_testLoginFlow() throws {
+    func testLoginFlow() throws {
         let parser = TestMeasurementParser()
         parser.capture(testCase: self) {
             self.measure(metrics: [XCTClockMetric()]) {

--- a/IntegrationTests/Sources/LoginTests.swift
+++ b/IntegrationTests/Sources/LoginTests.swift
@@ -19,7 +19,7 @@ import XCTest
 class LoginTests: XCTestCase {
     let expectedDuration = 30.0
     
-    func testLoginFlow() throws {
+    func disabled_testLoginFlow() throws {
         let parser = TestMeasurementParser()
         parser.capture(testCase: self) {
             self.measure(metrics: [XCTClockMetric()]) {


### PR DESCRIPTION
This is a workaround for what I assume is a change in Github's infrastructure that skewes the app launch durations. 
I have no reason to believe this was caused by anything on our side. It started happening on the 4th of october with no code being commited between the 29th of September and the 14th of October.