### PR TITLE
Timeline scrolling performance issues

### DIFF
--- a/ElementX/Sources/Services/Timeline/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineController.swift
@@ -378,7 +378,7 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
     }
     
     private func loadUserAvatarForTimelineItem(_ timelineItem: EventBasedTimelineItemProtocol) async {
-        if timelineItem.shouldShowSenderDetails == false {
+        if timelineItem.shouldShowSenderDetails == false || timelineItem.senderAvatar != nil {
             return
         }
         
@@ -408,7 +408,7 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
     }
     
     private func loadUserDisplayNameForTimelineItem(_ timelineItem: EventBasedTimelineItemProtocol) async {
-        if timelineItem.shouldShowSenderDetails == false {
+        if timelineItem.shouldShowSenderDetails == false || timelineItem.senderDisplayName != nil {
             return
         }
         

--- a/changelog.d/330.bugfix
+++ b/changelog.d/330.bugfix
@@ -1,0 +1,1 @@
+Timeline: Fixed scrolling performance issues.


### PR DESCRIPTION
closes #330 

The issue was due to the repeated loading of avatars and usernames for list items. Updating list items with the loaded avatar or username, triggered body of `TimelineItemList` to get re-evaluated and that caused all of the list items to be recreated, causing a performance hit. 

There are other things that could potentially be improved. For example, when a user tries to download more items, all items in the view model are recreated, causing again all of the list items to be recreated. Maybe it could be possible just to update state objects by adding new items only. 