### PR TITLE
Tweaks timeline pagination sizes

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -21,7 +21,7 @@ typealias RoomScreenViewModelType = StateStoreViewModel<RoomScreenViewState, Roo
 
 class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol {
     private enum Constants {
-        static let backPaginationPageSize: UInt = 20
+        static let backPaginationPageSize: UInt = 50
     }
 
     private let timelineController: RoomTimelineControllerProtocol

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -86,7 +86,7 @@ class ClientProxy: ClientProxyProtocol {
                 let slidingSyncBuilder = try client.slidingSync().homeserver(url: ServiceLocator.shared.settings.slidingSyncProxyBaseURLString)
 
                 let visibleRoomsView = try SlidingSyncViewBuilder()
-                    .timelineLimit(limit: 10)
+                    .timelineLimit(limit: 30)
                     .requiredState(requiredState: [RequiredState(key: "m.room.avatar", value: ""),
                                                    RequiredState(key: "m.room.encryption", value: "")])
                     .name(name: "CurrentlyVisibleRooms")


### PR DESCRIPTION
We need at least one screen of content when opening a room. We used 30 on EI for big devices.
