### PR TITLE
Expose sliding sync proxy URL on the server selection screen

### DIFF
--- a/ElementX/Sources/Application/BuildSettings.swift
+++ b/ElementX/Sources/Application/BuildSettings.swift
@@ -20,8 +20,9 @@ final class BuildSettings {
     // MARK: - Servers
 
     static let defaultHomeserverAddress = "matrix.org"
-    static let slidingSyncProxyBaseURL = URL(staticString: "https://slidingsync.lab.element.dev")
-
+    
+    static let defaultSlidingSyncProxyBaseURLString = "https://slidingsync.lab.element.dev"
+    
     // MARK: - Bug report
 
     static let bugReportServiceBaseURL = URL(staticString: "https://riot.im/bugreports")

--- a/ElementX/Sources/Other/ElementSettings.swift
+++ b/ElementX/Sources/Other/ElementSettings.swift
@@ -25,13 +25,17 @@ final class ElementSettings: ObservableObject {
         case timelineStyle
         case enableAnalytics
         case isIdentifiedForAnalytics
+        case slidingSyncProxyBaseURLString
     }
 
     static let shared = ElementSettings()
 
     /// UserDefaults to be used on reads and writes.
     static var store: UserDefaults {
-        .standard
+        guard let userDefaults = UserDefaults(suiteName: ElementInfoPlist.appGroupIdentifier) else {
+            fatalError("Fail to load shared UserDefaults")
+        }
+        return userDefaults
     }
 
     private init() {
@@ -59,4 +63,9 @@ final class ElementSettings: ObservableObject {
 
     @AppStorage(UserDefaultsKeys.timelineStyle.rawValue, store: store)
     var timelineStyle = BuildSettings.defaultRoomTimelineStyle
+    
+    // MARK: - Client
+    
+    @AppStorage(UserDefaultsKeys.slidingSyncProxyBaseURLString.rawValue, store: store)
+    var slidingSyncProxyBaseURLString = BuildSettings.defaultSlidingSyncProxyBaseURLString
 }

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionModels.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionModels.swift
@@ -59,6 +59,8 @@ struct ServerSelectionViewState: BindableState {
 struct ServerSelectionBindings {
     /// The homeserver address input by the user.
     var homeserverAddress: String
+    /// The sliding sync proxy address input by the user.
+    var slidingSyncProxyAddress: String
     /// Information describing the currently displayed alert.
     var alertInfo: AlertInfo<ServerSelectionErrorType>?
 }

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModel.swift
@@ -30,7 +30,9 @@ class ServerSelectionViewModel: ServerSelectionViewModelType, ServerSelectionVie
     // MARK: - Setup
     
     init(homeserverAddress: String, isModallyPresented: Bool) {
-        let bindings = ServerSelectionBindings(homeserverAddress: homeserverAddress)
+        let bindings = ServerSelectionBindings(homeserverAddress: homeserverAddress,
+                                               slidingSyncProxyAddress: ElementSettings.shared.slidingSyncProxyBaseURLString)
+        
         super.init(initialViewState: ServerSelectionViewState(bindings: bindings,
                                                               isModallyPresented: isModallyPresented))
     }
@@ -40,6 +42,10 @@ class ServerSelectionViewModel: ServerSelectionViewModelType, ServerSelectionVie
     override func process(viewAction: ServerSelectionViewAction) async {
         switch viewAction {
         case .confirm:
+            if !state.bindings.slidingSyncProxyAddress.isEmpty {
+                ElementSettings.shared.slidingSyncProxyBaseURLString = state.bindings.slidingSyncProxyAddress
+            }
+            
             callback?(.confirm(homeserverAddress: state.bindings.homeserverAddress))
         case .dismiss:
             callback?(.dismiss)

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/View/ServerSelectionScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/View/ServerSelectionScreen.swift
@@ -17,17 +17,7 @@
 import SwiftUI
 
 struct ServerSelectionScreen: View {
-    // MARK: - Properties
-    
-    // MARK: Private
-    
-    @FocusState var isTextFieldFocused: Bool
-    
-    // MARK: Public
-    
     @ObservedObject var context: ServerSelectionViewModel.Context
-    
-    // MARK: Views
     
     var body: some View {
         ScrollView {
@@ -69,8 +59,8 @@ struct ServerSelectionScreen: View {
     var serverForm: some View {
         VStack(alignment: .leading, spacing: 12) {
             TextField(ElementL10n.ftueAuthChooseServerEntryHint, text: $context.homeserverAddress)
-                .focused($isTextFieldFocused)
-                .textFieldStyle(.elementInput(footerText: context.viewState.footerMessage,
+                .textFieldStyle(.elementInput(labelText: ElementL10n.hsUrl,
+                                              footerText: context.viewState.footerMessage,
                                               isError: context.viewState.isShowingFooterError))
                 .keyboardType(.URL)
                 .autocapitalization(.none)
@@ -79,6 +69,17 @@ struct ServerSelectionScreen: View {
                 .submitLabel(.done)
                 .onSubmit(submit)
                 .accessibilityIdentifier("addressTextField")
+            
+            Divider()
+            
+            TextField(ElementL10n.ftueAuthChooseServerEntryHint, text: $context.slidingSyncProxyAddress)
+                .textFieldStyle(.elementInput(labelText: "Sliding sync proxy URL"))
+                .keyboardType(.URL)
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                .submitLabel(.done)
+                .onSubmit(submit)
+                .accessibilityIdentifier("slidingSyncProxyAddressTextField")
             
             Button(action: submit) {
                 Text(context.viewState.buttonTitle)

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -46,7 +46,7 @@ protocol ClientProxyProtocol {
 
     var restorationToken: RestorationToken? { get }
     
-    var roomSummaryProvider: RoomSummaryProviderProtocol { get }
+    var roomSummaryProvider: RoomSummaryProviderProtocol? { get }
     
     func startSync()
     

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -26,7 +26,7 @@ struct MockClientProxy: ClientProxyProtocol {
     let homeserver = ""
     let restorationToken: RestorationToken? = nil
     
-    var roomSummaryProvider: RoomSummaryProviderProtocol = MockRoomSummaryProvider()
+    var roomSummaryProvider: RoomSummaryProviderProtocol? = MockRoomSummaryProvider()
     
     func startSync() { }
     

--- a/changelog.d/320.feature
+++ b/changelog.d/320.feature
@@ -1,0 +1,1 @@
+Expose sliding sync proxy configuration URL on the server selection screen


### PR DESCRIPTION
This PR will:
* move the sliding sync server url to the user defaults
* expose it on the server selection screen
* make the app more resilient to slidinc sync configuration errors. Instead of throwing fatal errors it will allow the app to start and show the home screen but will always stay in the skeletons view. The user can choose to log out and change the server settings.

![Screenshot 2022-11-17 at 09 27 03](https://user-images.githubusercontent.com/637564/202384268-4f6dde71-4168-4685-aa48-b991beaf59c3.png)
