### PR TITLE
Support for manually starting SaS verification flows

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		27E9263DA75E266690A37EB1 /* PermalinkBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB31A32C93D94930B253FBF /* PermalinkBuilderTests.swift */; };
 		282A5F3375DDC774AE09B0C3 /* TracingConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1734A445A58ED855B977A0A8 /* TracingConfigurationTests.swift */; };
 		28410F3DE89C2C44E4F75C92 /* MockBugReportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E7BF8F7BB1021F889C6483 /* MockBugReportService.swift */; };
+		28934460A497CD002249ED71 /* TimelineStartRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF73D6149F4755E9C530303 /* TimelineStartRoomTimelineItem.swift */; };
 		290FDB0FFDC2F1DDF660343E /* TestMeasurementParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4048041C1A6B20CB97FD18 /* TestMeasurementParser.swift */; };
 		297CD0A27C87B0C50FF192EE /* RoomTimelineViewFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE384418EB1FEDFA62C9CD0 /* RoomTimelineViewFactoryProtocol.swift */; };
 		29EE1791E0AFA1ABB7F23D2F /* SwiftyBeaver in Frameworks */ = {isa = PBXBuildFile; productRef = A981A4CA233FB5C13B9CA690 /* SwiftyBeaver */; };
@@ -124,6 +125,7 @@
 		388FD50AC66E9E684DDFA9D8 /* ServerSelectionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D2C0950F8196232D88045C /* ServerSelectionScreen.swift */; };
 		38C76D586404C1FDED095F3A /* LoginModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B01468022EC826CB2FD2C0 /* LoginModels.swift */; };
 		3910D3A2EF98587C0E7B9CCB /* EmojiMartEmoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F7F3CF7E70518BD7D25E04 /* EmojiMartEmoji.swift */; };
+		392D0519E5597A538BFB2CAB /* UnsupportedRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7EDBCE09CCF06B5BB522502 /* UnsupportedRoomTimelineItem.swift */; };
 		39929D29B265C3F6606047DE /* AlignedScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8872E9C5E91E9F2BFC4EBCCA /* AlignedScrollView.swift */; };
 		3A08584ECDD4A4541DBF21F8 /* EmojiLoaderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201305507D7DFD16E544563A /* EmojiLoaderProtocol.swift */; };
 		3A64A93A651A3CB8774ADE8E /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 21C83087604B154AA30E9A8F /* SnapshotTesting */; };
@@ -149,6 +151,7 @@
 		49E9B99CB6A275C7744351F0 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D58333B377888012740101 /* LoginViewModel.swift */; };
 		49F2E7DD8CAACE09CEECE3E6 /* SeparatorRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6390A6DC140CA3D6865A66FF /* SeparatorRoomTimelineView.swift */; };
 		4A2E0DBB63919AC8309B6D40 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A191D3FDB995309C7E2DE7D /* SettingsViewModel.swift */; };
+		4A67D2EAB564B34EE5C03E11 /* StickerRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C84013BB71998CDD90C634C /* StickerRoomTimelineItem.swift */; };
 		4BB282209EA82015D0DF8F89 /* NavigationStackCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C698E30698EC59302A8EEBD /* NavigationStackCoordinatorTests.swift */; };
 		4C3365818DE1CEAEDF590FD3 /* MediaProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C888BCD78E2A55DCE364F160 /* MediaProviderProtocol.swift */; };
 		4E8F17EBA24FBBA6ABB62ECB /* MockBackgroundTaskService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3948D16F021DFDB2CD26EAA8 /* MockBackgroundTaskService.swift */; };
@@ -213,6 +216,7 @@
 		6E6E0AAF6C44C0B117EBBE5A /* SlidingSyncViewProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F3B445BD6EF1C751806B22 /* SlidingSyncViewProxy.swift */; };
 		6F2AB43A1EFAD8A97AF41A15 /* DeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = A7CA6F33C553805035C3B114 /* DeviceKit */; };
 		6FC10A00D268FCD48B631E37 /* ViewFrameReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF7BF82A950B91BC5469E91 /* ViewFrameReader.swift */; };
+		6FF51EB400DBA0668FC38B97 /* TimelineStartRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9ED8E731E21055F728E5FED /* TimelineStartRoomTimelineView.swift */; };
 		7002C55A4C917F3715765127 /* MediaProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C888BCD78E2A55DCE364F160 /* MediaProviderProtocol.swift */; };
 		702694459B649B9D3A3C34F8 /* TimelineTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9212AE02CBDD692C56A879F /* TimelineTableViewController.swift */; };
 		70558528EF68CAAEF09972D5 /* RoomTimelineItemFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96ED747FF90332EA1333C22 /* RoomTimelineItemFixtures.swift */; };
@@ -229,6 +233,7 @@
 		755727E0B756430DFFEC4732 /* SessionVerificationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF05DA24F71B455E8EFEBC3B /* SessionVerificationViewModelTests.swift */; };
 		758BF44CA565AB0AB84F2185 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7109E709A7738E6BCC4553E6 /* Localizable.strings */; };
 		75EA4ABBFAA810AFF289D6F4 /* TemplateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB6E40BAD4504D899FAAC9A /* TemplateViewModel.swift */; };
+		764AFCC225B044CF5F9B41E5 /* PaginationIndicatorRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EEA67A6796BDC2761619C5 /* PaginationIndicatorRoomTimelineView.swift */; };
 		77119672143B2BF0C9838DDC /* RoomDetailsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC031D32CED2CBE122E5038 /* RoomDetailsModels.swift */; };
 		7732B2F635626BE1C1CD92A4 /* UIActivityViewControllerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A57A4AFA6A068668AFBD070 /* UIActivityViewControllerWrapper.swift */; };
 		7756C4E90CABE6F14F7920A0 /* BugReportUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6FEA87EA3752203065ECE27 /* BugReportUITests.swift */; };
@@ -395,6 +400,7 @@
 		CD6A72B65D3B6076F4045C30 /* PHGPostHogConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B891A6DA826E2461DBB40F /* PHGPostHogConfiguration.swift */; };
 		CE1694C7BB93C3311524EF28 /* Untranslated.strings in Resources */ = {isa = PBXBuildFile; fileRef = D2F7194F440375338F8E2487 /* Untranslated.strings */; };
 		CE7148E80F09B7305E026AC6 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1198B925F4A88DA74083662 /* OnboardingViewModel.swift */; };
+		CE79753EA0C433641F0449C0 /* PaginationIndicatorRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756288D339AFC15D2C3F4A0D /* PaginationIndicatorRoomTimelineItem.swift */; };
 		CE9530A4CA661E090635C2F2 /* NotificationItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F7FE40EF7490A7E09D7BE6 /* NotificationItemProxy.swift */; };
 		CEB8FB1269DE20536608B957 /* LoginMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B41FABA2B0AEF4389986495 /* LoginMode.swift */; };
 		CF6319CC05F964B4D05BF614 /* MockFileCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC96B3DC55090BBF8876CC2 /* MockFileCache.swift */; };
@@ -425,6 +431,7 @@
 		E01373F2043E76393A0CE073 /* AnalyticsPromptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11B74ACE8D71747E1044A9C /* AnalyticsPromptViewModel.swift */; };
 		E0A4DCA633D174EB43AD599F /* BackgroundTaskProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA028DCD4157F9A1F999827 /* BackgroundTaskProtocol.swift */; };
 		E1DF24D085572A55C9758A2D /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E89E530A8E92EC44301CA1 /* Bundle.swift */; };
+		E1F446C6B78A3A0FEA15079C /* UnsupportedRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC3C656E960E15B5905E05 /* UnsupportedRoomTimelineView.swift */; };
 		E290C78E7F09F47FD2662986 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40C19719687984FD9478FBE /* Task.swift */; };
 		E3291AD16D7A5CB14781819C /* UserNotificationCenterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D8149FDDA0315CDC553B4B /* UserNotificationCenterProtocol.swift */; };
 		E3CA565A4B9704F191B191F0 /* JoinedRoomSize+MemberCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF9AEA706926DD0DA2B954C /* JoinedRoomSize+MemberCount.swift */; };
@@ -452,6 +459,7 @@
 		F06CE9132855E81EBB6DDC32 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 800631D7250B7F93195035F1 /* KeychainAccess */; };
 		F0F82C3C848C865C3098AA52 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 67E7A6F388D3BF85767609D9 /* Sentry */; };
 		F257F964493A9CD02A6F720C /* OnboardingPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF2717AB91060260E5F4781 /* OnboardingPageView.swift */; };
+		F32B271F60531BE92C6E62A1 /* StickerRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612EF972F2A1800682D32C5E /* StickerRoomTimelineView.swift */; };
 		F425C3F85BFF28C9AC593F52 /* MockNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96561CC53F7C1E24D4C292E4 /* MockNotificationManager.swift */; };
 		F508683B76EF7B23BB2CBD6D /* TimelineItemPlainStylerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94BCC8A9C73C1F838122C645 /* TimelineItemPlainStylerView.swift */; };
 		F61AFA8BF2E739FBC30472F5 /* NotificationServiceProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD5FEE195446A9E458DDDAF /* NotificationServiceProxyProtocol.swift */; };
@@ -666,6 +674,7 @@
 		40B21E611DADDEF00307E7AC /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		41F3B445BD6EF1C751806B22 /* SlidingSyncViewProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlidingSyncViewProxy.swift; sourceTree = "<group>"; };
 		422724361B6555364C43281E /* RoomHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomHeaderView.swift; sourceTree = "<group>"; };
+		42EEA67A6796BDC2761619C5 /* PaginationIndicatorRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationIndicatorRoomTimelineView.swift; sourceTree = "<group>"; };
 		434522ED2BDED08759048077 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4488F5F92A64A137665C96CD /* pa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pa; path = pa.lproj/Localizable.strings; sourceTree = "<group>"; };
 		44AEEE13AC1BF303AE48CBF8 /* eu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -689,11 +698,13 @@
 		4B362E695A7103C11F64B185 /* AnalyticsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsSettings.swift; sourceTree = "<group>"; };
 		4B40B7F6FCCE2D8C242492D9 /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4B41FABA2B0AEF4389986495 /* LoginMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginMode.swift; sourceTree = "<group>"; };
+		4C84013BB71998CDD90C634C /* StickerRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerRoomTimelineItem.swift; sourceTree = "<group>"; };
 		4C8D988E82A8DFA13BE46F7C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = pl; path = pl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		4CD6AC7546E8D7E5C73CEA48 /* ElementX.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = ElementX.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CDDDDD9FE1A699D23A5E096 /* LoginScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScreen.swift; sourceTree = "<group>"; };
 		4D6E4C37E9F0E53D3DF951AC /* HomeScreenUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenUITests.swift; sourceTree = "<group>"; };
 		4DF56C3239EA3C16951E1E66 /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4DF73D6149F4755E9C530303 /* TimelineStartRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStartRoomTimelineItem.swift; sourceTree = "<group>"; };
 		4E2245243369B99216C7D84E /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		4F0CB536D1C3CC15AA740CC6 /* AuthenticationServiceProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceProxyProtocol.swift; sourceTree = "<group>"; };
 		4F49CDE349C490D617332770 /* NoticeRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeRoomTimelineItem.swift; sourceTree = "<group>"; };
@@ -726,6 +737,7 @@
 		5FF214969B25BFCBF87B908B /* bn-BD */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "bn-BD"; path = "bn-BD.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		6033779EB37259F27F938937 /* ClientProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientProxyProtocol.swift; sourceTree = "<group>"; };
 		607974D08BD2AF83725D817A /* RoomMessageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMessageProtocol.swift; sourceTree = "<group>"; };
+		612EF972F2A1800682D32C5E /* StickerRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerRoomTimelineView.swift; sourceTree = "<group>"; };
 		616197D81103330BF2ADD559 /* gl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gl; path = gl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		624244C398804ADC885239AA /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		62A81CCC2516D9CF9322DF01 /* MediaProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProviderTests.swift; sourceTree = "<group>"; };
@@ -762,6 +774,7 @@
 		72F910035944E5F38F4F801E /* RoomMembersScreenUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMembersScreenUITests.swift; sourceTree = "<group>"; };
 		73FC861755C6388F62B9280A /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		748AE77AC3B0A01223033B87 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		756288D339AFC15D2C3F4A0D /* PaginationIndicatorRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationIndicatorRoomTimelineItem.swift; sourceTree = "<group>"; };
 		799A3A11C434296ED28F87C8 /* iw */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = iw; path = iw.lproj/Localizable.strings; sourceTree = "<group>"; };
 		7AB7ED3A898B07976F3AA90F /* BugReportViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportViewModelTests.swift; sourceTree = "<group>"; };
 		7B04BD3874D736127A8156B8 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -844,6 +857,7 @@
 		A11B74ACE8D71747E1044A9C /* AnalyticsPromptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsPromptViewModel.swift; sourceTree = "<group>"; };
 		A1C22B1B5FA3A765EADB2CC9 /* SessionVerificationStateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationStateMachineTests.swift; sourceTree = "<group>"; };
 		A1ED7E89865201EE7D53E6DA /* SeparatorRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorRoomTimelineItem.swift; sourceTree = "<group>"; };
+		A2AC3C656E960E15B5905E05 /* UnsupportedRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedRoomTimelineView.swift; sourceTree = "<group>"; };
 		A2B6433F516F1E6DFA0E2D89 /* vls */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vls; path = vls.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A3004DFA1B10951962787D90 /* VideoPlayerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerViewModelTests.swift; sourceTree = "<group>"; };
 		A30A1758E2B73EF38E7C42F8 /* ServerSelectionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionModels.swift; sourceTree = "<group>"; };
@@ -928,6 +942,7 @@
 		C6FEA87EA3752203065ECE27 /* BugReportUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportUITests.swift; sourceTree = "<group>"; };
 		C75EF87651B00A176AB08E97 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C789E7BFC066CF39B8AE0974 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		C7EDBCE09CCF06B5BB522502 /* UnsupportedRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedRoomTimelineItem.swift; sourceTree = "<group>"; };
 		C830A64609CBD152F06E0457 /* NotificationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationConstants.swift; sourceTree = "<group>"; };
 		C88508B6F7974CFABEC4B261 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C888BCD78E2A55DCE364F160 /* MediaProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProviderProtocol.swift; sourceTree = "<group>"; };
@@ -1044,6 +1059,7 @@
 		F899D02CF26EA7675EEBE74C /* UserSessionScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionScreenTests.swift; sourceTree = "<group>"; };
 		F9212AE02CBDD692C56A879F /* TimelineTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineTableViewController.swift; sourceTree = "<group>"; };
 		F9E785D5137510481733A3E8 /* TextRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRoomTimelineView.swift; sourceTree = "<group>"; };
+		F9ED8E731E21055F728E5FED /* TimelineStartRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStartRoomTimelineView.swift; sourceTree = "<group>"; };
 		FA154570F693D93513E584C1 /* RoomMessageFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMessageFactory.swift; sourceTree = "<group>"; };
 		FAB10E673916D2B8D21FD197 /* TemplateModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateModels.swift; sourceTree = "<group>"; };
 		FBC776F301D374A3298C69DA /* AppCoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorProtocol.swift; sourceTree = "<group>"; };
@@ -1752,11 +1768,15 @@
 				C00A7110B937C6AE2EF5D7D6 /* FileRoomTimelineItem.swift */,
 				1A63815AD6A5C306453342F2 /* ImageRoomTimelineItem.swift */,
 				4F49CDE349C490D617332770 /* NoticeRoomTimelineItem.swift */,
+				756288D339AFC15D2C3F4A0D /* PaginationIndicatorRoomTimelineItem.swift */,
 				02351B2D9CD9B2B914352908 /* ReadMarkerRoomTimelineItem.swift */,
 				9B577F829C693B8DFB7014FD /* RedactedRoomTimelineItem.swift */,
 				289FA233E896FBC5956C67E0 /* RoomTimelineItemProperties.swift */,
 				A1ED7E89865201EE7D53E6DA /* SeparatorRoomTimelineItem.swift */,
+				4C84013BB71998CDD90C634C /* StickerRoomTimelineItem.swift */,
 				F6A8C632CEF4600107792899 /* TextRoomTimelineItem.swift */,
+				4DF73D6149F4755E9C530303 /* TimelineStartRoomTimelineItem.swift */,
+				C7EDBCE09CCF06B5BB522502 /* UnsupportedRoomTimelineItem.swift */,
 				A4B5B19A10D3F7C2BC5315DF /* VideoRoomTimelineItem.swift */,
 			);
 			path = Items;
@@ -2164,11 +2184,15 @@
 				F73FF1A33198F5FAE9D34B1F /* FormattedBodyText.swift */,
 				D0A45283CF1DB96E583BECA6 /* ImageRoomTimelineView.swift */,
 				B5B243E7818E5E9F6A4EDC7A /* NoticeRoomTimelineView.swift */,
+				42EEA67A6796BDC2761619C5 /* PaginationIndicatorRoomTimelineView.swift */,
 				0950733DD4BA83EEE752E259 /* PlaceholderAvatarImage.swift */,
 				B6311F21F911E23BE4DF51B4 /* ReadMarkerRoomTimelineView.swift */,
 				C8F2A7A4E3F5060F52ACFFB0 /* RedactedRoomTimelineView.swift */,
 				6390A6DC140CA3D6865A66FF /* SeparatorRoomTimelineView.swift */,
+				612EF972F2A1800682D32C5E /* StickerRoomTimelineView.swift */,
 				F9E785D5137510481733A3E8 /* TextRoomTimelineView.swift */,
+				F9ED8E731E21055F728E5FED /* TimelineStartRoomTimelineView.swift */,
+				A2AC3C656E960E15B5905E05 /* UnsupportedRoomTimelineView.swift */,
 				1941C8817E6B6971BA4415F5 /* VideoRoomTimelineView.swift */,
 			);
 			path = Timeline;
@@ -3085,6 +3109,8 @@
 				CE7148E80F09B7305E026AC6 /* OnboardingViewModel.swift in Sources */,
 				992477AB8E3F3C36D627D32E /* OnboardingViewModelProtocol.swift in Sources */,
 				CD6A72B65D3B6076F4045C30 /* PHGPostHogConfiguration.swift in Sources */,
+				CE79753EA0C433641F0449C0 /* PaginationIndicatorRoomTimelineItem.swift in Sources */,
+				764AFCC225B044CF5F9B41E5 /* PaginationIndicatorRoomTimelineView.swift in Sources */,
 				80D00A7C62AAB44F54725C43 /* PermalinkBuilder.swift in Sources */,
 				7D1DAAA364A9A29D554BD24E /* PlaceholderAvatarImage.swift in Sources */,
 				DF504B10A4918F971A57BEF2 /* PostHogAnalyticsClient.swift in Sources */,
@@ -3167,6 +3193,8 @@
 				165A883C29998EC779465068 /* SoftLogoutViewModelProtocol.swift in Sources */,
 				DF004A5B2EABBD0574D06A04 /* SplashScreenCoordinator.swift in Sources */,
 				B4AAB3257A83B73F53FB2689 /* StateStoreViewModel.swift in Sources */,
+				4A67D2EAB564B34EE5C03E11 /* StickerRoomTimelineItem.swift in Sources */,
+				F32B271F60531BE92C6E62A1 /* StickerRoomTimelineView.swift in Sources */,
 				2F94054F50E312AF30BE07F3 /* String.swift in Sources */,
 				A7D48E44D485B143AADDB77D /* Strings+Untranslated.swift in Sources */,
 				066A1E9B94723EE9F3038044 /* Strings.swift in Sources */,
@@ -3187,6 +3215,8 @@
 				440123E29E2F9B001A775BBE /* TimelineItemProxy.swift in Sources */,
 				9B582B3EEFEA615D4A6FBF1A /* TimelineReactionsView.swift in Sources */,
 				ABF3FAB234AD3565B214309B /* TimelineSenderAvatarView.swift in Sources */,
+				28934460A497CD002249ED71 /* TimelineStartRoomTimelineItem.swift in Sources */,
+				6FF51EB400DBA0668FC38B97 /* TimelineStartRoomTimelineView.swift in Sources */,
 				69BCBB4FB2DC3D61A28D3FD8 /* TimelineStyle.swift in Sources */,
 				FFD3E4FF948E06C7585317FC /* TimelineStyler.swift in Sources */,
 				702694459B649B9D3A3C34F8 /* TimelineTableViewController.swift in Sources */,
@@ -3202,6 +3232,8 @@
 				E96005321849DBD7C72A28F2 /* UITestsAppCoordinator.swift in Sources */,
 				086C2FA7750378EB2BFD0BEE /* UITestsRootCoordinator.swift in Sources */,
 				071A017E415AD378F2961B11 /* URL.swift in Sources */,
+				392D0519E5597A538BFB2CAB /* UnsupportedRoomTimelineItem.swift in Sources */,
+				E1F446C6B78A3A0FEA15079C /* UnsupportedRoomTimelineView.swift in Sources */,
 				7A71AEF419904209BB8C2833 /* UserAgentBuilder.swift in Sources */,
 				87BD4F95F9D603C309837378 /* UserNotification.swift in Sources */,
 				E3291AD16D7A5CB14781819C /* UserNotificationCenterProtocol.swift in Sources */,
@@ -3913,7 +3945,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "1.0.27-alpha";
+				version = "1.0.28-alpha";
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "91590089932586b623c03ef544daa9c56186bf07",
-        "version" : "1.0.27-alpha"
+        "revision" : "d8bd9bc10423fe68f54c89811950ca269af9da9e",
+        "version" : "1.0.28-alpha"
       }
     },
     {

--- a/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
@@ -9,6 +9,7 @@
 
 "settings_appearance" = "Appearance";
 "settings_timeline_style" = "Timeline Style";
+
 "room_timeline_style_plain_long_description" = "Plain Timeline";
 "room_timeline_style_bubbled_long_description" = "Bubbled Timeline";
 
@@ -20,6 +21,8 @@
 "room_timeline_syncing" = "Syncing";
 
 "room_timeline_context_menu_retry_decryption" = "Retry decryption";
+
+"room_timeline_item_unsupported" = "Unsupported event";
 
 "session_verification_banner_title" = "Help keep your messages secure";
 "session_verification_banner_message" = "Looks like you’re using a new device. Verify its you.";

--- a/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
@@ -23,8 +23,6 @@
 
 "session_verification_banner_title" = "Help keep your messages secure";
 "session_verification_banner_message" = "Looks like you’re using a new device. Verify its you.";
-"session_verification_screen_emojis_title" = "Lets check if these";
-"session_verification_screen_emojis_message" = "Open Element on one of your other sessions to compare.";
 
 "server_selection_server_footer" = "You can only connect to a server that has already been set up";
 

--- a/ElementX/Sources/Generated/Strings+Untranslated.swift
+++ b/ElementX/Sources/Generated/Strings+Untranslated.swift
@@ -58,10 +58,6 @@ extension ElementL10n {
   public static let sessionVerificationBannerMessage = ElementL10n.tr("Untranslated", "session_verification_banner_message")
   /// Help keep your messages secure
   public static let sessionVerificationBannerTitle = ElementL10n.tr("Untranslated", "session_verification_banner_title")
-  /// Open Element on one of your other sessions to compare.
-  public static let sessionVerificationScreenEmojisMessage = ElementL10n.tr("Untranslated", "session_verification_screen_emojis_message")
-  /// Lets check if these
-  public static let sessionVerificationScreenEmojisTitle = ElementL10n.tr("Untranslated", "session_verification_screen_emojis_title")
   /// Appearance
   public static let settingsAppearance = ElementL10n.tr("Untranslated", "settings_appearance")
   /// Timeline Style

--- a/ElementX/Sources/Generated/Strings+Untranslated.swift
+++ b/ElementX/Sources/Generated/Strings+Untranslated.swift
@@ -36,6 +36,8 @@ extension ElementL10n {
   public static let roomTimelineContextMenuRetryDecryption = ElementL10n.tr("Untranslated", "room_timeline_context_menu_retry_decryption")
   /// Editing
   public static let roomTimelineEditing = ElementL10n.tr("Untranslated", "room_timeline_editing")
+  /// Unsupported event
+  public static let roomTimelineItemUnsupported = ElementL10n.tr("Untranslated", "room_timeline_item_unsupported")
   /// Failed creating the permalink
   public static let roomTimelinePermalinkCreationFailure = ElementL10n.tr("Untranslated", "room_timeline_permalink_creation_failure")
   /// Replying to %@

--- a/ElementX/Sources/Screens/BugReport/View/BugReportScreen.swift
+++ b/ElementX/Sources/Screens/BugReport/View/BugReportScreen.swift
@@ -88,7 +88,8 @@ struct BugReportScreen: View {
                 Toggle(ElementL10n.sendBugReportIncludeLogs, isOn: $context.sendingLogsEnabled)
                     .toggleStyle(ElementToggleStyle())
                     .accessibilityIdentifier("sendLogsToggle")
-                Text(ElementL10n.sendBugReportIncludeLogs).accessibilityIdentifier("sendLogsText")
+                Text(ElementL10n.sendBugReportIncludeLogs)
+                    .accessibilityIdentifier("sendLogsText")
             }
             .onTapGesture {
                 context.send(viewAction: .toggleSendLogs)

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -21,6 +21,7 @@ typealias RoomScreenViewModelType = StateStoreViewModel<RoomScreenViewState, Roo
 
 class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol {
     private enum Constants {
+        static let backPaginationEventLimit: UInt = 20
         static let backPaginationPageSize: UInt = 50
         static let toastErrorID = "RoomScreenToastError"
     }
@@ -122,7 +123,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     // MARK: - Private
     
     private func paginateBackwards() async {
-        switch await timelineController.paginateBackwards(Constants.backPaginationPageSize) {
+        switch await timelineController.paginateBackwards(requestSize: Constants.backPaginationEventLimit, untilNumberOfItems: Constants.backPaginationPageSize) {
         case .failure:
             displayError(.toast(ElementL10n.roomTimelineBackpaginationFailure))
         default:

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -98,7 +98,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
 
     @ViewBuilder
     var styledContentOutgoing: some View {
-        let topPadding: CGFloat? = timelineItem.inGroupState == .single || timelineItem.inGroupState == .beginning ? 8 : 0
+        let topPadding: CGFloat? = timelineItem.groupState == .single || timelineItem.groupState == .beginning ? 8 : 0
         
         if shouldAvoidBubbling {
             content()

--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineDeliveryStatusView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineDeliveryStatusView.swift
@@ -16,7 +16,7 @@
 
 import SwiftUI
 struct TimelineDeliveryStatusView: View {
-    let deliveryStatus: MessageTimelineItemDeliveryStatus
+    let deliveryStatus: TimelineItemDeliveryStatus
     
     @State var showDeliveryStatus: Bool
     
@@ -29,7 +29,7 @@ struct TimelineDeliveryStatusView: View {
         }
     }
     
-    init(deliveryStatus: MessageTimelineItemDeliveryStatus) {
+    init(deliveryStatus: TimelineItemDeliveryStatus) {
         self.deliveryStatus = deliveryStatus
         
         switch deliveryStatus {

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/EmoteRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/EmoteRoomTimelineView.swift
@@ -31,7 +31,6 @@ struct EmoteRoomTimelineView: View {
                 }
             }
         }
-        .id(timelineItem.id)
     }
 }
 
@@ -57,7 +56,7 @@ struct EmoteRoomTimelineView_Previews: PreviewProvider {
         EmoteRoomTimelineItem(id: UUID().uuidString,
                               text: text,
                               timestamp: timestamp,
-                              inGroupState: .single,
+                              groupState: .single,
                               isOutgoing: false,
                               isEditable: false,
                               senderId: senderId)

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/EncryptedRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/EncryptedRoomTimelineView.swift
@@ -26,20 +26,19 @@ struct EncryptedRoomTimelineView: View {
             Button {
                 showEncryptionInfo = !showEncryptionInfo
             } label: {
-                HStack(alignment: .top) {
-                    Image(systemName: "lock.shield")
-                        .foregroundColor(.red)
-                        .padding(.top, 1.0)
+                Label {
                     if showEncryptionInfo {
                         FormattedBodyText(text: encryptionDetails)
                     } else {
                         FormattedBodyText(text: timelineItem.text)
                     }
+                } icon: {
+                    Image(systemName: "lock.shield")
+                        .foregroundColor(.red)
                 }
                 .animation(nil, value: showEncryptionInfo)
             }
         }
-        .id(timelineItem.id)
     }
     
     private var encryptionDetails: String {
@@ -79,7 +78,7 @@ struct EncryptedRoomTimelineView_Previews: PreviewProvider {
                                   text: text,
                                   encryptionType: .unknown,
                                   timestamp: timestamp,
-                                  inGroupState: .single,
+                                  groupState: .single,
                                   isOutgoing: isOutgoing,
                                   isEditable: false,
                                   senderId: senderId)

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FileRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FileRoomTimelineView.swift
@@ -30,7 +30,6 @@ struct FileRoomTimelineView: View {
             .padding(.vertical, 12)
             .padding(.horizontal, 6)
         }
-        .id(timelineItem.id)
     }
 }
 
@@ -45,7 +44,7 @@ struct FileRoomTimelineView_Previews: PreviewProvider {
             FileRoomTimelineView(timelineItem: FileRoomTimelineItem(id: UUID().uuidString,
                                                                     text: "document.pdf",
                                                                     timestamp: "Now",
-                                                                    inGroupState: .single,
+                                                                    groupState: .single,
                                                                     isOutgoing: false,
                                                                     isEditable: false,
                                                                     senderId: "Bob",
@@ -55,7 +54,7 @@ struct FileRoomTimelineView_Previews: PreviewProvider {
             FileRoomTimelineView(timelineItem: FileRoomTimelineItem(id: UUID().uuidString,
                                                                     text: "document.docx",
                                                                     timestamp: "Now",
-                                                                    inGroupState: .single,
+                                                                    groupState: .single,
                                                                     isOutgoing: false,
                                                                     isEditable: false,
                                                                     senderId: "Bob",
@@ -65,7 +64,7 @@ struct FileRoomTimelineView_Previews: PreviewProvider {
             FileRoomTimelineView(timelineItem: FileRoomTimelineItem(id: UUID().uuidString,
                                                                     text: "document.txt",
                                                                     timestamp: "Now",
-                                                                    inGroupState: .single,
+                                                                    groupState: .single,
                                                                     isOutgoing: false,
                                                                     isEditable: false,
                                                                     senderId: "Bob",

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/ImageRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/ImageRoomTimelineView.swift
@@ -44,7 +44,6 @@ struct ImageRoomTimelineView: View {
                 .aspectRatio(timelineItem.aspectRatio, contentMode: .fit)
             }
         }
-        .id(timelineItem.id)
         .animation(.elementDefault, value: timelineItem.image)
     }
 }
@@ -60,7 +59,7 @@ struct ImageRoomTimelineView_Previews: PreviewProvider {
             ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: UUID().uuidString,
                                                                       text: "Some image",
                                                                       timestamp: "Now",
-                                                                      inGroupState: .single,
+                                                                      groupState: .single,
                                                                       isOutgoing: false,
                                                                       isEditable: false,
                                                                       senderId: "Bob",
@@ -70,7 +69,7 @@ struct ImageRoomTimelineView_Previews: PreviewProvider {
             ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: UUID().uuidString,
                                                                       text: "Some other image",
                                                                       timestamp: "Now",
-                                                                      inGroupState: .single,
+                                                                      groupState: .single,
                                                                       isOutgoing: false,
                                                                       isEditable: false,
                                                                       senderId: "Bob",
@@ -80,7 +79,7 @@ struct ImageRoomTimelineView_Previews: PreviewProvider {
             ImageRoomTimelineView(timelineItem: ImageRoomTimelineItem(id: UUID().uuidString,
                                                                       text: "Blurhashed image",
                                                                       timestamp: "Now",
-                                                                      inGroupState: .single,
+                                                                      groupState: .single,
                                                                       isOutgoing: false,
                                                                       isEditable: false,
                                                                       senderId: "Bob",

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/NoticeRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/NoticeRoomTimelineView.swift
@@ -31,7 +31,6 @@ struct NoticeRoomTimelineView: View {
                 }
             }
         }
-        .id(timelineItem.id)
     }
 }
 
@@ -57,7 +56,7 @@ struct NoticeRoomTimelineView_Previews: PreviewProvider {
         NoticeRoomTimelineItem(id: UUID().uuidString,
                                text: text,
                                timestamp: timestamp,
-                               inGroupState: .single,
+                               groupState: .single,
                                isOutgoing: false,
                                isEditable: false,
                                senderId: senderId)

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/PaginationIndicatorRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/PaginationIndicatorRoomTimelineView.swift
@@ -14,21 +14,20 @@
 // limitations under the License.
 //
 
-import Foundation
-import UIKit
+import SwiftUI
 
-struct EmoteRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hashable {
-    let id: String
-    let text: String
-    var attributedComponents: [AttributedStringBuilderComponent]?
-    let timestamp: String
-    let groupState: TimelineItemGroupState
-    let isOutgoing: Bool
-    let isEditable: Bool
+struct PaginationIndicatorRoomTimelineView: View {
+    let timelineItem: PaginationIndicatorRoomTimelineItem
     
-    let senderId: String
-    var senderDisplayName: String?
-    var senderAvatar: UIImage?
-    
-    var properties = RoomTimelineItemProperties()
+    var body: some View {
+        ProgressView()
+            .frame(maxWidth: .infinity)
+    }
+}
+
+struct PaginationIndicatorRoomTimelineView_Previews: PreviewProvider {
+    static var previews: some View {
+        let item = PaginationIndicatorRoomTimelineItem()
+        PaginationIndicatorRoomTimelineView(timelineItem: item)
+    }
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/ReadMarkerRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/ReadMarkerRoomTimelineView.swift
@@ -24,7 +24,6 @@ struct ReadMarkerRoomTimelineView: View {
         VStack {
             Spacer(minLength: 4.0)
             Divider()
-                .id(timelineItem.id)
                 .frame(maxWidth: .infinity)
                 .overlay(Color.element.accent)
         }
@@ -33,7 +32,7 @@ struct ReadMarkerRoomTimelineView: View {
 
 struct ReadMarkerRoomTimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        let item = ReadMarkerRoomTimelineItem(id: UUID().uuidString)
+        let item = ReadMarkerRoomTimelineItem()
         ReadMarkerRoomTimelineView(timelineItem: item)
     }
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/RedactedRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/RedactedRoomTimelineView.swift
@@ -27,7 +27,6 @@ struct RedactedRoomTimelineView: View {
                 FormattedBodyText(text: timelineItem.text)
             }
         }
-        .id(timelineItem.id)
     }
 }
 
@@ -44,7 +43,7 @@ struct RedactedRoomTimelineView_Previews: PreviewProvider {
         RedactedRoomTimelineItem(id: UUID().uuidString,
                                  text: text,
                                  timestamp: timestamp,
-                                 inGroupState: .single,
+                                 groupState: .single,
                                  isOutgoing: false,
                                  isEditable: false,
                                  senderId: senderId)

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/StickerRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/StickerRoomTimelineView.swift
@@ -1,0 +1,93 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import SwiftUI
+
+struct StickerRoomTimelineView: View {
+    let timelineItem: StickerRoomTimelineItem
+    
+    var body: some View {
+        TimelineStyler(timelineItem: timelineItem) {
+            if let image = timelineItem.image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(timelineItem.aspectRatio, contentMode: .fit)
+            } else if let blurhash = timelineItem.blurhash,
+                      // Build a small blurhash image so that it's fast
+                      let image = UIImage(blurHash: blurhash, size: .init(width: 10.0, height: 10.0)) {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(timelineItem.aspectRatio, contentMode: .fit)
+            } else {
+                ZStack {
+                    Rectangle()
+                        .foregroundColor(.element.systemGray6)
+                        .opacity(0.3)
+                    
+                    ProgressView(ElementL10n.loading)
+                        .frame(maxWidth: .infinity)
+                }
+                .aspectRatio(timelineItem.aspectRatio, contentMode: .fit)
+            }
+        }
+        .animation(.elementDefault, value: timelineItem.image)
+        .accessibilityLabel(timelineItem.text)
+    }
+}
+
+struct StickerRoomTimelineView_Previews: PreviewProvider {
+    static var previews: some View {
+        body
+        body.timelineStyle(.plain)
+    }
+    
+    static var body: some View {
+        VStack(spacing: 20.0) {
+            StickerRoomTimelineView(timelineItem: StickerRoomTimelineItem(id: UUID().uuidString,
+                                                                          text: "Some image",
+                                                                          timestamp: "Now",
+                                                                          groupState: .single,
+                                                                          isOutgoing: false,
+                                                                          isEditable: false,
+                                                                          senderId: "Bob",
+                                                                          urlString: nil,
+                                                                          image: UIImage(systemName: "photo")))
+            
+            StickerRoomTimelineView(timelineItem: StickerRoomTimelineItem(id: UUID().uuidString,
+                                                                          text: "Some other image",
+                                                                          timestamp: "Now",
+                                                                          groupState: .single,
+                                                                          isOutgoing: false,
+                                                                          isEditable: false,
+                                                                          senderId: "Bob",
+                                                                          urlString: nil,
+                                                                          image: nil))
+            
+            StickerRoomTimelineView(timelineItem: StickerRoomTimelineItem(id: UUID().uuidString,
+                                                                          text: "Blurhashed image",
+                                                                          timestamp: "Now",
+                                                                          groupState: .single,
+                                                                          isOutgoing: false,
+                                                                          isEditable: false,
+                                                                          senderId: "Bob",
+                                                                          urlString: nil,
+                                                                          image: nil,
+                                                                          aspectRatio: 0.7,
+                                                                          blurhash: "L%KUc%kqS$RP?Ks,WEf8OlrqaekW"))
+        }
+    }
+}

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
@@ -28,7 +28,6 @@ struct TextRoomTimelineView: View {
                 FormattedBodyText(text: timelineItem.text)
             }
         }
-        .id(timelineItem.id)
     }
 }
 
@@ -66,7 +65,7 @@ struct TextRoomTimelineView_Previews: PreviewProvider {
         TextRoomTimelineItem(id: UUID().uuidString,
                              text: text,
                              timestamp: timestamp,
-                             inGroupState: .single,
+                             groupState: .single,
                              isOutgoing: isOutgoing,
                              isEditable: isOutgoing,
                              senderId: senderId)

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/TimelineStartRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/TimelineStartRoomTimelineView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 New Vector Ltd
+// Copyright 2023 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,21 +16,29 @@
 
 import SwiftUI
 
-struct SeparatorRoomTimelineView: View {
-    let timelineItem: SeparatorRoomTimelineItem
+struct TimelineStartRoomTimelineView: View {
+    let timelineItem: TimelineStartRoomTimelineItem
     
     var body: some View {
-        Text(timelineItem.text)
+        Text(title)
             .font(.element.footnote)
             .foregroundColor(.element.secondaryContent)
             .padding(.vertical, 24)
             .frame(maxWidth: .infinity)
     }
+    
+    var title: String {
+        var text = ElementL10n.thisIsTheBeginningOfRoomNoName
+        if let name = timelineItem.name {
+            text = ElementL10n.thisIsTheBeginningOfRoom(name)
+        }
+        return text
+    }
 }
 
-struct SeparatorRoomTimelineView_Previews: PreviewProvider {
+struct TimelineStartRoomTimelineView_Previews: PreviewProvider {
     static var previews: some View {
-        let item = SeparatorRoomTimelineItem(text: "This is a separator")
-        SeparatorRoomTimelineView(timelineItem: item)
+        let item = TimelineStartRoomTimelineItem(name: "Alice and Bob")
+        TimelineStartRoomTimelineView(timelineItem: item)
     }
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/UnsupportedRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/UnsupportedRoomTimelineView.swift
@@ -1,0 +1,74 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+struct UnsupportedRoomTimelineView: View {
+    let timelineItem: UnsupportedRoomTimelineItem
+    
+    var body: some View {
+        TimelineStyler(timelineItem: timelineItem) {
+            Label {
+                VStack(alignment: .leading) {
+                    Text("\(timelineItem.text): \(timelineItem.eventType)")
+                        .fixedSize(horizontal: false, vertical: true)
+                        .foregroundColor(.element.primaryContent)
+                    
+                    Text(timelineItem.error)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .font(.element.footnote)
+                        .foregroundColor(.element.primaryContent)
+                }
+            } icon: {
+                Image(systemName: "exclamationmark.bubble")
+                    .foregroundColor(.red)
+            }
+        }
+    }
+}
+
+struct UnsupportedRoomTimelineView_Previews: PreviewProvider {
+    static var previews: some View {
+        body
+        body.timelineStyle(.plain)
+    }
+    
+    static var body: some View {
+        VStack(alignment: .leading, spacing: 20.0) {
+            UnsupportedRoomTimelineView(timelineItem: itemWith(text: "Text",
+                                                               timestamp: "Now",
+                                                               isOutgoing: false,
+                                                               senderId: "Bob"))
+            
+            UnsupportedRoomTimelineView(timelineItem: itemWith(text: "Some other text",
+                                                               timestamp: "Later",
+                                                               isOutgoing: true,
+                                                               senderId: "Anne"))
+        }
+    }
+    
+    private static func itemWith(text: String, timestamp: String, isOutgoing: Bool, senderId: String) -> UnsupportedRoomTimelineItem {
+        UnsupportedRoomTimelineItem(id: UUID().uuidString,
+                                    text: text,
+                                    eventType: "Some Event Type",
+                                    error: "Something went wrong",
+                                    timestamp: timestamp,
+                                    groupState: .single,
+                                    isOutgoing: isOutgoing,
+                                    isEditable: false,
+                                    senderId: senderId)
+    }
+}

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/VideoRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/VideoRoomTimelineView.swift
@@ -40,7 +40,6 @@ struct VideoRoomTimelineView: View {
                 .aspectRatio(timelineItem.aspectRatio, contentMode: .fit)
             }
         }
-        .id(timelineItem.id)
         .animation(.elementDefault, value: timelineItem.image)
     }
 
@@ -70,7 +69,7 @@ struct VideoRoomTimelineView_Previews: PreviewProvider {
             VideoRoomTimelineView(timelineItem: VideoRoomTimelineItem(id: UUID().uuidString,
                                                                       text: "Some video",
                                                                       timestamp: "Now",
-                                                                      inGroupState: .single,
+                                                                      groupState: .single,
                                                                       isOutgoing: false,
                                                                       isEditable: false,
                                                                       senderId: "Bob",
@@ -82,7 +81,7 @@ struct VideoRoomTimelineView_Previews: PreviewProvider {
             VideoRoomTimelineView(timelineItem: VideoRoomTimelineItem(id: UUID().uuidString,
                                                                       text: "Some other video",
                                                                       timestamp: "Now",
-                                                                      inGroupState: .single,
+                                                                      groupState: .single,
                                                                       isOutgoing: false,
                                                                       isEditable: false,
                                                                       senderId: "Bob",
@@ -94,7 +93,7 @@ struct VideoRoomTimelineView_Previews: PreviewProvider {
             VideoRoomTimelineView(timelineItem: VideoRoomTimelineItem(id: UUID().uuidString,
                                                                       text: "Blurhashed video",
                                                                       timestamp: "Now",
-                                                                      inGroupState: .single,
+                                                                      groupState: .single,
                                                                       isOutgoing: false,
                                                                       isEditable: false,
                                                                       senderId: "Bob",

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -191,32 +191,29 @@ class TimelineTableViewController: UIViewController {
             
             cell.item = timelineItem
             cell.contentConfiguration = UIHostingConfiguration {
-                if case .backPaginationIndicator = timelineItem {
-                    timelineItem
-                } else {
-                    timelineItem
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .opacity(opacity)
-                        .contextMenu {
-                            contextMenuBuilder?(timelineItem.id)
-                        }
-                        .onAppear {
-                            coordinator.send(viewAction: .itemAppeared(id: timelineItem.id))
-                        }
-                        .onDisappear {
-                            coordinator.send(viewAction: .itemDisappeared(id: timelineItem.id))
-                        }
-                        .environment(\.openURL, OpenURLAction { url in
-                            coordinator.send(viewAction: .linkClicked(url: url))
-                            return .systemAction
-                        })
-                        .onTapGesture(count: 2) {
-                            coordinator.send(viewAction: .displayEmojiPicker(itemId: timelineItem.id))
-                        }
-                        .onTapGesture {
-                            coordinator.send(viewAction: .itemTapped(id: timelineItem.id))
-                        }
-                }
+                timelineItem
+                    .id(timelineItem.id)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .opacity(opacity)
+                    .contextMenu {
+                        contextMenuBuilder?(timelineItem.id)
+                    }
+                    .onAppear {
+                        coordinator.send(viewAction: .itemAppeared(id: timelineItem.id))
+                    }
+                    .onDisappear {
+                        coordinator.send(viewAction: .itemDisappeared(id: timelineItem.id))
+                    }
+                    .environment(\.openURL, OpenURLAction { url in
+                        coordinator.send(viewAction: .linkClicked(url: url))
+                        return .systemAction
+                    })
+                    .onTapGesture(count: 2) {
+                        coordinator.send(viewAction: .displayEmojiPicker(itemId: timelineItem.id))
+                    }
+                    .onTapGesture {
+                        coordinator.send(viewAction: .itemTapped(id: timelineItem.id))
+                    }
             }
             .margins(.all, self.timelineStyle.rowInsets)
             .minSize(height: 1)
@@ -236,8 +233,6 @@ class TimelineTableViewController: UIViewController {
         let previousLayout = layout()
         
         var snapshot = NSDiffableDataSourceSnapshot<TimelineSection, RoomTimelineViewProvider>()
-        snapshot.appendSections([.loadingIndicator])
-        snapshot.appendItems([.backPaginationIndicator(isBackPaginating)])
         snapshot.appendSections([.main])
         snapshot.appendItems(timelineItems)
         dataSource.apply(snapshot, animatingDifferences: false)
@@ -399,7 +394,6 @@ extension TimelineTableViewController: UITableViewDelegate {
 extension TimelineTableViewController {
     /// The sections of the table view used in the diffable data source.
     enum TimelineSection {
-        case loadingIndicator
         case main
     }
     

--- a/ElementX/Sources/Screens/SessionVerification/SessionVerificationModels.swift
+++ b/ElementX/Sources/Screens/SessionVerification/SessionVerificationModels.swift
@@ -22,21 +22,18 @@ enum SessionVerificationViewModelAction {
 
 struct SessionVerificationViewState: BindableState {
     var verificationState: SessionVerificationStateMachine.State = .initial
-    
-    var title: String? {
-        switch verificationState {
-        case .showingChallenge:
-            return ElementL10n.sessionVerificationScreenEmojisTitle
-        default:
-            return nil
-        }
-    }
-    
+        
     var message: String {
         switch verificationState {
         case .initial:
             return ElementL10n.verificationOpenOtherToVerify
         case .requestingVerification:
+            return ElementL10n.verificationRequestWaiting
+        case .verificationRequestAccepted:
+            return ElementL10n.verificationEmojiNotice
+        case .startingSasVerification:
+            return ElementL10n.verificationRequestWaiting
+        case .sasVerificationStarted:
             return ElementL10n.verificationRequestWaiting
         case .acceptingChallenge:
             return ElementL10n.verificationRequestWaiting
@@ -45,7 +42,7 @@ struct SessionVerificationViewState: BindableState {
         case .cancelling:
             return ElementL10n.verificationRequestWaiting
         case .showingChallenge:
-            return ElementL10n.sessionVerificationScreenEmojisMessage
+            return ElementL10n.verificationCodeNotice
         case .verified:
             return ElementL10n.verificationConclusionOkSelfNotice
         case .cancelled:
@@ -55,7 +52,8 @@ struct SessionVerificationViewState: BindableState {
 }
 
 enum SessionVerificationViewAction {
-    case start
+    case requestVerification
+    case startSasVerification
     case restart
     case accept
     case decline

--- a/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
@@ -23,13 +23,6 @@ struct SessionVerificationScreen: View {
         NavigationView {
             ScrollView {
                 VStack(spacing: 32.0) {
-                    if let title = context.viewState.title {
-                        Text(title)
-                            .font(.element.headlineBold)
-                            .foregroundColor(.element.systemPrimaryLabel)
-                            .multilineTextAlignment(.center)
-                    }
-                    
                     Text(context.viewState.message)
                         .font(.body)
                         .multilineTextAlignment(.center)
@@ -66,6 +59,15 @@ struct SessionVerificationScreen: View {
         case .requestingVerification:
             ProgressView()
                 .accessibilityIdentifier("requestingVerificationProgressView")
+            
+        case .verificationRequestAccepted:
+            StateIcon(systemName: "lock.shield")
+        case .startingSasVerification:
+            ProgressView()
+                .accessibilityIdentifier("startingSasVerification")
+        case .sasVerificationStarted:
+            ProgressView()
+                .accessibilityIdentifier("startedSasVerification")
         case .cancelling:
             ProgressView()
                 .accessibilityIdentifier("cancellingVerificationProgressView")
@@ -98,10 +100,10 @@ struct SessionVerificationScreen: View {
         switch context.viewState.verificationState {
         case .initial:
             Button(ElementL10n.startVerification) {
-                context.send(viewAction: .start)
+                context.send(viewAction: .requestVerification)
             }
             .buttonStyle(.elementAction(.xLarge))
-            .accessibilityIdentifier("startButton")
+            .accessibilityIdentifier("requestVerificationButton")
         
         case .cancelled:
             Button(ElementL10n.globalRetry) {
@@ -109,16 +111,23 @@ struct SessionVerificationScreen: View {
             }
             .buttonStyle(.elementAction(.xLarge))
             .accessibilityIdentifier("restartButton")
+            
+        case .verificationRequestAccepted:
+            Button(ElementL10n.startVerification) {
+                context.send(viewAction: .startSasVerification)
+            }
+            .buttonStyle(.elementAction(.xLarge))
+            .accessibilityIdentifier("sasVerificationStartButton")
         
         case .showingChallenge:
             VStack(spacing: 30) {
                 Button { context.send(viewAction: .accept) } label: {
-                    Label(ElementL10n.actionMatch, systemImage: "checkmark")
+                    Label(ElementL10n.verificationSasMatch, systemImage: "checkmark")
                 }
                 .buttonStyle(.elementAction(.xLarge))
                 .accessibilityLabel("challengeAcceptButton")
                 
-                Button(ElementL10n.no) {
+                Button(ElementL10n.verificationSasDoNotMatch) {
                     context.send(viewAction: .decline)
                 }
                 .font(.element.bodyBold)

--- a/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
@@ -125,13 +125,13 @@ struct SessionVerificationScreen: View {
                     Label(ElementL10n.verificationSasMatch, systemImage: "checkmark")
                 }
                 .buttonStyle(.elementAction(.xLarge))
-                .accessibilityLabel("challengeAcceptButton")
+                .accessibilityIdentifier("challengeAcceptButton")
                 
                 Button(ElementL10n.verificationSasDoNotMatch) {
                     context.send(viewAction: .decline)
                 }
                 .font(.element.bodyBold)
-                .accessibilityLabel("challengeDeclineButton")
+                .accessibilityIdentifier("challengeDeclineButton")
             }
         
         case .verified:

--- a/ElementX/Sources/Services/Room/MockRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/MockRoomProxy.swift
@@ -55,7 +55,7 @@ struct MockRoomProxy: RoomProxyProtocol {
         .failure(.failedAddingTimelineListener)
     }
     
-    func paginateBackwards(count: UInt) async -> Result<UInt, RoomProxyError> {
+    func paginateBackwards(requestSize: UInt, untilNumberOfItems: UInt) async -> Result<Void, RoomProxyError> {
         .failure(.failedPaginatingBackwards)
     }
         

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -56,7 +56,7 @@ protocol RoomProxyProtocol {
     
     func addTimelineListener(listener: TimelineListener) -> Result<Void, RoomProxyError>
     
-    func paginateBackwards(count: UInt) async -> Result<UInt, RoomProxyError>
+    func paginateBackwards(requestSize: UInt, untilNumberOfItems: UInt) async -> Result<Void, RoomProxyError>
     
     func sendMessage(_ message: String, inReplyToEventId: String?) async -> Result<Void, RoomProxyError>
     

--- a/ElementX/Sources/Services/SessionVerification/MockSessionVerificationControllerProxy.swift
+++ b/ElementX/Sources/Services/SessionVerification/MockSessionVerificationControllerProxy.swift
@@ -27,7 +27,21 @@ struct MockSessionVerificationControllerProxy: SessionVerificationControllerProx
     func requestVerification() async -> Result<Void, SessionVerificationControllerProxyError> {
         Task.detached {
             try await Task.sleep(for: requestDelay)
-            callbacks.send(.receivedVerificationData(Self.emojis))
+            callbacks.send(.acceptedVerificationRequest)
+        }
+        
+        return .success(())
+    }
+    
+    func startSasVerification() async -> Result<Void, SessionVerificationControllerProxyError> {
+        Task.detached {
+            try await Task.sleep(for: requestDelay)
+            callbacks.send(.startedSasVerification)
+            
+            Task.detached {
+                try await Task.sleep(for: requestDelay)
+                callbacks.send(.receivedVerificationData(Self.emojis))
+            }
         }
         
         return .success(())

--- a/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
+++ b/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
@@ -31,6 +31,14 @@ private class WeakSessionVerificationControllerProxy: SessionVerificationControl
         proxy?.didReceiveData(data)
     }
     
+    func didAcceptVerificationRequest() {
+        proxy?.didAcceptVerificationRequest()
+    }
+    
+    func didStartSasVerification() {
+        proxy?.didStartSasVerification()
+    }
+    
     func didFail() {
         proxy?.didFail()
     }
@@ -73,6 +81,17 @@ class SessionVerificationControllerProxy: SessionVerificationControllerProxyProt
         }
     }
     
+    func startSasVerification() async -> Result<Void, SessionVerificationControllerProxyError> {
+        await Task.dispatch(on: .global()) {
+            do {
+                try self.sessionVerificationController.startSasVerification()
+                return .success(())
+            } catch {
+                return .failure(.failedStartingSasVerification)
+            }
+        }
+    }
+    
     func approveVerification() async -> Result<Void, SessionVerificationControllerProxyError> {
         await Task.dispatch(on: .global()) {
             do {
@@ -107,6 +126,14 @@ class SessionVerificationControllerProxy: SessionVerificationControllerProxyProt
     }
     
     // MARK: - Private
+    
+    fileprivate func didAcceptVerificationRequest() {
+        callbacks.send(.acceptedVerificationRequest)
+    }
+    
+    fileprivate func didStartSasVerification() {
+        callbacks.send(.startedSasVerification)
+    }
     
     fileprivate func didReceiveData(_ data: [MatrixRustSDK.SessionVerificationEmoji]) {
         callbacks.send(.receivedVerificationData(data.map { emoji in

--- a/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxyProtocol.swift
+++ b/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxyProtocol.swift
@@ -19,12 +19,15 @@ import Foundation
 
 enum SessionVerificationControllerProxyError: Error {
     case failedRequestingVerification
+    case failedStartingSasVerification
     case failedApprovingVerification
     case failedDecliningVerification
     case failedCancellingVerification
 }
 
 enum SessionVerificationControllerProxyCallback {
+    case acceptedVerificationRequest
+    case startedSasVerification
     case receivedVerificationData([SessionVerificationEmoji])
     case finished
     case cancelled
@@ -42,6 +45,8 @@ protocol SessionVerificationControllerProxyProtocol {
     var isVerified: Bool { get }
         
     func requestVerification() async -> Result<Void, SessionVerificationControllerProxyError>
+    
+    func startSasVerification() async -> Result<Void, SessionVerificationControllerProxyError>
     
     func approveVerification() async -> Result<Void, SessionVerificationControllerProxyError>
     

--- a/ElementX/Sources/Services/Timeline/Fixtures/RoomTimelineItemFixtures.swift
+++ b/ElementX/Sources/Services/Timeline/Fixtures/RoomTimelineItemFixtures.swift
@@ -19,12 +19,11 @@ import Foundation
 enum RoomTimelineItemFixtures {
     /// The default timeline items used in Xcode previews etc.
     static var `default`: [RoomTimelineItemProtocol] = [
-        SeparatorRoomTimelineItem(id: UUID().uuidString,
-                                  text: "Yesterday"),
+        SeparatorRoomTimelineItem(text: "Yesterday"),
         TextRoomTimelineItem(id: UUID().uuidString,
                              text: "That looks so good!",
                              timestamp: "10:10 AM",
-                             inGroupState: .single,
+                             groupState: .single,
                              isOutgoing: false,
                              isEditable: false,
                              senderId: "",
@@ -33,7 +32,7 @@ enum RoomTimelineItemFixtures {
         TextRoomTimelineItem(id: UUID().uuidString,
                              text: "Let’s get lunch soon! New salad place opened up 🥗. When are y’all free? 🤗",
                              timestamp: "10:11 AM",
-                             inGroupState: .beginning,
+                             groupState: .beginning,
                              isOutgoing: false,
                              isEditable: false,
                              senderId: "",
@@ -44,7 +43,7 @@ enum RoomTimelineItemFixtures {
         TextRoomTimelineItem(id: UUID().uuidString,
                              text: "I can be around on Wednesday. How about some 🌮 instead? Like https://www.tortilla.co.uk/",
                              timestamp: "10:11 AM",
-                             inGroupState: .end,
+                             groupState: .end,
                              isOutgoing: false,
                              isEditable: false,
                              senderId: "",
@@ -53,12 +52,11 @@ enum RoomTimelineItemFixtures {
                                  AggregatedReaction(key: "🙏", count: 1, isHighlighted: false),
                                  AggregatedReaction(key: "🙌", count: 2, isHighlighted: true)
                              ])),
-        SeparatorRoomTimelineItem(id: UUID().uuidString,
-                                  text: "Today"),
+        SeparatorRoomTimelineItem(text: "Today"),
         TextRoomTimelineItem(id: UUID().uuidString,
                              text: "Wow, cool. Ok, lets go the usual place tomorrow?! Is that too soon?  Here’s the menu, let me know what you want it’s on me!",
                              timestamp: "5 PM",
-                             inGroupState: .single,
+                             groupState: .single,
                              isOutgoing: false,
                              isEditable: false,
                              senderId: "",
@@ -66,7 +64,7 @@ enum RoomTimelineItemFixtures {
         TextRoomTimelineItem(id: UUID().uuidString,
                              text: "And John's speech was amazing!",
                              timestamp: "5 PM",
-                             inGroupState: .beginning,
+                             groupState: .beginning,
                              isOutgoing: true,
                              isEditable: true,
                              senderId: "",
@@ -74,7 +72,7 @@ enum RoomTimelineItemFixtures {
         TextRoomTimelineItem(id: UUID().uuidString,
                              text: "New home office set up!",
                              timestamp: "5 PM",
-                             inGroupState: .end,
+                             groupState: .end,
                              isOutgoing: true,
                              isEditable: true,
                              senderId: "",
@@ -91,7 +89,7 @@ enum RoomTimelineItemFixtures {
                                  AttributedStringBuilderComponent(attributedString: "That's amazing! Congrats 🥳", isBlockquote: false)
                              ],
                              timestamp: "5 PM",
-                             inGroupState: .single,
+                             groupState: .single,
                              isOutgoing: false,
                              isEditable: false,
                              senderId: "",
@@ -101,24 +99,24 @@ enum RoomTimelineItemFixtures {
     /// A small chunk of events, containing 2 text items.
     static var smallChunk: [RoomTimelineItemProtocol] {
         [TextRoomTimelineItem(text: "Hey there 👋",
-                              inGroupState: .beginning,
+                              groupState: .beginning,
                               senderDisplayName: "Alice"),
          TextRoomTimelineItem(text: "How are you?",
-                              inGroupState: .end,
+                              groupState: .end,
                               senderDisplayName: "Alice")]
     }
     
     /// A chunk of events that contains a single text item.
     static var singleMessageChunk: [RoomTimelineItemProtocol] {
         [TextRoomTimelineItem(text: "Tap tap tap 🎙️. Is this thing on?",
-                              inGroupState: .single,
+                              groupState: .single,
                               senderDisplayName: "Helena")]
     }
     
     /// A single text item.
     static var incomingMessage: RoomTimelineItemProtocol {
         TextRoomTimelineItem(text: "Hello, World!",
-                             inGroupState: .single,
+                             groupState: .single,
                              senderDisplayName: "Bob")
     }
     
@@ -209,11 +207,11 @@ enum RoomTimelineItemFixtures {
 }
 
 private extension TextRoomTimelineItem {
-    init(text: String, inGroupState: TimelineItemInGroupState = .single, senderDisplayName: String) {
+    init(text: String, groupState: TimelineItemGroupState = .single, senderDisplayName: String) {
         self.init(id: UUID().uuidString,
                   text: text,
                   timestamp: "10:47 am",
-                  inGroupState: inGroupState,
+                  groupState: groupState,
                   isOutgoing: senderDisplayName == "Alice",
                   isEditable: false,
                   senderId: "",

--- a/ElementX/Sources/Services/Timeline/MockRoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/MockRoomTimelineProvider.swift
@@ -23,7 +23,7 @@ struct MockRoomTimelineProvider: RoomTimelineProviderProtocol {
     
     private var itemProxies = [TimelineItemProxy]()
     
-    func paginateBackwards(_ count: UInt) async -> Result<Void, RoomTimelineProviderError> {
+    func paginateBackwards(requestSize: UInt, untilNumberOfItems: UInt) async -> Result<Void, RoomTimelineProviderError> {
         .failure(.failedPaginatingBackwards)
     }
     

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
@@ -68,18 +68,14 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
         }
     }
     
-    func paginateBackwards(_ count: UInt) async -> Result<Void, RoomTimelineProviderError> {
+    func paginateBackwards(requestSize: UInt, untilNumberOfItems: UInt) async -> Result<Void, RoomTimelineProviderError> {
         // Set this back to false after actually updating the items or if failed
         backPaginationPublisher.send(true)
         
         MXLog.info("Started back pagination request")
-        switch await roomProxy.paginateBackwards(count: count) {
-        case .success(let numberOfUpdates):
-            MXLog.info("Finished back pagination request. Got \(numberOfUpdates) updates")
-            
-            if numberOfUpdates == 0 {
-                backPaginationPublisher.send(false)
-            }
+        switch await roomProxy.paginateBackwards(requestSize: requestSize, untilNumberOfItems: untilNumberOfItems) {
+        case .success:
+            MXLog.info("Finished back pagination request")
             return .success(())
         case .failure(let error):
             MXLog.error("Failed back pagination request with error: \(error)")
@@ -152,7 +148,7 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
     // MARK: - Private
     
     private func updateItemsWithDiffs(_ diffs: [TimelineDiff]) {
-        MXLog.info("Received timeline diffs")
+        MXLog.verbose("Received timeline diffs")
         
         itemProxies = diffs
             .reduce(itemProxies) { currentItems, diff in
@@ -171,7 +167,7 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
                 return updatedItems
             }
         
-        MXLog.info("Finished applying diffs")
+        MXLog.verbose("Finished applying diffs")
     }
      
     // swiftlint:disable:next cyclomatic_complexity function_body_length

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProviderProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProviderProtocol.swift
@@ -31,7 +31,7 @@ protocol RoomTimelineProviderProtocol {
     
     var backPaginationPublisher: CurrentValueSubject<Bool, Never> { get }
     
-    func paginateBackwards(_ count: UInt) async -> Result<Void, RoomTimelineProviderError>
+    func paginateBackwards(requestSize: UInt, untilNumberOfItems: UInt) async -> Result<Void, RoomTimelineProviderError>
     
     func sendMessage(_ message: String, inReplyToItemId: String?) async -> Result<Void, RoomTimelineProviderError>
 

--- a/ElementX/Sources/Services/Timeline/TimeLineItemContent/MessageTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimeLineItemContent/MessageTimelineItem.swift
@@ -23,13 +23,6 @@ protocol MessageContentProtocol: RoomMessageEventContentProtocol {
     var body: String { get }
 }
 
-/// The delivery status for the item.
-enum MessageTimelineItemDeliveryStatus: Hashable {
-    case unknown
-    case sending
-    case sent(elapsedTime: TimeInterval)
-}
-
 /// A timeline item that represents an `m.room.message` event.
 struct MessageTimelineItem<Content: MessageContentProtocol> {
     let item: MatrixRustSDK.EventTimelineItem
@@ -43,15 +36,6 @@ struct MessageTimelineItem<Content: MessageContentProtocol> {
             return eventID
         }
     }
-    
-    var deliveryStatus: MessageTimelineItemDeliveryStatus {
-        switch item.key() {
-        case .transactionId:
-            return .sending
-        case .eventId:
-            return .sent(elapsedTime: Date().timeIntervalSince1970 - timestamp.timeIntervalSince1970)
-        }
-    }
 
     var body: String {
         content.body
@@ -61,18 +45,10 @@ struct MessageTimelineItem<Content: MessageContentProtocol> {
         item.content().asMessage()?.isEdited() == true
     }
 
-    var isEditable: Bool {
-        item.isEditable()
-    }
-    
     var inReplyTo: String? {
         item.content().asMessage()?.inReplyTo()
     }
     
-    var reactions: [Reaction] {
-        item.reactions()
-    }
-
     var sender: String {
         item.sender()
     }

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerProtocol.swift
@@ -48,7 +48,7 @@ protocol RoomTimelineControllerProtocol {
 
     func processItemTap(_ itemId: String) async -> RoomTimelineControllerAction
     
-    func paginateBackwards(_ count: UInt) async -> Result<Void, RoomTimelineControllerError>
+    func paginateBackwards(requestSize: UInt, untilNumberOfItems: UInt) async -> Result<Void, RoomTimelineControllerError>
     
     func sendMessage(_ message: String) async
     

--- a/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
@@ -42,6 +42,13 @@ enum TimelineItemProxy {
     }
 }
 
+/// The delivery status for the item.
+enum TimelineItemDeliveryStatus: Hashable {
+    case unknown
+    case sending
+    case sent(elapsedTime: TimeInterval)
+}
+
 /// A light wrapper around event timeline items returned from Rust.
 struct EventTimelineItemProxy: CustomDebugStringConvertible {
     let item: MatrixRustSDK.EventTimelineItem
@@ -59,6 +66,15 @@ struct EventTimelineItemProxy: CustomDebugStringConvertible {
         }
     }
     
+    var deliveryStatus: TimelineItemDeliveryStatus {
+        switch item.key() {
+        case .transactionId:
+            return .sending
+        case .eventId:
+            return .sent(elapsedTime: Date().timeIntervalSince1970 - timestamp.timeIntervalSince1970)
+        }
+    }
+    
     var body: String? {
         content.asMessage()?.body()
     }
@@ -69,10 +85,6 @@ struct EventTimelineItemProxy: CustomDebugStringConvertible {
     
     var content: TimelineItemContent {
         item.content()
-    }
-
-    var isRedacted: Bool {
-        content.isRedactedMessage()
     }
 
     var isOwn: Bool {

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
@@ -17,7 +17,7 @@
 import Foundation
 import UIKit
 
-enum TimelineItemInGroupState: Hashable {
+enum TimelineItemGroupState: Hashable {
     case single
     case beginning
     case middle
@@ -37,7 +37,7 @@ protocol EventBasedTimelineItemProtocol: RoomTimelineItemProtocol {
     var text: String { get }
     var timestamp: String { get }
     var shouldShowSenderDetails: Bool { get }
-    var inGroupState: TimelineItemInGroupState { get }
+    var groupState: TimelineItemGroupState { get }
     var isOutgoing: Bool { get }
     var isEditable: Bool { get }
     
@@ -50,11 +50,11 @@ protocol EventBasedTimelineItemProtocol: RoomTimelineItemProtocol {
 
 extension EventBasedTimelineItemProtocol {
     var shouldShowSenderDetails: Bool {
-        inGroupState.shouldShowSenderDetails
+        groupState.shouldShowSenderDetails
     }
     
     var roundedCorners: UIRectCorner {
-        switch inGroupState {
+        switch groupState {
         case .single:
             return .allCorners
         case .beginning:

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/EncryptedRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/EncryptedRoomTimelineItem.swift
@@ -27,7 +27,7 @@ struct EncryptedRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, 
     let text: String
     let encryptionType: EncryptionType
     let timestamp: String
-    let inGroupState: TimelineItemInGroupState
+    let groupState: TimelineItemGroupState
     let isOutgoing: Bool
     let isEditable: Bool
     

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/FileRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/FileRoomTimelineItem.swift
@@ -21,7 +21,7 @@ struct FileRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hasha
     let id: String
     let text: String
     let timestamp: String
-    let inGroupState: TimelineItemInGroupState
+    let groupState: TimelineItemGroupState
     let isOutgoing: Bool
     let isEditable: Bool
     

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/ImageRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/ImageRoomTimelineItem.swift
@@ -21,7 +21,7 @@ struct ImageRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hash
     let id: String
     let text: String
     let timestamp: String
-    let inGroupState: TimelineItemInGroupState
+    let groupState: TimelineItemGroupState
     let isOutgoing: Bool
     let isEditable: Bool
     

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/NoticeRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/NoticeRoomTimelineItem.swift
@@ -22,7 +22,7 @@ struct NoticeRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Has
     let text: String
     var attributedComponents: [AttributedStringBuilderComponent]?
     let timestamp: String
-    let inGroupState: TimelineItemInGroupState
+    let groupState: TimelineItemGroupState
     let isOutgoing: Bool
     let isEditable: Bool
     

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/PaginationIndicatorRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/PaginationIndicatorRoomTimelineItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 New Vector Ltd
+// Copyright 2023 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,20 +15,7 @@
 //
 
 import Foundation
-import UIKit
 
-struct EmoteRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hashable {
-    let id: String
-    let text: String
-    var attributedComponents: [AttributedStringBuilderComponent]?
-    let timestamp: String
-    let groupState: TimelineItemGroupState
-    let isOutgoing: Bool
-    let isEditable: Bool
-    
-    let senderId: String
-    var senderDisplayName: String?
-    var senderAvatar: UIImage?
-    
-    var properties = RoomTimelineItemProperties()
+struct PaginationIndicatorRoomTimelineItem: DecorationTimelineItemProtocol, Identifiable, Hashable {
+    let id: String = UUID().uuidString
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/ReadMarkerRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/ReadMarkerRoomTimelineItem.swift
@@ -17,5 +17,5 @@
 import Foundation
 
 struct ReadMarkerRoomTimelineItem: DecorationTimelineItemProtocol, Identifiable, Hashable {
-    let id: String
+    let id: String = UUID().uuidString
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/RedactedRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/RedactedRoomTimelineItem.swift
@@ -21,7 +21,7 @@ struct RedactedRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, H
     let id: String
     let text: String
     let timestamp: String
-    let inGroupState: TimelineItemInGroupState
+    let groupState: TimelineItemGroupState
     let isOutgoing: Bool
     let isEditable: Bool
     

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/RoomTimelineItemProperties.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/RoomTimelineItemProperties.swift
@@ -23,5 +23,5 @@ struct RoomTimelineItemProperties: Hashable {
     /// The aggregated reactions that have been sent for this item.
     var reactions: [AggregatedReaction] = []
     /// The delivery status for this item.
-    var deliveryStatus: MessageTimelineItemDeliveryStatus = .unknown
+    var deliveryStatus: TimelineItemDeliveryStatus = .unknown
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/SeparatorRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/SeparatorRoomTimelineItem.swift
@@ -17,6 +17,6 @@
 import Foundation
 
 struct SeparatorRoomTimelineItem: DecorationTimelineItemProtocol, Identifiable, Hashable {
-    let id: String
+    let id: String = UUID().uuidString
     let text: String
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/StickerRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/StickerRoomTimelineItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 New Vector Ltd
+// Copyright 2023 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,13 +14,11 @@
 // limitations under the License.
 //
 
-import Foundation
 import UIKit
 
-struct EmoteRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hashable {
+struct StickerRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hashable {
     let id: String
     let text: String
-    var attributedComponents: [AttributedStringBuilderComponent]?
     let timestamp: String
     let groupState: TimelineItemGroupState
     let isOutgoing: Bool
@@ -29,6 +27,14 @@ struct EmoteRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hash
     let senderId: String
     var senderDisplayName: String?
     var senderAvatar: UIImage?
+    
+    let urlString: String?
+    var image: UIImage?
+    
+    var width: CGFloat?
+    var height: CGFloat?
+    var aspectRatio: CGFloat?
+    var blurhash: String?
     
     var properties = RoomTimelineItemProperties()
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/TextRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/TextRoomTimelineItem.swift
@@ -22,7 +22,7 @@ struct TextRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hasha
     let text: String
     var attributedComponents: [AttributedStringBuilderComponent]?
     let timestamp: String
-    let inGroupState: TimelineItemInGroupState
+    let groupState: TimelineItemGroupState
     let isOutgoing: Bool
     let isEditable: Bool
     

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/TimelineStartRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/TimelineStartRoomTimelineItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 New Vector Ltd
+// Copyright 2023 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,20 +15,8 @@
 //
 
 import Foundation
-import UIKit
 
-struct EmoteRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hashable {
-    let id: String
-    let text: String
-    var attributedComponents: [AttributedStringBuilderComponent]?
-    let timestamp: String
-    let groupState: TimelineItemGroupState
-    let isOutgoing: Bool
-    let isEditable: Bool
-    
-    let senderId: String
-    var senderDisplayName: String?
-    var senderAvatar: UIImage?
-    
-    var properties = RoomTimelineItemProperties()
+struct TimelineStartRoomTimelineItem: DecorationTimelineItemProtocol, Identifiable, Hashable {
+    let id: String = UUID().uuidString
+    let name: String?
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/UnsupportedRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/UnsupportedRoomTimelineItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 New Vector Ltd
+// Copyright 2023 New Vector Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,13 +14,15 @@
 // limitations under the License.
 //
 
-import Foundation
 import UIKit
 
-struct EmoteRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hashable {
+struct UnsupportedRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hashable {
     let id: String
     let text: String
-    var attributedComponents: [AttributedStringBuilderComponent]?
+    
+    let eventType: String
+    let error: String
+    
     let timestamp: String
     let groupState: TimelineItemGroupState
     let isOutgoing: Bool

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/VideoRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/VideoRoomTimelineItem.swift
@@ -21,7 +21,7 @@ struct VideoRoomTimelineItem: EventBasedTimelineItemProtocol, Identifiable, Hash
     let id: String
     let text: String
     let timestamp: String
-    let inGroupState: TimelineItemInGroupState
+    let groupState: TimelineItemGroupState
     let isOutgoing: Bool
     let isEditable: Bool
     

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactoryProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactoryProtocol.swift
@@ -19,5 +19,5 @@ import Foundation
 @MainActor
 protocol RoomTimelineItemFactoryProtocol {
     func buildTimelineItemFor(eventItemProxy: EventTimelineItemProxy,
-                              inGroupState: TimelineItemInGroupState) -> RoomTimelineItemProtocol
+                              groupState: TimelineItemGroupState) -> RoomTimelineItemProtocol
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewFactory.swift
@@ -40,6 +40,14 @@ struct RoomTimelineViewFactory: RoomTimelineViewFactoryProtocol {
             return .encrypted(item)
         case let item as ReadMarkerRoomTimelineItem:
             return .readMarker(item)
+        case let item as PaginationIndicatorRoomTimelineItem:
+            return .paginationIndicator(item)
+        case let item as StickerRoomTimelineItem:
+            return .sticker(item)
+        case let item as UnsupportedRoomTimelineItem:
+            return .unsupported(item)
+        case let item as TimelineStartRoomTimelineItem:
+            return .timelineStart(item)
         default:
             fatalError("Unknown timeline item")
         }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewProvider.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineViewProvider.swift
@@ -28,7 +28,10 @@ enum RoomTimelineViewProvider: Identifiable, Hashable {
     case redacted(RedactedRoomTimelineItem)
     case encrypted(EncryptedRoomTimelineItem)
     case readMarker(ReadMarkerRoomTimelineItem)
-    case backPaginationIndicator(Bool)
+    case paginationIndicator(PaginationIndicatorRoomTimelineItem)
+    case sticker(StickerRoomTimelineItem)
+    case unsupported(UnsupportedRoomTimelineItem)
+    case timelineStart(TimelineStartRoomTimelineItem)
     
     var id: String {
         switch self {
@@ -52,8 +55,14 @@ enum RoomTimelineViewProvider: Identifiable, Hashable {
             return item.id
         case .readMarker(let item):
             return item.id
-        case .backPaginationIndicator:
-            return "BackpaginationLoadingIndicator"
+        case .paginationIndicator(let item):
+            return item.id
+        case .sticker(let item):
+            return item.id
+        case .unsupported(let item):
+            return item.id
+        case .timelineStart(let item):
+            return item.id
         }
     }
 }
@@ -81,10 +90,14 @@ extension RoomTimelineViewProvider: View {
             EncryptedRoomTimelineView(timelineItem: item)
         case .readMarker(let item):
             ReadMarkerRoomTimelineView(timelineItem: item)
-        case .backPaginationIndicator(let isBackPaginating):
-            ProgressView()
-                .frame(maxWidth: .infinity)
-                .opacity(isBackPaginating ? 1.0 : 0.0)
+        case .paginationIndicator(let item):
+            PaginationIndicatorRoomTimelineView(timelineItem: item)
+        case .sticker(let item):
+            StickerRoomTimelineView(timelineItem: item)
+        case .unsupported(let item):
+            UnsupportedRoomTimelineView(timelineItem: item)
+        case .timelineStart(let item):
+            TimelineStartRoomTimelineView(timelineItem: item)
         }
     }
 }

--- a/UITests/Sources/SessionVerificationUITests.swift
+++ b/UITests/Sources/SessionVerificationUITests.swift
@@ -22,15 +22,21 @@ class SessionVerificationUITests: XCTestCase {
         let app = Application.launch()
         app.goToScreenWithIdentifier(.sessionVerification)
         
-        XCTAssert(app.buttons["startButton"].exists)
+        XCTAssert(app.buttons["requestVerificationButton"].exists)
         XCTAssert(app.buttons["closeButton"].exists)
         XCTAssert(app.staticTexts["titleLabel"].exists)
 
         app.assertScreenshot(.sessionVerification)
         
-        app.buttons["startButton"].tap()
+        app.buttons["requestVerificationButton"].tap()
         
         XCTAssert(app.activityIndicators["requestingVerificationProgressView"].exists)
+        
+        XCTAssert(app.buttons["sasVerificationStartButton"].waitForExistence(timeout: 5.0))
+        app.buttons["sasVerificationStartButton"].tap()
+        
+        XCTAssert(app.activityIndicators["startingSasVerification"].waitForExistence(timeout: 5.0))
+        XCTAssert(app.activityIndicators["startedSasVerification"].waitForExistence(timeout: 5.0))
         
         XCTAssert(app.buttons["challengeAcceptButton"].waitForExistence(timeout: 5.0))
         XCTAssert(app.buttons["challengeDeclineButton"].waitForExistence(timeout: 5.0))
@@ -50,13 +56,19 @@ class SessionVerificationUITests: XCTestCase {
         let app = Application.launch()
         app.goToScreenWithIdentifier(.sessionVerification)
         
-        XCTAssert(app.buttons["startButton"].exists)
+        XCTAssert(app.buttons["requestVerificationButton"].exists)
         XCTAssert(app.buttons["closeButton"].exists)
         XCTAssert(app.staticTexts["titleLabel"].exists)
         
-        app.buttons["startButton"].tap()
+        app.buttons["requestVerificationButton"].tap()
         
         XCTAssert(app.activityIndicators["requestingVerificationProgressView"].exists)
+        
+        XCTAssert(app.buttons["sasVerificationStartButton"].waitForExistence(timeout: 5.0))
+        app.buttons["sasVerificationStartButton"].tap()
+        
+        XCTAssert(app.activityIndicators["startingSasVerification"].waitForExistence(timeout: 5.0))
+        XCTAssert(app.activityIndicators["startedSasVerification"].waitForExistence(timeout: 5.0))
         
         XCTAssert(app.buttons["challengeAcceptButton"].waitForExistence(timeout: 5.0))
         XCTAssert(app.buttons["challengeDeclineButton"].waitForExistence(timeout: 5.0))
@@ -74,13 +86,19 @@ class SessionVerificationUITests: XCTestCase {
         let app = Application.launch()
         app.goToScreenWithIdentifier(.sessionVerification)
         
-        XCTAssert(app.buttons["startButton"].exists)
+        XCTAssert(app.buttons["requestVerificationButton"].exists)
         XCTAssert(app.buttons["closeButton"].exists)
         XCTAssert(app.staticTexts["titleLabel"].exists)
         
-        app.buttons["startButton"].tap()
+        app.buttons["requestVerificationButton"].tap()
         
         XCTAssert(app.activityIndicators["requestingVerificationProgressView"].waitForExistence(timeout: 1))
+        
+        XCTAssert(app.buttons["sasVerificationStartButton"].waitForExistence(timeout: 5.0))
+        app.buttons["sasVerificationStartButton"].tap()
+        
+        XCTAssert(app.activityIndicators["startingSasVerification"].waitForExistence(timeout: 5.0))
+        XCTAssert(app.activityIndicators["startedSasVerification"].waitForExistence(timeout: 5.0))
         
         app.buttons["closeButton"].tap()
         

--- a/UnitTests/Sources/SessionVerificationStateMachineTests.swift
+++ b/UnitTests/Sources/SessionVerificationStateMachineTests.swift
@@ -33,6 +33,12 @@ class SessionVerificationStateMachineTests: XCTestCase {
         stateMachine.processEvent(.requestVerification)
         XCTAssertEqual(stateMachine.state, .requestingVerification)
         
+        stateMachine.processEvent(.didAcceptVerificationRequest)
+        XCTAssertEqual(stateMachine.state, .verificationRequestAccepted)
+        
+        stateMachine.processEvent(.didStartSasVerification)
+        XCTAssertEqual(stateMachine.state, .sasVerificationStarted)
+        
         stateMachine.processEvent(.didReceiveChallenge(emojis: MockSessionVerificationControllerProxy.emojis))
         XCTAssertEqual(stateMachine.state, .showingChallenge(emojis: MockSessionVerificationControllerProxy.emojis))
         
@@ -48,6 +54,12 @@ class SessionVerificationStateMachineTests: XCTestCase {
         
         stateMachine.processEvent(.requestVerification)
         XCTAssertEqual(stateMachine.state, .requestingVerification)
+        
+        stateMachine.processEvent(.didAcceptVerificationRequest)
+        XCTAssertEqual(stateMachine.state, .verificationRequestAccepted)
+        
+        stateMachine.processEvent(.didStartSasVerification)
+        XCTAssertEqual(stateMachine.state, .sasVerificationStarted)
         
         stateMachine.processEvent(.didReceiveChallenge(emojis: MockSessionVerificationControllerProxy.emojis))
         XCTAssertEqual(stateMachine.state, .showingChallenge(emojis: MockSessionVerificationControllerProxy.emojis))
@@ -83,6 +95,12 @@ class SessionVerificationStateMachineTests: XCTestCase {
         
         stateMachine.processEvent(.requestVerification)
         XCTAssertEqual(stateMachine.state, .requestingVerification)
+        
+        stateMachine.processEvent(.didAcceptVerificationRequest)
+        XCTAssertEqual(stateMachine.state, .verificationRequestAccepted)
+        
+        stateMachine.processEvent(.didStartSasVerification)
+        XCTAssertEqual(stateMachine.state, .sasVerificationStarted)
         
         stateMachine.processEvent(.didReceiveChallenge(emojis: MockSessionVerificationControllerProxy.emojis))
         XCTAssertEqual(stateMachine.state, .showingChallenge(emojis: MockSessionVerificationControllerProxy.emojis))

--- a/changelog.d/pr-408.feature
+++ b/changelog.d/pr-408.feature
@@ -1,0 +1,1 @@
+Add support for manually starting SaS verification flows and accepting remotely started ones

--- a/changelog.d/pr-424.feature
+++ b/changelog.d/pr-424.feature
@@ -1,0 +1,1 @@
+Add support for new timeline items: loading indicators, stickers, invalid events and begining of history

--- a/project.yml
+++ b/project.yml
@@ -40,7 +40,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.27-alpha
+    exactVersion: 1.0.28-alpha
     # path: ../matrix-rust-sdk
   DesignKit:
     path: ./


### PR DESCRIPTION
Add support for manually starting SaS verification flows and accepting remotely started ones + some UI tweaking

Requires https://github.com/matrix-org/matrix-rust-sdk/pull/1323 and https://github.com/matrix-org/matrix-rust-sdk/pull/1300

![Screenshot 2023-01-05 at 18 03 48](https://user-images.githubusercontent.com/637564/210826889-0027d0d7-7fe9-4b65-8261-37d218865338.png)

![Screenshot 2023-01-05 at 18 03 56](https://user-images.githubusercontent.com/637564/210826897-fc084d48-8578-40f4-bce0-30e2e84f88e8.png)
