### PR TITLE
Enable e2ee support

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -3223,7 +3223,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "1.0.14-alpha";
+				version = "1.0.15-alpha";
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "787b00fbdd34cf296a760c27136749e60223ed01",
-        "version" : "1.0.14-alpha"
+        "revision" : "e3ae8941c864ba18e7e5c51d25a6ce2c5c7a65a0",
+        "version" : "1.0.15-alpha"
       }
     },
     {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -84,7 +84,8 @@ class ClientProxy: ClientProxyProtocol {
             
             let slidingSyncView = try SlidingSyncViewBuilder()
                 .timelineLimit(limit: 10)
-                .requiredState(requiredState: [RequiredState(key: "m.room.avatar", value: "")])
+                .requiredState(requiredState: [RequiredState(key: "m.room.avatar", value: ""),
+                                               RequiredState(key: "m.room.encryption", value: "")])
                 .name(name: "HomeScreenView")
                 .syncMode(mode: .fullSync)
                 .build()

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -91,7 +91,7 @@ class ClientProxy: ClientProxyProtocol {
             
             slidingSync = try slidingSyncBuilder
                 .addView(view: slidingSyncView)
-//                .withCommonExtensions()
+                .withCommonExtensions()
                 .build()
             
             roomSummaryProvider = RoomSummaryProvider(slidingSyncController: slidingSync,
@@ -254,6 +254,6 @@ class ClientProxy: ClientProxyProtocol {
     fileprivate func didReceiveSlidingSyncUpdate(summary: UpdateSummary) {
         roomSummaryProvider.updateRoomsWithIdentifiers(summary.rooms)
         
-//        callbacks.send(.receivedSyncUpdate)
+        callbacks.send(.receivedSyncUpdate)
     }
 }

--- a/ElementX/Sources/UserSession/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/UserSession/UserSessionFlowCoordinator.swift
@@ -112,7 +112,7 @@ class UserSessionFlowCoordinator: Coordinator {
             case .presentRoom(let roomIdentifier):
                 self.stateMachine.processEvent(.showRoomScreen(roomId: roomIdentifier))
             case .presentSettings:
-                self.presentSettingsScreen()
+                self.stateMachine.processEvent(.showSettingsScreen)
             case .presentBugReport:
                 self.presentBugReportScreen()
             case .verifySession:
@@ -209,6 +209,8 @@ class UserSessionFlowCoordinator: Coordinator {
 
         navigationRouter.dismissModule()
         remove(childCoordinator: coordinator)
+        
+        stateMachine.processEvent(.dismissedSettingsScreen)
     }
     
     // MARK: Session verification

--- a/ElementX/Sources/UserSession/UserSessionFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/UserSession/UserSessionFlowCoordinatorStateMachine.swift
@@ -89,6 +89,14 @@ class UserSessionFlowCoordinatorStateMachine {
                 return .suspended
             case (.becomeActive, .suspended):
                 return self.stateBeforeSuspension
+            case (.showSettingsScreen, .homeScreen):
+                return .settingsScreen
+            case (.dismissedSettingsScreen, .settingsScreen):
+                return .homeScreen
+            case (.showSessionVerificationScreen, .homeScreen):
+                return .sessionVerificationScreen
+            case (.dismissedSessionVerificationScreen, .sessionVerificationScreen):
+                return .homeScreen
             default:
                 return nil
             }

--- a/UITests/Sources/Application.swift
+++ b/UITests/Sources/Application.swift
@@ -63,11 +63,11 @@ extension XCUIApplication {
     }
 
     private var languageCode: String {
-        Locale.current.languageCode ?? ""
+        Locale.current.language.languageCode?.identifier ?? ""
     }
 
     private var regionCode: String {
-        Locale.current.regionCode ?? ""
+        Locale.current.language.region?.identifier ?? ""
     }
 
     private var osVersion: String {

--- a/changelog.d/pr-274.feature
+++ b/changelog.d/pr-274.feature
@@ -1,0 +1,1 @@
+Enable e2e encryption support

--- a/project.yml
+++ b/project.yml
@@ -35,7 +35,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.14-alpha
+    exactVersion: 1.0.15-alpha
     # path: ../matrix-rust-components-swift
   DesignKit:
     path: ./


### PR DESCRIPTION
This PR enable the sliding sync extensions and adds a missing `m.room.encryption` SS required state.
It also moves some extra screens to the `UserSessionFlowCoordinatorStateMachine` (bugReport still left to be done)