### PR TITLE
Storage location change

### DIFF
--- a/ElementX/Sources/Other/Extensions/URL.swift
+++ b/ElementX/Sources/Other/Extensions/URL.swift
@@ -64,6 +64,7 @@ extension URL {
         var url = appGroupContainerDirectory
             .appendingPathComponent("Library", isDirectory: true)
             .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent(InfoPlistReader.target.baseBundleIdentifier, isDirectory: true)
 
         try? FileManager.default.createDirectoryIfNeeded(at: url)
         

--- a/ElementX/Sources/Services/Keychain/KeychainController.swift
+++ b/ElementX/Sources/Services/Keychain/KeychainController.swift
@@ -50,17 +50,6 @@ class KeychainController: KeychainControllerProtocol {
                 return nil
             }
 
-            // Handle the previous restoration token format as we don't want users to have to log in again
-            // It will automatically be updated to the new version after login
-            if let legacyRestorationToken = try? JSONDecoder().decode(LegacyRestorationToken.self, from: tokenData) {
-                return .init(session: .init(accessToken: legacyRestorationToken.session.accessToken,
-                                            refreshToken: nil,
-                                            userId: legacyRestorationToken.session.userId,
-                                            deviceId: legacyRestorationToken.session.deviceId,
-                                            homeserverUrl: legacyRestorationToken.homeURL,
-                                            isSoftLogout: legacyRestorationToken.isSoftLogout ?? false))
-            }
-
             return try JSONDecoder().decode(RestorationToken.self, from: tokenData)
         } catch {
             MXLog.error("Failed retrieving user restore token")

--- a/ElementX/Sources/Services/UserSession/RestorationToken.swift
+++ b/ElementX/Sources/Services/UserSession/RestorationToken.swift
@@ -46,31 +46,3 @@ extension MatrixRustSDK.Session: Codable {
         case accessToken, refreshToken, userId, deviceId, homeserverUrl, isSoftLogout
     }
 }
-
-#warning("Remove this in a couple of releases - sceriu 03.11.2022")
-struct LegacyRestorationToken: Decodable {
-    let isGuest: Bool?
-    let isSoftLogout: Bool?
-    let homeURL: String
-    let session: Session
-    
-    enum CodingKeys: String, CodingKey {
-        case isGuest = "is_guest"
-        case isSoftLogout = "is_soft_logout"
-        case homeURL = "homeurl"
-        case session
-    }
-    
-    struct Session: Decodable {
-        let accessToken: String
-        let userId: String
-        let deviceId: String
-    
-        // swiftlint:disable:next nesting
-        enum CodingKeys: String, CodingKey {
-            case accessToken = "access_token"
-            case userId = "user_id"
-            case deviceId = "device_id"
-        }
-    }
-}

--- a/changelog.d/389.bugfix
+++ b/changelog.d/389.bugfix
@@ -1,0 +1,1 @@
+Migrate and store session data in Application Support instead of Caches


### PR DESCRIPTION
- remove the old restoration token handling
- move session data to the shared container's `Library/Application Support` folder and handle migrations. Also excludes it from iCloud backups. Left a warning in place so we can remove the migration in a couple of releases