### PR TITLE
Use matrix-rust-sdk for local development.

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -41,7 +41,7 @@ packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
     exactVersion: 1.0.22-alpha
-    # path: ../matrix-rust-components-swift
+    # path: ../matrix-rust-sdk
   DesignKit:
     path: ./
   AnalyticsEvents:


### PR DESCRIPTION
The SDK will be setup as a Swift package when using the Swift xtask so this is a much easier way to do local dev (for anyone who doesn't want to use #362).