### PR TITLE
Various fixes

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -20,7 +20,7 @@ typealias RoomScreenViewModelType = StateStoreViewModel<RoomScreenViewState, Roo
 
 class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol {
     private enum Constants {
-        static let backPaginationPageSize: UInt = 50
+        static let backPaginationPageSize: UInt = 20
     }
 
     private let timelineController: RoomTimelineControllerProtocol

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -91,7 +91,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
             .store(in: &cancellables)
         
         weakProvider.roomListDiffPublisher
-            .collect(.byTime(DispatchQueue.global(qos: .background), 0.5))
+            .collect(.byTime(DispatchQueue.global(), 0.5))
             .sink { self.updateRoomsWithDiffs($0) }
             .store(in: &cancellables)
         

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
@@ -53,7 +53,7 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
 
             roomTimelineListener
                 .itemsUpdatePublisher
-                .collect(.byTime(DispatchQueue.global(qos: .background), 0.5))
+                .collect(.byTime(DispatchQueue.global(), 0.5))
                 .sink { self.updateItemsWithDiffs($0) }
                 .store(in: &cancellables)
         }

--- a/changelog.d/pr-327.bugfix
+++ b/changelog.d/pr-327.bugfix
@@ -1,0 +1,1 @@
+Fixed timelines not sticking to the bottom on first appearance and when message heights change


### PR DESCRIPTION
* Decrease timeline back pagination size from 50 to 20
* Switch the roomSummaryProvider and roomTimelineProvider to collect on the default global queue instead of background
* Force the timeline to stay at the bottom when first loading
* Reverted *reverted* commit that was handling offsets on item changes, like edits