### PR TITLE
Fix build badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Element iOS Matrix room #element-ios:matrix.org](https://img.shields.io/matrix/element-ios:matrix.org.svg?label=%23element-ios:matrix.org&logo=matrix&server_fqdn=matrix.org)](https://matrix.to/#/#element-ios:matrix.org)
 ![GitHub](https://img.shields.io/github/license/vector-im/element-x-ios)
 
-![Build Status](https://img.shields.io/github/workflow/status/vector-im/element-x-ios/Tests?style=flat-square)
+![Build Status](https://img.shields.io/github/actions/workflow/status/vector-im/element-x-ios/unit_tests.yml?style=flat-square)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/vector-im/element-x-ios)
 
 [![codecov](https://codecov.io/gh/vector-im/element-x-ios/branch/develop/graph/badge.svg?token=AVIJB2MJU2)](https://codecov.io/gh/vector-im/element-x-ios)


### PR DESCRIPTION
This pull request updates the link used in the build badge readme to follow the new format required by shields.io. Note that the badge now only reflects the status of the unit_tests.yml workflow which presumably was not the case when referencing by title was still possible (the title probably matched ui and unit tests).

See https://github.com/badges/shields/issues/8671

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.

Signed-off-by: `networkException <git@nwex.de>` (private sign-off)