### PR TITLE
Fixed XcodeCloud release workflows

### DIFF
--- a/ci_scripts/ci_common.sh
+++ b/ci_scripts/ci_common.sh
@@ -13,10 +13,12 @@ setup_environment () {
     echo 'export GEM_HOME=$HOME/.gem' >>~/.zshrc
     echo 'export PATH=$GEM_HOME/bin:$PATH' >>~/.zshrc
     echo 'export PATH="/usr/local/opt/ruby@2.7/bin:$PATH"' >> ~/.zshrc
+    echo 'export PATH="/Users/local/Library/Python/3.9/bin:$PATH"' >> ~/.zshrc
 
     export GEM_HOME=$HOME/.gem
     export PATH=$GEM_HOME/bin:$PATH
     export PATH="/usr/local/opt/ruby@2.7/bin:$PATH"
+    export PATH="/Users/local/Library/Python/3.9/bin:$PATH"
 
     # Things don't work well on the default ruby version
     brew install "ruby@2.7"

--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -8,6 +8,7 @@ if [ "$CI_WORKFLOW" = "Release" ]; then
     install_python_dependencies
 
     bundle exec fastlane release_to_github
+    bundle exec fastlane prepare_next_release
 fi
 
 # Upload dsyms no matter the workflow

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -171,7 +171,10 @@ lane :release_to_github do
 
 end
 
-lane :prepare_next_release do 
+lane :prepare_next_release do
+  api_token = ENV["GITHUB_TOKEN"]
+  UI.user_error!("Invalid GitHub API token.") unless !api_token.to_s.empty?
+
   target_file_path = "../ElementX/SupportingFiles/target.yml"
   xcode_project_file_path = "../ElementX.xcodeproj"
 
@@ -185,11 +188,18 @@ lane :prepare_next_release do
 
   xcodegen(spec: "project.yml")
 
+  sh("git config --global user.name 'Element CI'")
+  sh("git config --global user.email 'ci@element.io'")
+
   sh("git add #{target_file_path} #{xcode_project_file_path}")
 
   sh("git commit -m 'Prepare next release'")
 
-  sh("git push")  
+  # Get repo url path, without `http` or `git@` prefixes
+  repo_url = sh("git ls-remote --get-url origin | sed 's#http://##g' | sed 's#https:\/\/##g' | sed 's#git@##g\'")
+
+  # Use the access token for write access
+  sh("git push https://#{api_token}@#{repo_url}")
 end
 
 private_lane :config_xcodegen_alpha do


### PR DESCRIPTION
This PR will make Xcode Cloud:
* correctly access the path where towncrier (python dependency) is installed
* configure git with `Element CI` / `ci@element.io`
* generate version bump commit and push it using the Github Access Token to (Xcode Cloud doesn't have write access)

There's a discussion to be had on whether we should create release branches, automatically merge to master etc. but for now this will do