### PR TITLE
Setup tracing with a typed configuration.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		24BDDD09A90B8BFE3793F3AA /* ClientProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033779EB37259F27F938937 /* ClientProxyProtocol.swift */; };
 		2797C9D9BA642370F1C85D78 /* Untranslated.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = F75DF9500D69A3AAF8339E69 /* Untranslated.stringsdict */; };
 		27E9263DA75E266690A37EB1 /* PermalinkBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB31A32C93D94930B253FBF /* PermalinkBuilderTests.swift */; };
+		282A5F3375DDC774AE09B0C3 /* TracingConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1734A445A58ED855B977A0A8 /* TracingConfigurationTests.swift */; };
 		28410F3DE89C2C44E4F75C92 /* MockBugReportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E7BF8F7BB1021F889C6483 /* MockBugReportService.swift */; };
 		290FDB0FFDC2F1DDF660343E /* TestMeasurementParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4048041C1A6B20CB97FD18 /* TestMeasurementParser.swift */; };
 		297CD0A27C87B0C50FF192EE /* RoomTimelineViewFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE384418EB1FEDFA62C9CD0 /* RoomTimelineViewFactoryProtocol.swift */; };
@@ -145,6 +146,7 @@
 		4FC1EFE4968A259CBBACFAFB /* RoomProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A65F140F9FE5E8D4DAEFF354 /* RoomProxy.swift */; };
 		4FF90E2242DBD596E1ED2E27 /* AppCoordinatorStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077D7C3BE199B6E5DDEC07EC /* AppCoordinatorStateMachine.swift */; };
 		500CB65ED116B81DA52FDAEE /* TimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A1842477895F199567BD7 /* TimelineView.swift */; };
+		50C90117FE25390BFBD40173 /* RustTracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542D4F49FABA056DEEEB3400 /* RustTracing.swift */; };
 		518C93DC6516D3D018DE065F /* UNNotificationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E751D7EDB6043238111D90 /* UNNotificationRequest.swift */; };
 		51DB67C5B5BC68B0A6FF54D4 /* MockRoomProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACBDC1D28EFB7789EB467E0 /* MockRoomProxy.swift */; };
 		524C9C31EF8D58C2249F8A10 /* sample_screenshot.png in Resources */ = {isa = PBXBuildFile; fileRef = 9414DCADBDF9D6C4B806F61E /* sample_screenshot.png */; };
@@ -205,6 +207,7 @@
 		706F79A39BDB32F592B8C2C7 /* UIKitBackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FCD9116ADDE820E4E30F92 /* UIKitBackgroundTask.swift */; };
 		7096FA3AC218D914E88BFB70 /* AggregratedReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15BE37BE2FB86E00C8D150A /* AggregratedReaction.swift */; };
 		719E7AAD1F8E68F68F30FECD /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40C19719687984FD9478FBE /* Task.swift */; };
+		7354D094A4C59B555F407FA1 /* RustTracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542D4F49FABA056DEEEB3400 /* RustTracing.swift */; };
 		7405B4824D45BA7C3D943E76 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0CBC76C80E04345E11F2DB /* Application.swift */; };
 		744C029EB6C43429926A0499 /* AnalyticsPromptViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A86C95340248A8B7BA9A43 /* AnalyticsPromptViewModelProtocol.swift */; };
 		74604ACFDBE7F54260E7B617 /* ApplicationProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8903A9F615BBD0E6D7CD133 /* ApplicationProtocol.swift */; };
@@ -530,6 +533,7 @@
 		167521635A1CC27624FCEB7F /* ServerSelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionViewModel.swift; sourceTree = "<group>"; };
 		16DC8C5B2991724903F1FA6A /* AppIcon.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = AppIcon.pdf; sourceTree = "<group>"; };
 		1715E3D7F53C0748AA50C91C /* PostHogAnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogAnalyticsClient.swift; sourceTree = "<group>"; };
+		1734A445A58ED855B977A0A8 /* TracingConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingConfigurationTests.swift; sourceTree = "<group>"; };
 		179423E34EE846E048E49CBF /* MediaSourceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaSourceProxy.swift; sourceTree = "<group>"; };
 		184CF8C196BE143AE226628D /* DecorationTimelineItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecorationTimelineItemProtocol.swift; sourceTree = "<group>"; };
 		18F2958E6D247AE2516BEEE8 /* ClientProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientProxy.swift; sourceTree = "<group>"; };
@@ -655,6 +659,7 @@
 		534A5C8FCDE2CBC50266B9F2 /* gl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = gl; path = gl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		536E72DCBEEC4A1FE66CFDCE /* target.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = target.yml; sourceTree = "<group>"; };
 		541542F5AC323709D8563458 /* AnalyticsPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsPrompt.swift; sourceTree = "<group>"; };
+		542D4F49FABA056DEEEB3400 /* RustTracing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustTracing.swift; sourceTree = "<group>"; };
 		5445FCE0CE15E634FDC1A2E2 /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
 		55BC11560C8A2598964FFA4C /* bs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		55D7187F6B0C0A651AC3DFFA /* in */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = in; path = in.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1054,6 +1059,7 @@
 			children = (
 				111B698739E3410E2CDB7144 /* MXLog.swift */,
 				A34A814CBD56230BC74FFCF4 /* MXLogger.swift */,
+				542D4F49FABA056DEEEB3400 /* RustTracing.swift */,
 			);
 			path = Logging;
 			sourceTree = "<group>";
@@ -1577,6 +1583,7 @@
 				3D487C1185D658F8B15B8F55 /* SettingsViewModelTests.swift */,
 				32C5DAA1773F57653BF1C4F9 /* SoftLogoutViewModelTests.swift */,
 				2CEBCB9676FCD1D0F13188DD /* StringTests.swift */,
+				1734A445A58ED855B977A0A8 /* TracingConfigurationTests.swift */,
 				EB3B237387B8288A5A938F1B /* UserAgentBuilderTests.swift */,
 				0DE6C5C756E1393202BA95CD /* UserNotificationControllerTests.swift */,
 				A3004DFA1B10951962787D90 /* VideoPlayerViewModelTests.swift */,
@@ -2652,6 +2659,7 @@
 				BFB534E338A3D949944FB2F5 /* NotificationServiceProxy.swift in Sources */,
 				7E3B1F8D72573ED2FCB2D94B /* NotificationServiceProxyProtocol.swift in Sources */,
 				414F50CFCFEEE2611127DCFB /* RestorationToken.swift in Sources */,
+				7354D094A4C59B555F407FA1 /* RustTracing.swift in Sources */,
 				719E7AAD1F8E68F68F30FECD /* Task.swift in Sources */,
 				BA074E9812F96FFA3200ED1D /* TimelineItemProxy.swift in Sources */,
 				6126CC51654E159804999E6A /* UNMutableNotificationContent.swift in Sources */,
@@ -2693,6 +2701,7 @@
 				09AAF04B27732046C755D914 /* SoftLogoutViewModelTests.swift in Sources */,
 				1FEC0A4EC6E6DF693C16B32A /* StringTests.swift in Sources */,
 				7AE1FFB132F2B84EB8A2AEBC /* TemplateViewModelTests.swift in Sources */,
+				282A5F3375DDC774AE09B0C3 /* TracingConfigurationTests.swift in Sources */,
 				8D3E1FADD78E72504DE0E402 /* UserAgentBuilderTests.swift in Sources */,
 				8196A2E71ACC902DD69F24EE /* UserNotificationControllerTests.swift in Sources */,
 				1504CE9A609A348D90B69E47 /* VideoPlayerViewModelTests.swift in Sources */,
@@ -2880,6 +2889,7 @@
 				297CD0A27C87B0C50FF192EE /* RoomTimelineViewFactoryProtocol.swift in Sources */,
 				CF82143AA4A4F7BD11D22946 /* RoomTimelineViewProvider.swift in Sources */,
 				B2F8E01ABA1BA30265B4ECBE /* RoundedCornerShape.swift in Sources */,
+				50C90117FE25390BFBD40173 /* RustTracing.swift in Sources */,
 				CC736DA1AA8F8B9FD8785009 /* ScreenshotDetector.swift in Sources */,
 				0BFA67AFD757EE2BA569836A /* ScrollViewAdapter.swift in Sources */,
 				1281625B25371BE53D36CB3A /* SeparatorRoomTimelineItem.swift in Sources */,

--- a/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
+++ b/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
@@ -95,6 +95,13 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
       </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "RUST_BACKTRACE"
+            value = "full"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -84,13 +84,10 @@ class AppCoordinator: AppCoordinatorProtocol {
         loggerConfiguration.maxLogFilesCount = 10
         
         #if DEBUG
-        // This exposes the full Rust side tracing subscriber filter for more flexibility.
-        // We can filter by level, crate and even file. See more details here:
-        // https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/filter/struct.EnvFilter.html#examples
-        setupTracing(filter: "warn,hyper=warn,sled=warn,matrix_sdk_sled=warn")
+        setupTracing(configuration: .debug)
         loggerConfiguration.logLevel = .debug
         #else
-        setupTracing(filter: "info,hyper=warn,sled=warn,matrix_sdk_sled=warn")
+        setupTracing(configuration: .release)
         loggerConfiguration.logLevel = .info
         #endif
         

--- a/ElementX/Sources/Other/Logging/RustTracing.swift
+++ b/ElementX/Sources/Other/Logging/RustTracing.swift
@@ -1,0 +1,61 @@
+//
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import MatrixRustSDK
+
+// This exposes the full Rust side tracing subscriber filter for more flexibility.
+// We can filter by level, crate and even file. See more details here:
+// https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/filter/struct.EnvFilter.html#examples
+struct TracingConfiguration {
+    static var release = TracingConfiguration(common: .info)
+    static var debug = TracingConfiguration()
+    static var full = TracingConfiguration(common: .info,
+                                           crates: [
+                                               .hyper: .warn,
+                                               .sled: .warn,
+                                               .matrix_sdk_sled: .warn,
+                                               .matrix_sdk_http_client: .trace,
+                                               .matrix_sdk_ffi_uniffi_api: .warn,
+                                               .matrix_sdk_ffi: .warn,
+                                               .matrix_sdk_sliding_sync: .warn,
+                                               .matrix_sdk_base_sliding_sync: .warn
+                                           ])
+    
+    enum Target: String {
+        case hyper, sled, matrix_sdk_sled, matrix_sdk_ffi
+        case matrix_sdk_http_client = "matrix_sdk::http_client"
+        case matrix_sdk_ffi_uniffi_api = "matrix_sdk_ffi::uniffi_api"
+        case matrix_sdk_sliding_sync = "matrix_sdk::sliding_sync"
+        case matrix_sdk_base_sliding_sync = "matrix_sdk_base::sliding_sync"
+    }
+    
+    enum LogLevel: String { case warn, trace, info }
+    
+    var common = LogLevel.warn
+    var crates: [Target: LogLevel] = [
+        .hyper: .warn,
+        .sled: .warn,
+        .matrix_sdk_sled: .warn
+    ]
+    
+    var filter: String {
+        "\(common),\(crates.map { "\($0.key)=\($0.value)" }.joined(separator: ","))"
+    }
+}
+
+func setupTracing(configuration: TracingConfiguration) {
+    setupTracing(filter: configuration.filter)
+}

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -18,6 +18,10 @@ schemes:
       config: Release
     run:
       config: Debug
+      environmentVariables:
+        - variable: RUST_BACKTRACE
+          value: full
+          isEnabled: false
     test:
       config: Debug
       gatherCoverageData: true

--- a/NSE/Sources/Other/NSELogger.swift
+++ b/NSE/Sources/Other/NSELogger.swift
@@ -86,13 +86,10 @@ class NSELogger {
         configuration.subLogName = "nse"
 
         #if DEBUG
-        // This exposes the full Rust side tracing subscriber filter for more flexibility.
-        // We can filter by level, crate and even file. See more details here:
-        // https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/filter/struct.EnvFilter.html#examples
-        setupTracing(filter: "warn,hyper=warn,sled=warn,matrix_sdk_sled=warn")
+        setupTracing(configuration: .debug)
         configuration.logLevel = .debug
         #else
-        setupTracing(filter: "info,hyper=warn,sled=warn,matrix_sdk_sled=warn")
+        setupTracing(configuration: .release)
         configuration.logLevel = .info
         #endif
 

--- a/UnitTests/Sources/TracingConfigurationTests.swift
+++ b/UnitTests/Sources/TracingConfigurationTests.swift
@@ -1,0 +1,50 @@
+//
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+@testable import ElementX
+
+class TracingConfigurationTests: XCTestCase {
+    func testReleaseConfiguration() {
+        let filterComponents = TracingConfiguration.release.filter.components(separatedBy: ",")
+        XCTAssertTrue(filterComponents.contains("info"))
+        XCTAssertTrue(filterComponents.contains("hyper=warn"))
+        XCTAssertTrue(filterComponents.contains("sled=warn"))
+        XCTAssertTrue(filterComponents.contains("matrix_sdk_sled=warn"))
+    }
+    
+    func testDebugConfiguration() {
+        let filterComponents = TracingConfiguration.debug.filter.components(separatedBy: ",")
+        XCTAssertTrue(filterComponents.contains("warn"))
+        XCTAssertTrue(filterComponents.contains("hyper=warn"))
+        XCTAssertTrue(filterComponents.contains("sled=warn"))
+        XCTAssertTrue(filterComponents.contains("matrix_sdk_sled=warn"))
+    }
+    
+    func testFullConfiguration() {
+        let filterComponents = TracingConfiguration.full.filter.components(separatedBy: ",")
+        XCTAssertTrue(filterComponents.contains("info"))
+        XCTAssertTrue(filterComponents.contains("hyper=warn"))
+        XCTAssertTrue(filterComponents.contains("sled=warn"))
+        XCTAssertTrue(filterComponents.contains("matrix_sdk_sled=warn"))
+        XCTAssertTrue(filterComponents.contains("matrix_sdk_http_client=trace"))
+        XCTAssertTrue(filterComponents.contains("matrix_sdk_ffi_uniffi_api=warn"))
+        XCTAssertTrue(filterComponents.contains("matrix_sdk_ffi=warn"))
+        XCTAssertTrue(filterComponents.contains("matrix_sdk_sliding_sync=warn"))
+        XCTAssertTrue(filterComponents.contains("matrix_sdk_base_sliding_sync=warn"))
+    }
+}

--- a/changelog.d/pr-336.misc
+++ b/changelog.d/pr-336.misc
@@ -1,0 +1,1 @@
+Setup tracing with a typed configuration and add some presets. 


### PR DESCRIPTION
This change allows us to create tracing presents so that its easier to increase the logging as needed.

I've also added the `RUST_BACKTRACE` env var to the run scheme (but disabled by default) as that seems like it would be useful to easily toggle on and off.