### PR TITLE
Fix message composer padding with multiple lines.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
@@ -35,9 +35,8 @@ struct MessageComposer: View {
                                          text: $text,
                                          focused: $focused,
                                          maxHeight: 300,
-                                         onEnterKeyHandler: {
-                                             sendAction()
-                                         })
+                                         onEnterKeyHandler: sendAction)
+                    .padding(.vertical, 12)
                 
                 Button {
                     sendAction()
@@ -147,6 +146,22 @@ struct MessageComposer_Previews: PreviewProvider {
                             replyCancellationAction: { },
                             editCancellationAction: { })
             
+            MessageComposer(text: .constant("This is a very long message that will wrap to 2 lines on an iPhone 14."),
+                            focused: .constant(false),
+                            sendingDisabled: false,
+                            type: .default,
+                            sendAction: { },
+                            replyCancellationAction: { },
+                            editCancellationAction: { })
+            
+            MessageComposer(text: .constant("This is an even longer message that will wrap to 3 lines on an iPhone 14, just to see the difference it makes."),
+                            focused: .constant(false),
+                            sendingDisabled: false,
+                            type: .default,
+                            sendAction: { },
+                            replyCancellationAction: { },
+                            editCancellationAction: { })
+            
             MessageComposer(text: .constant("Some message"),
                             focused: .constant(false),
                             sendingDisabled: false,
@@ -165,5 +180,6 @@ struct MessageComposer_Previews: PreviewProvider {
                             editCancellationAction: { })
         }
         .tint(.element.accent)
+        .padding(.horizontal)
     }
 }

--- a/changelog.d/305.bugfix
+++ b/changelog.d/305.bugfix
@@ -1,0 +1,1 @@
+Message Composer: Fix vertical padding with multiple lines of text. 


### PR DESCRIPTION
Fixes #305.

| Before | After |
| - | - |
| ![Screenshot 2022-11-18 at 4 00 46 pm](https://user-images.githubusercontent.com/6060466/202748217-420f0f6d-b962-4913-b369-cf393c5263e5.png) | ![Screenshot 2022-11-18 at 4 00 37 pm](https://user-images.githubusercontent.com/6060466/202748229-3988dbab-3418-4e55-a55c-58db38aaa88b.png) |
