### PR TITLE
Set visible ranges on the home screen sliding sync view

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		0AE0AB1952F186EB86719B4F /* HomeScreenRoomCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED044D00F2176681CC02CD54 /* HomeScreenRoomCell.swift */; };
 		0B1F80C2BF7D223159FBA82C /* ImageAnonymizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6045E825AE900A92D61FEFF0 /* ImageAnonymizerTests.swift */; };
 		0BEFE400B4802FE8C9DB39B3 /* FilePreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BDF0FF4F59AF6EA858B70B /* FilePreviewViewModel.swift */; };
+		0BFA67AFD757EE2BA569836A /* ScrollViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53482ECA4B6633961EC224F5 /* ScrollViewAdapter.swift */; };
 		0C38C3E771B472E27295339D /* SessionVerificationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BB9A17AC512A7EF4B106E5 /* SessionVerificationModels.swift */; };
 		0E8C480700870BB34A2A360F /* AppAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 4346F63D53A346271577FD9C /* AppAuth */; };
 		0EA6537A07E2DC882AEA5962 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 187853A7E643995EE49FAD43 /* Localizable.stringsdict */; };
@@ -196,6 +197,7 @@
 		6CA81428F0970785CDCC5E86 /* UserNotificationToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31A4E5941ACBA4BB9FEF94C /* UserNotificationToastView.swift */; };
 		6D046D653DA28ADF1E6E59A4 /* BackgroundTaskServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE73D571D4F9C36DD45255A /* BackgroundTaskServiceProtocol.swift */; };
 		6DF37000571B1BC6D134CC9E /* WeakDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 304FFD608DB6E612075AB1B4 /* WeakDictionary.swift */; };
+		6E6E0AAF6C44C0B117EBBE5A /* SlidingSyncViewProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F3B445BD6EF1C751806B22 /* SlidingSyncViewProxy.swift */; };
 		6EA61FCA55D950BDE326A1A7 /* ImageAnonymizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12A626D74BBE9F4A60763B45 /* ImageAnonymizer.swift */; };
 		6F2AB43A1EFAD8A97AF41A15 /* DeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = A7CA6F33C553805035C3B114 /* DeviceKit */; };
 		6FC10A00D268FCD48B631E37 /* ViewFrameReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF7BF82A950B91BC5469E91 /* ViewFrameReader.swift */; };
@@ -608,6 +610,7 @@
 		3FEE631F3A4AFDC6652DD9DA /* RoomTimelineViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineViewFactory.swift; sourceTree = "<group>"; };
 		40B21E611DADDEF00307E7AC /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		41C2348F84A80F682E3A68D0 /* MediaPlayerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerCoordinator.swift; sourceTree = "<group>"; };
+		41F3B445BD6EF1C751806B22 /* SlidingSyncViewProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlidingSyncViewProxy.swift; sourceTree = "<group>"; };
 		422724361B6555364C43281E /* RoomHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomHeaderView.swift; sourceTree = "<group>"; };
 		434522ED2BDED08759048077 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		447A6399BC5EDE7AF7713267 /* MediaPlayerScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerScreen.swift; sourceTree = "<group>"; };
@@ -648,6 +651,7 @@
 		5221DFDF809142A2D6AC82B9 /* RoomScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreen.swift; sourceTree = "<group>"; };
 		5282B7A2DCD076AD2CF27F46 /* VideoPlayerViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerViewModelProtocol.swift; sourceTree = "<group>"; };
 		529513218340CC8419273165 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		53482ECA4B6633961EC224F5 /* ScrollViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewAdapter.swift; sourceTree = "<group>"; };
 		534A5C8FCDE2CBC50266B9F2 /* gl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = gl; path = gl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		536E72DCBEEC4A1FE66CFDCE /* target.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = target.yml; sourceTree = "<group>"; };
 		541542F5AC323709D8563458 /* AnalyticsPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsPrompt.swift; sourceTree = "<group>"; };
@@ -683,7 +687,6 @@
 		66F2402D738694F98729A441 /* RoomTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineProvider.swift; sourceTree = "<group>"; };
 		68232D336E2B546AD95B78B5 /* XCUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElement.swift; sourceTree = "<group>"; };
 		6920A4869821BF72FFC58842 /* MockMediaProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaProvider.swift; sourceTree = "<group>"; };
-		695AD3FAEAFEE32A6C73E8CB /* element-x-ios copy */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "element-x-ios copy"; path = .; sourceTree = SOURCE_ROOT; };
 		6A1AAC8EB2992918D01874AC /* rue */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = rue; path = rue.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6A580295A56B55A856CC4084 /* InfoPlistReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPlistReader.swift; sourceTree = "<group>"; };
 		6A6C4BE591FE5C38CE9C7EF3 /* UserProperties+Element.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserProperties+Element.swift"; sourceTree = "<group>"; };
@@ -885,6 +888,7 @@
 		D1A9CCCF53495CF3D7B19FCE /* MockSessionVerificationControllerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionVerificationControllerProxy.swift; sourceTree = "<group>"; };
 		D263254AFE5B7993FFBBF324 /* NSE.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NSE.entitlements; sourceTree = "<group>"; };
 		D2D783758EAE6A88C93564EB /* VideoPlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerViewModel.swift; sourceTree = "<group>"; };
+		D31DC8105C6233E5FFD9B84C /* element-x-ios */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "element-x-ios"; path = .; sourceTree = SOURCE_ROOT; };
 		D33116993D54FADC0C721C1F /* Application.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
 		D3D455BC2423D911A62ACFB2 /* NSELogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSELogger.swift; sourceTree = "<group>"; };
 		D4DA544B2520BFA65D6DB4BB /* target.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = target.yml; sourceTree = "<group>"; };
@@ -1669,6 +1673,7 @@
 				18F2958E6D247AE2516BEEE8 /* ClientProxy.swift */,
 				6033779EB37259F27F938937 /* ClientProxyProtocol.swift */,
 				3F40F48279322E504153AB0D /* MockClientProxy.swift */,
+				41F3B445BD6EF1C751806B22 /* SlidingSyncViewProxy.swift */,
 			);
 			path = Client;
 			sourceTree = "<group>";
@@ -1758,7 +1763,7 @@
 		9413F680ECDFB2B0DDB0DEF2 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
-				695AD3FAEAFEE32A6C73E8CB /* element-x-ios copy */,
+				D31DC8105C6233E5FFD9B84C /* element-x-ios */,
 			);
 			name = Packages;
 			sourceTree = SOURCE_ROOT;
@@ -1985,6 +1990,7 @@
 				6A580295A56B55A856CC4084 /* InfoPlistReader.swift */,
 				6AD1A853D605C2146B0DC028 /* MatrixEntityRegex.swift */,
 				F754E66A8970963B15B2A41E /* PermalinkBuilder.swift */,
+				53482ECA4B6633961EC224F5 /* ScrollViewAdapter.swift */,
 				BB3073CCD77D906B330BC1D6 /* Tests.swift */,
 				1F2529D434C750ED78ADF1ED /* UserAgentBuilder.swift */,
 				44BBB96FAA2F0D53C507396B /* Extensions */,
@@ -2875,6 +2881,7 @@
 				CF82143AA4A4F7BD11D22946 /* RoomTimelineViewProvider.swift in Sources */,
 				B2F8E01ABA1BA30265B4ECBE /* RoundedCornerShape.swift in Sources */,
 				CC736DA1AA8F8B9FD8785009 /* ScreenshotDetector.swift in Sources */,
+				0BFA67AFD757EE2BA569836A /* ScrollViewAdapter.swift in Sources */,
 				1281625B25371BE53D36CB3A /* SeparatorRoomTimelineItem.swift in Sources */,
 				49F2E7DD8CAACE09CEECE3E6 /* SeparatorRoomTimelineView.swift in Sources */,
 				87756CA950ED55870A1AAE8F /* ServerSelectionCoordinator.swift in Sources */,
@@ -2896,6 +2903,7 @@
 				7FED310F6AB7A70CBFB7C8A3 /* SettingsScreen.swift in Sources */,
 				4A2E0DBB63919AC8309B6D40 /* SettingsViewModel.swift in Sources */,
 				438FB9BC535BC95948AA5F34 /* SettingsViewModelProtocol.swift in Sources */,
+				6E6E0AAF6C44C0B117EBBE5A /* SlidingSyncViewProxy.swift in Sources */,
 				2276870A19F34B3FFFDA690F /* SoftLogoutCoordinator.swift in Sources */,
 				214C6B416609E58CCBF6DCEE /* SoftLogoutModels.swift in Sources */,
 				B09514A0A3EB3C19A4FD0B71 /* SoftLogoutScreen.swift in Sources */,

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -111,7 +111,7 @@
     {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
         "revision" : "f29e2014f6230cf7d5138fc899da51c7f513d467",
         "version" : "1.10.0"
@@ -129,7 +129,7 @@
     {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect",
+      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
       "state" : {
         "revision" : "f2616860a41f9d9932da412a8978fec79c06fe24",
         "version" : "0.1.4"

--- a/ElementX/Sources/Other/ScrollViewAdapter.swift
+++ b/ElementX/Sources/Other/ScrollViewAdapter.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+class ScrollViewAdapter: NSObject, ObservableObject, UIScrollViewDelegate {
+    var scrollView: UIScrollView? {
+        didSet {
+            oldValue?.delegate = nil
+            scrollView?.delegate = self
+        }
+    }
+        
+    @Published var isScrolling = false
+        
+    private func update() {
+        guard let scrollView else { return }
+        let newValue = scrollView.isDragging || scrollView.isDecelerating
+        
+        guard isScrolling != newValue else { return }
+        
+        isScrolling = newValue
+    }
+    
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        update()
+    }
+    
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        update()
+    }
+    
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        update()
+    }
+        
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        update()
+    }
+}

--- a/ElementX/Sources/Other/ScrollViewAdapter.swift
+++ b/ElementX/Sources/Other/ScrollViewAdapter.swift
@@ -17,7 +17,7 @@
 import Combine
 import UIKit
 
-class ScrollViewAdapter: NSObject, ObservableObject, UIScrollViewDelegate {
+class ScrollViewAdapter: NSObject, UIScrollViewDelegate {
     var scrollView: UIScrollView? {
         didSet {
             oldValue?.delegate = nil

--- a/ElementX/Sources/Other/ScrollViewAdapter.swift
+++ b/ElementX/Sources/Other/ScrollViewAdapter.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import Combine
 import UIKit
 
 class ScrollViewAdapter: NSObject, ObservableObject, UIScrollViewDelegate {
@@ -24,15 +25,11 @@ class ScrollViewAdapter: NSObject, ObservableObject, UIScrollViewDelegate {
         }
     }
         
-    @Published var isScrolling = false
+    var isScrolling = PassthroughSubject<Bool, Never>()
         
     private func update() {
         guard let scrollView else { return }
-        let newValue = scrollView.isDragging || scrollView.isDecelerating
-        
-        guard isScrolling != newValue else { return }
-        
-        isScrolling = newValue
+        isScrolling.send(scrollView.isDragging || scrollView.isDecelerating)
     }
     
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
@@ -48,6 +45,10 @@ class ScrollViewAdapter: NSObject, ObservableObject, UIScrollViewDelegate {
     }
         
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        update()
+    }
+    
+    func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
         update()
     }
 }

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -36,6 +36,7 @@ enum HomeScreenViewAction {
     case userMenu(action: HomeScreenViewUserMenuAction)
     case verifySession
     case skipSessionVerification
+    case updatedVisibleItemIdentifiers(Set<String>)
 }
 
 enum HomeScreenRoomListMode {

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -115,6 +115,8 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             callback?(.verifySession)
         case .skipSessionVerification:
             state.showSessionVerificationBanner = false
+        case .updatedVisibleItemIdentifiers(let identifiers):
+            updateVisibleRange(visibleItemIdentifiers: identifiers)
         }
     }
     
@@ -188,5 +190,21 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
         
         state.rooms = rooms
         roomsForIdentifiers = newRoomsForIdentifiers
+    }
+    
+    private func updateVisibleRange(visibleItemIdentifiers items: Set<String>) {
+        let result = items.compactMap { itemIdentifier in
+            state.rooms.firstIndex { $0.id == itemIdentifier }
+        }.sorted()
+        
+        guard !result.isEmpty else {
+            return
+        }
+        
+        guard let lowerBound = result.first, let upperBound = result.last else {
+            return
+        }
+        
+        userSession.clientProxy.roomSummaryProvider?.updateVisibleRange(lowerBound...upperBound)
     }
 }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -19,7 +19,7 @@ import SwiftUI
 struct HomeScreen: View {
     @State private var showingLogoutConfirmation = false
     @State private var visibleItemIdentifiers = Set<String>()
-    @StateObject private var scrollViewAdapter = ScrollViewAdapter()
+    @State private var scrollViewAdapter = ScrollViewAdapter()
     
     @ObservedObject var context: HomeScreenViewModel.Context
     
@@ -76,14 +76,14 @@ struct HomeScreen: View {
                 userMenuButton
             }
         }
-        .onReceive(scrollViewAdapter.isScrolling, perform: { isScrolling in
+        .onReceive(scrollViewAdapter.isScrolling) { isScrolling in
             guard context.viewState.bindings.searchQuery.isEmpty,
                   !isScrolling else {
                 return
             }
             
             context.send(viewAction: .updatedVisibleItemIdentifiers(visibleItemIdentifiers))
-        })
+        }
     }
 
     @ViewBuilder

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -76,10 +76,14 @@ struct HomeScreen: View {
                 userMenuButton
             }
         }
-        .onChange(of: scrollViewAdapter.isScrolling) { isScrolling in
-            guard !isScrolling else { return }
+        .onReceive(scrollViewAdapter.isScrolling, perform: { isScrolling in
+            guard context.viewState.bindings.searchQuery.isEmpty,
+                  !isScrolling else {
+                return
+            }
+            
             context.send(viewAction: .updatedVisibleItemIdentifiers(visibleItemIdentifiers))
-        }
+        })
     }
 
     @ViewBuilder

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -18,9 +18,10 @@ import SwiftUI
 
 struct HomeScreen: View {
     @State private var showingLogoutConfirmation = false
-    @ObservedObject var context: HomeScreenViewModel.Context
+    @State private var visibleItemIdentifiers = Set<String>()
+    @StateObject private var scrollViewAdapter = ScrollViewAdapter()
     
-    // MARK: Views
+    @ObservedObject var context: HomeScreenViewModel.Context
     
     var body: some View {
         ScrollView {
@@ -40,17 +41,29 @@ struct HomeScreen: View {
             } else {
                 LazyVStack {
                     ForEach(context.viewState.visibleRooms) { room in
-                        if room.isPlaceholder {
-                            HomeScreenRoomCell(room: room, context: context)
-                                .redacted(reason: .placeholder)
-                        } else {
-                            HomeScreenRoomCell(room: room, context: context)
+                        Group {
+                            if room.isPlaceholder {
+                                HomeScreenRoomCell(room: room, context: context)
+                                    .redacted(reason: .placeholder)
+                            } else {
+                                HomeScreenRoomCell(room: room, context: context)
+                            }
+                        }
+                        .onAppear {
+                            visibleItemIdentifiers.insert(room.id)
+                        }
+                        .onDisappear {
+                            visibleItemIdentifiers.remove(room.id)
                         }
                     }
                 }
                 .padding(.horizontal)
                 .searchable(text: $context.searchQuery)
             }
+        }
+        .introspectScrollView { scrollView in
+            guard scrollView != scrollViewAdapter.scrollView else { return }
+            scrollViewAdapter.scrollView = scrollView
         }
         .disabled(context.viewState.roomListMode == .skeletons)
         .animation(.elementDefault, value: context.viewState.showSessionVerificationBanner)
@@ -62,6 +75,10 @@ struct HomeScreen: View {
             ToolbarItem(placement: .navigationBarLeading) {
                 userMenuButton
             }
+        }
+        .onChange(of: scrollViewAdapter.isScrolling) { isScrolling in
+            guard !isScrolling else { return }
+            context.send(viewAction: .updatedVisibleItemIdentifiers(visibleItemIdentifiers))
         }
     }
 

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -163,6 +163,11 @@ class ClientProxy: ClientProxyProtocol {
         slidingSync?.setObserver(observer: nil)
     }
     
+    func restartSync() {
+        slidingSyncObserverToken?.cancel()
+        slidingSyncObserverToken = slidingSync?.sync()
+    }
+    
     func roomForIdentifier(_ identifier: String) async -> RoomProxyProtocol? {
         let (slidingSyncRoom, room) = await Task.dispatch(on: clientQueue) {
             self.roomTupleForIdentifier(identifier)

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -89,7 +89,7 @@ class ClientProxy: ClientProxyProtocol {
                                                    RequiredState(key: "m.room.encryption", value: "")])
                     .name(name: "HomeScreenView")
                     .syncMode(mode: .selective)
-                    .addRange(from: 0, to: 50) // FIXME: Replace this with a dynamic solution
+                    .addRange(from: 0, to: 20)
                     .build()
 
                 let slidingSync = try slidingSyncBuilder
@@ -98,8 +98,9 @@ class ClientProxy: ClientProxyProtocol {
                     .coldCache(name: "ElementX")
                     .build()
                 
-                self.roomSummaryProvider = RoomSummaryProvider(slidingSyncController: slidingSync,
-                                                               slidingSyncView: slidingSyncView,
+                let slidingSyncViewProxy = SlidingSyncViewProxy(clientProxy: self, slidingSync: slidingSync, slidingSyncView: slidingSyncView)
+                
+                self.roomSummaryProvider = RoomSummaryProvider(slidingSyncViewProxy: slidingSyncViewProxy,
                                                                roomMessageFactory: RoomMessageFactory())
                 
                 self.slidingSync = slidingSync

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -58,7 +58,7 @@ enum PushFormat {
 //    }
 }
 
-protocol ClientProxyProtocol: MediaProxyProtocol {
+protocol ClientProxyProtocol: AnyObject, MediaProxyProtocol {
     var callbacks: PassthroughSubject<ClientProxyCallback, Never> { get }
     
     var userIdentifier: String { get }

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -77,6 +77,8 @@ protocol ClientProxyProtocol: AnyObject, MediaProxyProtocol {
     
     func stopSync()
     
+    func restartSync()
+    
     func roomForIdentifier(_ identifier: String) async -> RoomProxyProtocol?
     
     func loadUserDisplayName() async -> Result<String, ClientProxyError>

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -38,6 +38,8 @@ class MockClientProxy: ClientProxyProtocol {
     
     func stopSync() { }
     
+    func restartSync() { }
+    
     func roomForIdentifier(_ identifier: String) async -> RoomProxyProtocol? {
         nil
     }

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -18,7 +18,7 @@ import Combine
 import Foundation
 import MatrixRustSDK
 
-struct MockClientProxy: ClientProxyProtocol {
+class MockClientProxy: ClientProxyProtocol {
     let callbacks = PassthroughSubject<ClientProxyCallback, Never>()
     
     let userIdentifier: String
@@ -28,6 +28,11 @@ struct MockClientProxy: ClientProxyProtocol {
     let restorationToken: RestorationToken? = nil
     
     var roomSummaryProvider: RoomSummaryProviderProtocol? = MockRoomSummaryProvider()
+    
+    internal init(userIdentifier: String, roomSummaryProvider: RoomSummaryProviderProtocol? = MockRoomSummaryProvider()) {
+        self.userIdentifier = userIdentifier
+        self.roomSummaryProvider = roomSummaryProvider
+    }
     
     func startSync() { }
     

--- a/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
+++ b/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
@@ -108,7 +108,6 @@ class SlidingSyncViewProxy {
         
         slidingSyncView.setRange(start: UInt32(range.lowerBound), end: UInt32(range.upperBound))
         
-        clientProxy?.stopSync()
-        clientProxy?.startSync()
+        clientProxy?.restartSync()
     }
 }

--- a/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
+++ b/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
@@ -1,0 +1,114 @@
+//
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Combine
+import Foundation
+import MatrixRustSDK
+
+private class SlidingSyncViewObserver: SlidingSyncViewRoomListObserver, SlidingSyncViewStateObserver, SlidingSyncViewRoomsCountObserver {
+    /// Publishes room list diffs as they come in through sliding sync
+    let roomListDiffPublisher = PassthroughSubject<SlidingSyncViewRoomsListDiff, Never>()
+    
+    /// Publishes the current state of sliding sync, such as whether its catching up or live.
+    let stateUpdatePublisher = CurrentValueSubject<SlidingSyncState, Never>(.cold)
+    
+    /// Publishes the number of available rooms
+    let countUpdatePublisher = CurrentValueSubject<UInt, Never>(0)
+        
+    // MARK: - SlidingSyncViewRoomListObserver
+    
+    func didReceiveUpdate(diff: SlidingSyncViewRoomsListDiff) {
+        MXLog.verbose("Received room diff")
+        roomListDiffPublisher.send(diff)
+    }
+    
+    // MARK: - SlidingSyncViewStateObserver
+    
+    func didReceiveUpdate(newState: SlidingSyncState) {
+        MXLog.verbose("Updated state: \(newState)")
+        stateUpdatePublisher.send(newState)
+    }
+    
+    // MARK: - SlidingSyncViewRoomsCountObserver
+    
+    func didReceiveUpdate(count: UInt32) {
+        MXLog.verbose("Updated room count: \(count)")
+        countUpdatePublisher.send(UInt(count))
+    }
+}
+
+class SlidingSyncViewProxy {
+    private weak var clientProxy: ClientProxyProtocol?
+    private let slidingSync: SlidingSyncProtocol
+    private let slidingSyncView: SlidingSyncViewProtocol
+    
+    private var listUpdateObserverToken: StoppableSpawn?
+    private var stateUpdateObserverToken: StoppableSpawn?
+    private var countUpdateObserverToken: StoppableSpawn?
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    let diffPublisher = PassthroughSubject<SlidingSyncViewRoomsListDiff, Never>()
+    let statePublisher = PassthroughSubject<SlidingSyncState, Never>()
+    let countPublisher = PassthroughSubject<UInt, Never>()
+    
+    deinit {
+        listUpdateObserverToken?.cancel()
+        stateUpdateObserverToken?.cancel()
+        countUpdateObserverToken?.cancel()
+    }
+    
+    init(clientProxy: ClientProxyProtocol, slidingSync: SlidingSyncProtocol, slidingSyncView: SlidingSyncViewProtocol) {
+        self.clientProxy = clientProxy
+        self.slidingSync = slidingSync
+        self.slidingSyncView = slidingSyncView
+        
+        let slidingSyncViewObserver = SlidingSyncViewObserver()
+        
+        slidingSyncViewObserver.stateUpdatePublisher
+            .subscribe(statePublisher)
+            .store(in: &cancellables)
+        
+        slidingSyncViewObserver.countUpdatePublisher
+            .subscribe(countPublisher)
+            .store(in: &cancellables)
+        
+        slidingSyncViewObserver.roomListDiffPublisher
+            .subscribe(diffPublisher)
+            .store(in: &cancellables)
+        
+        listUpdateObserverToken = slidingSyncView.observeRoomList(observer: slidingSyncViewObserver)
+        stateUpdateObserverToken = slidingSyncView.observeState(observer: slidingSyncViewObserver)
+        countUpdateObserverToken = slidingSyncView.observeRoomsCount(observer: slidingSyncViewObserver)
+    }
+    
+    func currentRoomsList() -> [RoomListEntry] {
+        slidingSyncView.currentRoomsList()
+    }
+    
+    func roomForIdentifier(_ identifier: String) throws -> SlidingSyncRoomProtocol? {
+        try slidingSync.getRoom(roomId: identifier)
+    }
+    
+    func updateVisibleRange(_ range: ClosedRange<Int>) {
+        MXLog.info("Setting sliding sync view range to \(range)")
+        
+        slidingSyncView.setRange(start: UInt32(range.lowerBound), end: UInt32(range.upperBound))
+        
+        clientProxy?.stopSync()
+        clientProxy?.startSync()
+    }
+}

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
@@ -27,8 +27,6 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
     let statePublisher: CurrentValueSubject<RoomSummaryProviderState, Never>
     let countPublisher: CurrentValueSubject<UInt, Never>
     
-    func updateRoomsWithIdentifiers(_ identifiers: [String]) { }
-    
     convenience init() {
         self.init(state: .loading)
     }
@@ -45,6 +43,10 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
             countPublisher = .init(UInt(Self.rooms.count))
         }
     }
+    
+    func updateRoomsWithIdentifiers(_ identifiers: [String]) { }
+    
+    func updateVisibleRange(_ range: ClosedRange<Int>) { }
     
     // MARK: - Private
     

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -119,7 +119,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
                     return currentItems
                 }
                 
-                MXLog.verbose("Applied diff \(collectionDiff), new count: \(updatedItems.count)")
+                MXLog.verbose("Applied diff, new count: \(updatedItems.count)")
                 
                 return updatedItems
             }

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -18,47 +18,10 @@ import Combine
 import Foundation
 import MatrixRustSDK
 
-private class WeakRoomSummaryProviderWrapper: SlidingSyncViewRoomListObserver, SlidingSyncViewStateObserver, SlidingSyncViewRoomsCountObserver {
-    /// Publishes room list diffs as they come in through sliding sync
-    let roomListDiffPublisher = PassthroughSubject<SlidingSyncViewRoomsListDiff, Never>()
-    
-    /// Publishes the current state of sliding sync, such as whether its catching up or live.
-    let stateUpdatePublisher = CurrentValueSubject<SlidingSyncState, Never>(.cold)
-    
-    /// Publishes the number of available rooms
-    let countUpdatePublisher = CurrentValueSubject<UInt, Never>(0)
-        
-    // MARK: - SlidingSyncViewRoomListObserver
-    
-    func didReceiveUpdate(diff: SlidingSyncViewRoomsListDiff) {
-        MXLog.verbose("Received room diff")
-        roomListDiffPublisher.send(diff)
-    }
-    
-    // MARK: - SlidingSyncViewStateObserver
-    
-    func didReceiveUpdate(newState: SlidingSyncState) {
-        MXLog.verbose("Updated state: \(newState)")
-        stateUpdatePublisher.send(newState)
-    }
-    
-    // MARK: - SlidingSyncViewRoomsCountObserver
-    
-    func didReceiveUpdate(count: UInt32) {
-        MXLog.verbose("Updated room count: \(count)")
-        countUpdatePublisher.send(UInt(count))
-    }
-}
-
 class RoomSummaryProvider: RoomSummaryProviderProtocol {
-    private let slidingSyncController: SlidingSyncProtocol
-    private let slidingSyncView: SlidingSyncViewProtocol
+    private let slidingSyncViewProxy: SlidingSyncViewProxy
     private let roomMessageFactory: RoomMessageFactoryProtocol
     private let serialDispatchQueue: DispatchQueue
-    
-    private var listUpdateObserverToken: StoppableSpawn?
-    private var stateUpdateObserverToken: StoppableSpawn?
-    private var countUpdateObserverToken: StoppableSpawn?
     
     private var cancellables = Set<AnyCancellable>()
     
@@ -72,47 +35,34 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         }
     }
     
-    deinit {
-        listUpdateObserverToken?.cancel()
-        stateUpdateObserverToken?.cancel()
-        countUpdateObserverToken?.cancel()
-    }
-    
-    init(slidingSyncController: SlidingSyncProtocol, slidingSyncView: SlidingSyncViewProtocol, roomMessageFactory: RoomMessageFactoryProtocol) {
-        self.slidingSyncView = slidingSyncView
-        self.slidingSyncController = slidingSyncController
+    init(slidingSyncViewProxy: SlidingSyncViewProxy, roomMessageFactory: RoomMessageFactoryProtocol) {
+        self.slidingSyncViewProxy = slidingSyncViewProxy
         self.roomMessageFactory = roomMessageFactory
         serialDispatchQueue = DispatchQueue(label: "io.element.elementx.roomsummaryprovider")
         
-        let weakProvider = WeakRoomSummaryProviderWrapper()
-        
-        rooms = slidingSyncView.currentRoomsList().map { roomListEntry in
+        rooms = slidingSyncViewProxy.currentRoomsList().map { roomListEntry in
             buildSummaryForRoomListEntry(roomListEntry)
         }
         
         roomListPublisher.send(rooms) // didSet not called from initialisers
         
-        weakProvider.stateUpdatePublisher
+        slidingSyncViewProxy.statePublisher
             .map(RoomSummaryProviderState.init)
             .subscribe(statePublisher)
             .store(in: &cancellables)
         
-        weakProvider.countUpdatePublisher
+        slidingSyncViewProxy.countPublisher
             .subscribe(countPublisher)
             .store(in: &cancellables)
         
-        weakProvider.roomListDiffPublisher
+        slidingSyncViewProxy.diffPublisher
             .collect(.byTime(serialDispatchQueue, 0.25))
             .sink { self.updateRoomsWithDiffs($0) }
             .store(in: &cancellables)
-        
-        listUpdateObserverToken = slidingSyncView.observeRoomList(observer: weakProvider)
-        stateUpdateObserverToken = slidingSyncView.observeState(observer: weakProvider)
-        countUpdateObserverToken = slidingSyncView.observeRoomsCount(observer: weakProvider)
     }
     
     func updateRoomsWithIdentifiers(_ identifiers: [String]) {
-        #warning("This is a valid check but Rust doesn't set it correct for selective ranged syncs")
+        #warning("This is a valid check but Rust doesn't set it correctly for selective ranged syncs")
 //        guard statePublisher.value == .live else {
 //            return
 //        }
@@ -141,6 +91,10 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         }
 
         rooms = newSummaries
+    }
+    
+    func updateVisibleRange(_ range: ClosedRange<Int>) {
+        slidingSyncViewProxy.updateVisibleRange(range)
     }
     
     // MARK: - Private
@@ -178,7 +132,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
     }
     
     private func buildRoomSummaryForIdentifier(_ identifier: String) -> RoomSummary {
-        guard let room = try? slidingSyncController.getRoom(roomId: identifier) else {
+        guard let room = try? slidingSyncViewProxy.roomForIdentifier(identifier) else {
             MXLog.error("Failed finding room with id: \(identifier)")
             return buildEmptyRoomSummary(forIdentifier: identifier)
         }

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -100,10 +100,10 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
     // MARK: - Private
     
     fileprivate func updateRoomsWithDiffs(_ diffs: [SlidingSyncViewRoomsListDiff]) {
-        MXLog.verbose("Received diffs")
-
+        MXLog.info("Received diffs")
+        
         rooms = diffs
-            .reduce(rooms) { currentItems, diff in                
+            .reduce(rooms) { currentItems, diff in
                 guard let collectionDiff = buildDiff(from: diff, on: currentItems) else {
                     MXLog.error("Failed building CollectionDifference from \(diff)")
                     return currentItems
@@ -119,7 +119,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
                 return updatedItems
             }
         
-        MXLog.verbose("Finished applying diffs")
+        MXLog.info("Finished applying diffs")
     }
     
     private func buildEmptyRoomSummary(forIdentifier identifier: String = UUID().uuidString) -> RoomSummary {

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -103,12 +103,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         MXLog.verbose("Received diffs")
 
         rooms = diffs
-            .reduce(rooms) { currentItems, diff in
-                // Invalidations are a no-op for the moment
-                if diff.isInvalidation {
-                    return currentItems
-                }
-                
+            .reduce(rooms) { currentItems, diff in                
                 guard let collectionDiff = buildDiff(from: diff, on: currentItems) else {
                     MXLog.error("Failed building CollectionDifference from \(diff)")
                     return currentItems

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
@@ -60,4 +60,6 @@ protocol RoomSummaryProviderProtocol {
     /// without necessarily changing their position in the list
     /// - Parameter identifiers: the identifiers for the rooms that have changed
     func updateRoomsWithIdentifiers(_ identifiers: [String])
+    
+    func updateVisibleRange(_ range: ClosedRange<Int>)
 }

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
@@ -131,7 +131,7 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
     // MARK: - Private
     
     private func updateItemsWithDiffs(_ diffs: [TimelineDiff]) {
-        MXLog.verbose("Received timeline diffs")
+        MXLog.info("Received timeline diffs")
         
         itemProxies = diffs
             .reduce(itemProxies) { currentItems, diff in
@@ -150,7 +150,7 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
                 return updatedItems
             }
         
-        MXLog.verbose("Finished applying diffs")
+        MXLog.info("Finished applying diffs")
     }
      
     // swiftlint:disable:next cyclomatic_complexity function_body_length


### PR DESCRIPTION
This PR starts using the sliding sync view ranges and sets them to whatever the user is currently looking at.
It also cleans up how the RoomSummaryProvider uses the slidingSync, slidingSyncView and clientProxy