### PR TITLE
Fixes #273 - Remove home screen animations

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -39,12 +39,10 @@ struct HomeScreen: View {
                     }
                 }
             }
-            .animation(.elementDefault, value: context.viewState.visibleRooms)
             .padding(.horizontal)
             .searchable(text: $context.searchQuery)
         }
         .disabled(context.viewState.roomListMode == .skeletons)
-        .animation(.elementDefault, value: context.viewState.roomListMode)
         .animation(.elementDefault, value: context.viewState.showSessionVerificationBanner)
         .ignoresSafeArea(.all, edges: .bottom)
         .navigationTitle(ElementL10n.allChats)

--- a/changelog.d/273.bugfix
+++ b/changelog.d/273.bugfix
@@ -1,0 +1,1 @@
+Remove home screen list change animations


### PR DESCRIPTION
This PR removes home screen list change animations as they're not quite pretty or useful