### PR TITLE
Stop making previews for light & dark colour schemes.

### DIFF
--- a/DesignKit/Sources/Buttons/ElementActionButtonStyle.swift
+++ b/DesignKit/Sources/Buttons/ElementActionButtonStyle.swift
@@ -67,7 +67,7 @@ public struct ElementActionButtonStyle: ButtonStyle {
 }
 
 public struct ElementActionButtonStyle_Previews: PreviewProvider {
-    public static var states: some View {
+    public static var previews: some View {
         VStack {
             Button("Enabled") { /* preview */ }
                 .buttonStyle(ElementActionButtonStyle())
@@ -86,12 +86,5 @@ public struct ElementActionButtonStyle_Previews: PreviewProvider {
                 .buttonStyle(ElementActionButtonStyle(color: .element.alert))
         }
         .padding()
-    }
-    
-    public static var previews: some View {
-        states
-            .preferredColorScheme(.light)
-        states
-            .preferredColorScheme(.dark)
     }
 }

--- a/DesignKit/Sources/Buttons/ElementCapsuleButtonStyle.swift
+++ b/DesignKit/Sources/Buttons/ElementCapsuleButtonStyle.swift
@@ -59,7 +59,7 @@ public struct ElementCapsuleButtonStyle: ButtonStyle {
 }
 
 struct ElementCapsuleButtonStyle_Previews: PreviewProvider {
-    public static var states: some View {
+    public static var previews: some View {
         VStack {
             Button("Enabled") { /* preview */ }
                 .buttonStyle(.elementCapsuleProminent)
@@ -76,12 +76,5 @@ struct ElementCapsuleButtonStyle_Previews: PreviewProvider {
                 .disabled(true)
         }
         .padding()
-    }
-    
-    public static var previews: some View {
-        states
-            .preferredColorScheme(.light)
-        states
-            .preferredColorScheme(.dark)
     }
 }

--- a/DesignKit/Sources/Buttons/ElementGhostButtonStyle.swift
+++ b/DesignKit/Sources/Buttons/ElementGhostButtonStyle.swift
@@ -66,17 +66,6 @@ public struct ElementGhostButtonStyle: ButtonStyle {
 
 public struct ElementGhostButtonStyle_Previews: PreviewProvider {
     public static var previews: some View {
-        Group {
-            states
-        }
-        .preferredColorScheme(.light)
-        Group {
-            states
-        }
-        .preferredColorScheme(.dark)
-    }
-    
-    public static var states: some View {
         VStack {
             Button("Enabled") { /* preview */ }
                 .buttonStyle(ElementGhostButtonStyle())

--- a/DesignKit/Sources/TextFields/BorderedInputFieldStyle.swift
+++ b/DesignKit/Sources/TextFields/BorderedInputFieldStyle.swift
@@ -97,7 +97,7 @@ public struct BorderedInputFieldStyle: TextFieldStyle {
 }
 
 public struct BorderedInputFieldStyle_Previews: PreviewProvider {
-    public static var states: some View {
+    public static var previews: some View {
         VStack {
             TextField("Placeholder", text: .constant(""))
                 .textFieldStyle(BorderedInputFieldStyle())
@@ -114,14 +114,5 @@ public struct BorderedInputFieldStyle_Previews: PreviewProvider {
                 .textFieldStyle(BorderedInputFieldStyle(isEditing: true, isError: true))
         }
         .padding()
-    }
-    
-    public static var previews: some View {
-        Group {
-            states
-                .preferredColorScheme(.light)
-            states
-                .preferredColorScheme(.dark)
-        }
     }
 }

--- a/DesignKit/Sources/TextFields/ElementTextFieldStyle.swift
+++ b/DesignKit/Sources/TextFields/ElementTextFieldStyle.swift
@@ -74,7 +74,7 @@ public struct ElementTextFieldStyle: TextFieldStyle {
 
 @available(iOS 15.0, *)
 struct ElementTextFieldStyle_Previews: PreviewProvider {
-    public static var states: some View {
+    public static var previews: some View {
         VStack(spacing: 12) {
             TextField("Placeholder", text: .constant(""))
                 .textFieldStyle(.elementInput(labelText: "Label", footerText: "Footer"))
@@ -87,14 +87,5 @@ struct ElementTextFieldStyle_Previews: PreviewProvider {
                 .disabled(true)
         }
         .padding()
-    }
-    
-    public static var previews: some View {
-        Group {
-            states
-                .preferredColorScheme(.light)
-            states
-                .preferredColorScheme(.dark)
-        }
     }
 }

--- a/ElementX/Sources/Other/UserNotifications/UserNotificationModalView.swift
+++ b/ElementX/Sources/Other/UserNotifications/UserNotificationModalView.swift
@@ -56,11 +56,6 @@ struct UserNotificationModalView: View {
 
 struct UserNotificationModalView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    private static var body: some View {
         VStack {
             UserNotificationModalView(notification: UserNotification(type: .modal,
                                                                      title: "Successfully logged in",

--- a/ElementX/Sources/Other/UserNotifications/UserNotificationToastView.swift
+++ b/ElementX/Sources/Other/UserNotifications/UserNotificationToastView.swift
@@ -48,11 +48,6 @@ struct UserNotificationToastView: View {
 
 struct UserNotificationToastView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    private static var body: some View {
         VStack {
             UserNotificationToastView(notification: UserNotification(title: "Successfully logged in",
                                                                      iconName: "checkmark"))

--- a/ElementX/Sources/Screens/BugReport/View/BugReportScreen.swift
+++ b/ElementX/Sources/Screens/BugReport/View/BugReportScreen.swift
@@ -140,12 +140,6 @@ struct BugReportScreen: View {
 
 struct BugReport_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-
-    @ViewBuilder
-    static var body: some View {
         let viewModel = BugReportViewModel(bugReportService: MockBugReportService(), screenshot: Asset.Images.appLogo.image, isModallyPresented: false)
         BugReportScreen(context: viewModel.context)
             .previewInterfaceOrientation(.portrait)

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -197,13 +197,9 @@ struct HomeScreen: View {
 
 struct HomeScreen_Previews: PreviewProvider {
     static var previews: some View {
-        body(.loading).preferredColorScheme(.light)
+        body(.loading)
             .tint(.element.accent)
-        body(.loading).preferredColorScheme(.dark)
-            .tint(.element.accent)
-        body(.loaded).preferredColorScheme(.light)
-            .tint(.element.accent)
-        body(.loaded).preferredColorScheme(.dark)
+        body(.loaded)
             .tint(.element.accent)
     }
     

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
@@ -104,10 +104,7 @@ struct HomeScreenRoomCell: View {
 
 struct HomeScreenRoomCell_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-            .tint(.element.accent)
-        body.preferredColorScheme(.dark)
-            .tint(.element.accent)
+        body.tint(.element.accent)
     }
     
     static var body: some View {

--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
@@ -131,12 +131,6 @@ private struct MessageComposerEditHeader: View {
 
 struct MessageComposer_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    @ViewBuilder
-    static var body: some View {
         VStack {
             MessageComposer(text: .constant(""),
                             focused: .constant(false),

--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
@@ -209,12 +209,6 @@ private class TextViewWithKeyDetection: UITextView {
 
 struct MessageComposerTextField_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    @ViewBuilder
-    static var body: some View {
         VStack {
             PreviewWrapper(text: "123")
             PreviewWrapper(text: "")

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
@@ -57,10 +57,8 @@ struct RoomHeaderView: View {
 
 struct RoomHeaderView_Previews: PreviewProvider {
     static var previews: some View {
-        bodyPlain.preferredColorScheme(.light)
-        bodyPlain.preferredColorScheme(.dark)
-        bodyEncrypted.preferredColorScheme(.light)
-        bodyEncrypted.preferredColorScheme(.dark)
+        bodyPlain
+        bodyEncrypted
     }
 
     @ViewBuilder

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -70,12 +70,6 @@ struct RoomScreen: View {
 
 struct RoomScreen_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    @ViewBuilder
-    static var body: some View {
         let viewModel = RoomScreenViewModel(timelineController: MockRoomTimelineController(),
                                             timelineViewFactory: RoomTimelineViewFactory(),
                                             mediaProvider: MockMediaProvider(),

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -156,12 +156,6 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
 
 struct TimelineItemBubbledStylerView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-
-    @ViewBuilder
-    static var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             ForEach(1..<MockRoomTimelineController().timelineItems.count, id: \.self) { index in
                 let item = MockRoomTimelineController().timelineItems[index]

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
@@ -73,12 +73,6 @@ struct TimelineItemPlainStylerView<Content: View>: View {
 
 struct TimelineItemPlainStylerView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-
-    @ViewBuilder
-    static var body: some View {
         VStack(alignment: .leading) {
             ForEach(1..<MockRoomTimelineController().timelineItems.count, id: \.self) { index in
                 let item = MockRoomTimelineController().timelineItems[index]

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/EmoteRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/EmoteRoomTimelineView.swift
@@ -37,15 +37,10 @@ struct EmoteRoomTimelineView: View {
 
 struct EmoteRoomTimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-        body.preferredColorScheme(.light)
-            .timelineStyle(.plain)
-        body.preferredColorScheme(.dark)
-            .timelineStyle(.plain)
+        body
+        body.timelineStyle(.plain)
     }
     
-    @ViewBuilder
     static var body: some View {
         VStack(alignment: .leading, spacing: 20.0) {
             EmoteRoomTimelineView(timelineItem: itemWith(text: "Short loin ground round tongue hamburger, fatback salami shoulder. Beef turkey sausage kielbasa strip steak. Alcatra capicola pig tail pancetta chislic.",

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/EncryptedRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/EncryptedRoomTimelineView.swift
@@ -56,15 +56,10 @@ struct EncryptedRoomTimelineView: View {
 
 struct EncryptedRoomTimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-        body.preferredColorScheme(.light)
-            .timelineStyle(.plain)
-        body.preferredColorScheme(.dark)
-            .timelineStyle(.plain)
+        body
+        body.timelineStyle(.plain)
     }
     
-    @ViewBuilder
     static var body: some View {
         VStack(alignment: .leading, spacing: 20.0) {
             EncryptedRoomTimelineView(timelineItem: itemWith(text: "Text",

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FileRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FileRoomTimelineView.swift
@@ -36,15 +36,10 @@ struct FileRoomTimelineView: View {
 
 struct FileRoomTimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-        body.preferredColorScheme(.light)
-            .timelineStyle(.plain)
-        body.preferredColorScheme(.dark)
-            .timelineStyle(.plain)
+        body
+        body.timelineStyle(.plain)
     }
-
-    @ViewBuilder
+    
     static var body: some View {
         VStack(spacing: 20.0) {
             FileRoomTimelineView(timelineItem: FileRoomTimelineItem(id: UUID().uuidString,

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
@@ -69,12 +69,8 @@ extension FormattedBodyText {
 
 struct FormattedBodyText_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-        body.preferredColorScheme(.light)
-            .timelineStyle(.plain)
-        body.preferredColorScheme(.dark)
-            .timelineStyle(.plain)
+        body
+        body.timelineStyle(.plain)
     }
     
     @ViewBuilder

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/ImageRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/ImageRoomTimelineView.swift
@@ -51,15 +51,10 @@ struct ImageRoomTimelineView: View {
 
 struct ImageRoomTimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-        body.preferredColorScheme(.light)
-            .timelineStyle(.plain)
-        body.preferredColorScheme(.dark)
-            .timelineStyle(.plain)
+        body
+        body.timelineStyle(.plain)
     }
-     
-    @ViewBuilder
+    
     static var body: some View {
         VStack(spacing: 20.0) {
             ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: UUID().uuidString,

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/NoticeRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/NoticeRoomTimelineView.swift
@@ -37,15 +37,10 @@ struct NoticeRoomTimelineView: View {
 
 struct NoticeRoomTimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-        body.preferredColorScheme(.light)
-            .timelineStyle(.plain)
-        body.preferredColorScheme(.dark)
-            .timelineStyle(.plain)
+        body
+        body.timelineStyle(.plain)
     }
     
-    @ViewBuilder
     static var body: some View {
         VStack(alignment: .leading, spacing: 20.0) {
             NoticeRoomTimelineView(timelineItem: itemWith(text: "Short loin ground round tongue hamburger, fatback salami shoulder. Beef turkey sausage kielbasa strip steak. Alcatra capicola pig tail pancetta chislic.",

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/PlaceholderAvatarImage.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/PlaceholderAvatarImage.swift
@@ -48,12 +48,6 @@ struct PlaceholderAvatarImage: View {
 
 struct PlaceholderAvatarImage_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    @ViewBuilder
-    static var body: some View {
         PlaceholderAvatarImage(text: "X", contentId: "@userid:matrix.org")
             .clipShape(Circle())
             .frame(width: 150, height: 100)

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/RedactedRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/RedactedRoomTimelineView.swift
@@ -33,12 +33,6 @@ struct RedactedRoomTimelineView: View {
 
 struct RedactedRoomTimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    @ViewBuilder
-    static var body: some View {
         VStack(alignment: .leading, spacing: 20.0) {
             RedactedRoomTimelineView(timelineItem: itemWith(text: ElementL10n.eventRedacted,
                                                             timestamp: "Later",

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/SeparatorRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/SeparatorRoomTimelineView.swift
@@ -32,12 +32,6 @@ struct SeparatorRoomTimelineView: View {
 
 struct SeparatorRoomTimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    @ViewBuilder
-    static var body: some View {
         let item = SeparatorRoomTimelineItem(id: UUID().uuidString, text: "This is a separator")
         SeparatorRoomTimelineView(timelineItem: item)
     }

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
@@ -34,15 +34,10 @@ struct TextRoomTimelineView: View {
 
 struct TextRoomTimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-        body.preferredColorScheme(.light)
-            .timelineStyle(.plain)
-        body.preferredColorScheme(.dark)
-            .timelineStyle(.plain)
+        body
+        body.timelineStyle(.plain)
     }
     
-    @ViewBuilder
     static var body: some View {
         VStack(alignment: .leading, spacing: 20.0) {
             TextRoomTimelineView(timelineItem: itemWith(text: "Short loin ground round tongue hamburger, fatback salami shoulder. Beef turkey sausage kielbasa strip steak. Alcatra capicola pig tail pancetta chislic.",

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/VideoRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/VideoRoomTimelineView.swift
@@ -61,15 +61,10 @@ struct VideoRoomTimelineView: View {
 
 struct VideoRoomTimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-        body.preferredColorScheme(.light)
-            .timelineStyle(.plain)
-        body.preferredColorScheme(.dark)
-            .timelineStyle(.plain)
+        body
+        body.timelineStyle(.plain)
     }
-     
-    @ViewBuilder
+    
     static var body: some View {
         VStack(spacing: 20.0) {
             VideoRoomTimelineView(timelineItem: VideoRoomTimelineItem(id: UUID().uuidString,

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemList.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemList.swift
@@ -199,12 +199,6 @@ private struct PinnedItem: Equatable {
 
 struct TimelineItemList_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    @ViewBuilder
-    static var body: some View {
         let viewModel = RoomScreenViewModel(timelineController: MockRoomTimelineController(),
                                             timelineViewFactory: RoomTimelineViewFactory(),
                                             mediaProvider: MockMediaProvider(),

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
@@ -49,12 +49,6 @@ struct TimelineView: View {
 
 struct TimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    @ViewBuilder
-    static var body: some View {
         let viewModel = RoomScreenViewModel(timelineController: MockRoomTimelineController(),
                                             timelineViewFactory: RoomTimelineViewFactory(),
                                             mediaProvider: MockMediaProvider(),

--- a/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
@@ -184,12 +184,6 @@ struct SessionVerificationScreen: View {
 
 struct SessionVerification_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    @ViewBuilder
-    static var body: some View {
         Group {
             sessionVerificationScreen(state: .initial)
             sessionVerificationScreen(state: .requestingVerification)

--- a/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
@@ -239,12 +239,6 @@ extension TimelineStyle: CustomStringConvertible {
 
 struct Settings_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-        body.preferredColorScheme(.dark)
-    }
-    
-    @ViewBuilder
-    static var body: some View {
         let userSession = MockUserSession(clientProxy: MockClientProxy(userIdentifier: "@userid:example.com"),
                                           mediaProvider: MockMediaProvider())
         let viewModel = SettingsViewModel(withUserSession: userSession)

--- a/changelog.d/pr-345.change
+++ b/changelog.d/pr-345.change
@@ -1,0 +1,1 @@
+Stop generating previews for light and dark colour schemes now that preview variants are a thing. 


### PR DESCRIPTION
Xcode 14 now has preview variants for this. Additionally removes some unnecessary `@ViewBuilder` uses.

@stefanceriu: I've enabled auto-merge on this one so if there are no comments after review GitHub should do it's thing.

| Previews using Colour Variants |
| - |
| <img width="462" alt="Screenshot 2022-11-25 at 5 21 25 pm" src="https://user-images.githubusercontent.com/6060466/204034180-ccf1e754-25f5-411a-9ead-0a48e782bd06.png"> |
