### PR TITLE
Replace completion handlers with async/await.

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -302,7 +302,7 @@ class AppCoordinator: AppCoordinatorProtocol {
                     .sink { [weak self] callback in
                         switch callback {
                         case .registeredNotifications(let deviceToken):
-                            self?.notificationManager?.register(with: deviceToken, completion: nil)
+                            Task { await self?.notificationManager?.register(with: deviceToken) }
                         case .failedToRegisteredNotifications(let error):
                             self?.notificationManager?.registrationFailed(with: error)
                         }
@@ -467,8 +467,8 @@ extension AppCoordinator: NotificationManagerDelegate {
             break
         default:
             // error or no room proxy
-            service.showLocalNotification(with: "⚠️ " + ElementL10n.dialogTitleError,
-                                          subtitle: ElementL10n.a11yErrorSomeMessageNotSent)
+            await service.showLocalNotification(with: "⚠️ " + ElementL10n.dialogTitleError,
+                                                subtitle: ElementL10n.a11yErrorSomeMessageNotSent)
         }
     }
 }

--- a/ElementX/Sources/Services/Notification/Manager/MockNotificationManager.swift
+++ b/ElementX/Sources/Services/Notification/Manager/MockNotificationManager.swift
@@ -29,7 +29,7 @@ class MockNotificationManager: NotificationManagerProtocol {
         delegate?.authorizationStatusUpdated(self, granted: false)
     }
 
-    func register(with deviceToken: Data, completion: ((Bool) -> Void)? = nil) { }
+    func register(with deviceToken: Data) async -> Bool { false }
 
     func registrationFailed(with error: Error) { }
 

--- a/ElementX/Sources/Services/Notification/Manager/NotificationManagerProtocol.swift
+++ b/ElementX/Sources/Services/Notification/Manager/NotificationManagerProtocol.swift
@@ -36,7 +36,7 @@ protocol NotificationManagerProtocol {
     var delegate: NotificationManagerDelegate? { get set }
 
     func start()
-    func register(with deviceToken: Data, completion: ((Bool) -> Void)?)
+    func register(with deviceToken: Data) async -> Bool
     func registrationFailed(with error: Error)
-    func showLocalNotification(with title: String, subtitle: String?)
+    func showLocalNotification(with title: String, subtitle: String?) async
 }

--- a/ElementX/Sources/Services/Notification/Manager/UserNotificationCenterProtocol.swift
+++ b/ElementX/Sources/Services/Notification/Manager/UserNotificationCenterProtocol.swift
@@ -19,7 +19,7 @@ import UserNotifications
 
 protocol UserNotificationCenterProtocol: AnyObject {
     var delegate: UNUserNotificationCenterDelegate? { get set }
-    func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: ((Error?) -> Void)?)
-    func requestAuthorization(options: UNAuthorizationOptions, completionHandler: @escaping (Bool, Error?) -> Void)
+    func add(_ request: UNNotificationRequest) async throws
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool
     func setNotificationCategories(_ categories: Set<UNNotificationCategory>)
 }

--- a/UnitTests/Sources/NotificationManager/UserNotificationCenterSpy.swift
+++ b/UnitTests/Sources/NotificationManager/UserNotificationCenterSpy.swift
@@ -21,16 +21,15 @@ class UserNotificationCenterSpy: UserNotificationCenterProtocol {
     weak var delegate: UNUserNotificationCenterDelegate?
     
     var addRequest: UNNotificationRequest?
-    func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: ((Error?) -> Void)?) {
+    func add(_ request: UNNotificationRequest) async throws {
         addRequest = request
-        completionHandler?(nil)
     }
     
     var requestAuthorizationOptions: UNAuthorizationOptions?
     var requestAuthorizationGrantedReturnValue = false
-    func requestAuthorization(options: UNAuthorizationOptions, completionHandler: @escaping (Bool, Error?) -> Void) {
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool {
         requestAuthorizationOptions = options
-        completionHandler(requestAuthorizationGrantedReturnValue, nil)
+        return requestAuthorizationGrantedReturnValue
     }
     
     var notificationCategoriesValue: Set<UNNotificationCategory>?

--- a/changelog.d/pr-407.change
+++ b/changelog.d/pr-407.change
@@ -1,0 +1,1 @@
+Notification Manager: Replace completion handlers with async/await.


### PR DESCRIPTION
Small follow up to #376 which keeps everything using async/await instead of completion handlers.
