### PR TITLE
Run SwiftFormat and SwiftLint as a SPM plugins.

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -16,6 +16,6 @@ jobs:
           key: danger-swift-cache-key
 
       - name: Danger
-        uses: docker://ghcr.io/danger/danger-swift-with-swiftlint:3.14.2
+        uses: docker://ghcr.io/danger/danger-swift-with-swiftlint:3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Brew bundle
         run:
-          brew update && brew bundle && brew upgrade swiftformat
+          brew update && brew bundle
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -34,11 +34,11 @@ jobs:
 
       - name: Brew bundle
         run:
-          brew bundle
+          brew update && brew bundle
 
       - name: SwiftFormat
         run:
-          swiftformat --lint .
+          swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint .
 
       - name: Bundle install
         run: |

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: SwiftFormat
         run:
-          swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint .
+          swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --target Tools .
 
       - name: Bundle install
         run: |

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: SwiftFormat
         run:
-          swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --target Tools .
+          swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --cache .build/swiftformat --target Tools .
 
       - name: Bundle install
         run: |

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Brew bundle
         run:
-          brew update && brew bundle && brew upgrade swiftformat
+          brew update && brew bundle
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,7 +30,7 @@ jobs:
       
       - name: SwiftFormat
         run:
-          swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint .
+          swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --target Tools .
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,7 +30,7 @@ jobs:
       
       - name: SwiftFormat
         run:
-          swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --target Tools .
+          swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --cache .build/swiftformat --target Tools .
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Brew bundle
         run:
-          brew update && brew bundle && brew upgrade swiftformat
+          brew update && brew bundle
       
       - name: SwiftFormat
         run:
-          swiftformat --lint .
+          swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint .
 
       - uses: actions/cache@v3
         with:

--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,5 @@
 brew "xcodegen"
 brew "swiftgen"
-brew "swiftformat"
 brew "git-lfs"
 
 #brew "swiftlint" # Fails on the CI: `Target /usr/local/bin/swiftlint Target /usr/local/bin/swiftlint already exists`. Installed through https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md#linters

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -2795,7 +2795,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "xcrun --sdk macosx swift package -c release plugin swiftlint\n";
 		};
 		A7130911BCB2DF3D249A1836 /* 🛠 SwiftGen */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -2833,7 +2833,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "xcrun --sdk macosx swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --lenient \"$PROJECT_DIR\"\n";
+			shellScript = "xcrun --sdk macosx swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --lenient --target Tools \"$PROJECT_DIR\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -804,7 +804,7 @@
 		8D6094DEAAEB388E1AE118C6 /* MockRoomTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRoomTimelineProvider.swift; sourceTree = "<group>"; };
 		8D8169443E5AC5FF71BFB3DB /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8DC2C9E0E15C79BBDA80F0A2 /* TimelineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStyle.swift; sourceTree = "<group>"; };
-		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
+		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; path = UITests.xctestplan; sourceTree = "<group>"; };
 		8ED2D2F6A137A95EA50413BE /* UserNotificationControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationControllerProtocol.swift; sourceTree = "<group>"; };
 		8F7D42E66E939B709C1EC390 /* MockRoomSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRoomSummaryProvider.swift; sourceTree = "<group>"; };
 		8FC26871038FB0E4AAE22605 /* apple_emojis_data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = apple_emojis_data.json; sourceTree = "<group>"; };
@@ -1018,7 +1018,7 @@
 		EBE5502760CF6CA2D7201883 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ja; path = ja.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		ED044D00F2176681CC02CD54 /* HomeScreenRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenRoomCell.swift; sourceTree = "<group>"; };
 		ED1D792EB82506A19A72C8DE /* RoomTimelineItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemProtocol.swift; sourceTree = "<group>"; };
-		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = message.caf; sourceTree = "<group>"; };
+		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; path = message.caf; sourceTree = "<group>"; };
 		EDAA4472821985BF868CC21C /* ServerSelectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionViewModelTests.swift; sourceTree = "<group>"; };
 		EDB6E40BAD4504D899FAAC9A /* TemplateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateViewModel.swift; sourceTree = "<group>"; };
 		EE8BCD14EFED23459A43FDFF /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -2833,7 +2833,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat >/dev/null; then\n    swiftformat --lint --lenient \"$PROJECT_DIR\"\nelse\n    echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
+			shellScript = "xcrun --sdk macosx swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --lenient \"$PROJECT_DIR\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -2833,7 +2833,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "xcrun --sdk macosx swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --lenient --target Tools \"$PROJECT_DIR\"\n";
+			shellScript = "xcrun --sdk macosx swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --lenient --cache \"$PROJECT_DIR/.build/swiftformat\" --target Tools \"$PROJECT_DIR\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
       "identity" : "devicekit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/devicekit/DeviceKit",
@@ -109,6 +118,15 @@
       }
     },
     {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "fc12c0f182c5cf80781dd933b17a82eb98bd7c61",
+        "version" : "0.33.1"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
@@ -127,12 +145,29 @@
       }
     },
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "a2d31e8880224f5a619f24bf58c122836faf99ff"
+      }
+    },
+    {
       "identity" : "swiftformat",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
         "revision" : "34cd9dd87b78048ce0d623a9153f9bf260ad6590",
         "version" : "0.50.7"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint",
+      "state" : {
+        "branch" : "main",
+        "revision" : "68dc0f58d2e3a2e2b44457ffa0753056f38736f6"
       }
     },
     {
@@ -160,6 +195,24 @@
       "state" : {
         "revision" : "12b5acf96d98f91d50de447369bd18df74600f1a",
         "version" : "1.9.6"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "4d0f62f561458cbe1f732171e625f03195151b60",
+        "version" : "7.0.1"
       }
     },
     {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -127,6 +127,15 @@
       }
     },
     {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat",
+      "state" : {
+        "revision" : "34cd9dd87b78048ce0d623a9153f9bf260ad6590",
+        "version" : "0.50.7"
+      }
+    },
+    {
       "identity" : "swiftstate",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactKit/SwiftState",

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -91,12 +91,7 @@ targets:
       basedOnDependencyAnalysis: false
       shell: /bin/sh
       script: |
-        export PATH="$PATH:/opt/homebrew/bin"
-        if which swiftlint >/dev/null; then
-            swiftlint
-        else
-            echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
-        fi
+        xcrun --sdk macosx swift package -c release plugin swiftlint
     - name: 🧹 SwiftFormat
       runOnlyWhenInstalling: false
       basedOnDependencyAnalysis: false

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -102,7 +102,7 @@ targets:
       basedOnDependencyAnalysis: false
       shell: /bin/sh
       script: |
-        xcrun --sdk macosx swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --lenient "$PROJECT_DIR"
+        xcrun --sdk macosx swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --lenient --target Tools "$PROJECT_DIR"
 
     dependencies:
     - target: NSE

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -97,7 +97,7 @@ targets:
       basedOnDependencyAnalysis: false
       shell: /bin/sh
       script: |
-        xcrun --sdk macosx swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --lenient --target Tools "$PROJECT_DIR"
+        xcrun --sdk macosx swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --lenient --cache "$PROJECT_DIR/.build/swiftformat" --target Tools "$PROJECT_DIR"
 
     dependencies:
     - target: NSE

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -102,12 +102,7 @@ targets:
       basedOnDependencyAnalysis: false
       shell: /bin/sh
       script: |
-        export PATH="$PATH:/opt/homebrew/bin"
-        if which swiftformat >/dev/null; then
-            swiftformat --lint --lenient "$PROJECT_DIR"
-        else
-            echo "warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat"
-        fi
+        xcrun --sdk macosx swift package -c release plugin --allow-writing-to-package-directory swiftformat --lint --lenient "$PROJECT_DIR"
 
     dependencies:
     - target: NSE

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,30 @@
 {
   "pins" : [
     {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
       "identity" : "element-design-tokens",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vector-im/element-design-tokens.git",
       "state" : {
         "revision" : "63e40f10b336c136d6d05f7967e4565e37d3d760",
         "version" : "0.0.3"
+      }
+    },
+    {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "fc12c0f182c5cf80781dd933b17a82eb98bd7c61",
+        "version" : "0.33.1"
       }
     },
     {
@@ -19,6 +37,14 @@
       }
     },
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "a2d31e8880224f5a619f24bf58c122836faf99ff"
+      }
+    },
+    {
       "identity" : "swiftformat",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
@@ -28,12 +54,39 @@
       }
     },
     {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint",
+      "state" : {
+        "branch" : "main",
+        "revision" : "68dc0f58d2e3a2e2b44457ffa0753056f38736f6"
+      }
+    },
+    {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
       "state" : {
         "revision" : "f2616860a41f9d9932da412a8978fec79c06fe24",
         "version" : "0.1.4"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "4d0f62f561458cbe1f732171e625f03195151b60",
+        "version" : "7.0.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat",
+      "state" : {
+        "revision" : "34cd9dd87b78048ce0d623a9153f9bf260ad6590",
+        "version" : "0.50.7"
+      }
+    },
+    {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect.git",

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
         .package(url: "https://github.com/jpsim/Yams", from: "5.0.1"),
         /* Package plug-ins */
+        .package(url: "https://github.com/realm/SwiftLint", branch: "main"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4")
     ],
     targets: [
@@ -37,6 +38,12 @@ let package = Package(
                               .product(name: "ArgumentParser", package: "swift-argument-parser"),
                               .product(name: "Yams", package: "Yams")
                           ],
-                          path: "Tools/Sources")
+                          path: "Tools/Sources"),
+        .plugin(name: "SwiftLint",
+                capability: .command(intent: .custom(verb: "swiftlint", description: "Run swiftlint on the project directory")),
+                dependencies: [
+                    .product(name: "swiftlint", package: "SwiftLint")
+                ],
+                path: "Tools/Plugins/SwiftLint")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,9 @@ let package = Package(
         .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", from: "0.1.4"),
         /* Command line tools dependencies */
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
-        .package(url: "https://github.com/jpsim/Yams", from: "5.0.1")
+        .package(url: "https://github.com/jpsim/Yams", from: "5.0.1"),
+        /* Package plug-ins */
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4")
     ],
     targets: [
         .target(name: "DesignKit",

--- a/Tools/Plugins/SwiftLint/SwiftLint.swift
+++ b/Tools/Plugins/SwiftLint/SwiftLint.swift
@@ -1,0 +1,14 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct SwiftLint: CommandPlugin {
+    func performCommand(context: PackagePlugin.PluginContext, arguments: [String]) async throws {
+        let swiftlint = try context.tool(named: "swiftlint")
+        
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: swiftlint.path.string)
+        process.currentDirectoryURL = URL(fileURLWithPath: context.package.directory.string)
+        try process.run()
+    }
+}

--- a/changelog.d/365.build
+++ b/changelog.d/365.build
@@ -1,0 +1,1 @@
+SwiftFormat: Replace usage from Homebrew with the SPM plugin.


### PR DESCRIPTION
Adds SwiftFormat as a dependency in Package.swift and uses it via `swift package plugin swiftformat` so that the dependency is pinned and automatically pulled in for us. We have to specify a `--target` otherwise the plugin runs on all 3 targets in the manifest, but by supplying a path after the target it runs on the whole project (which technically means it runs twice on the specified target 😕)

Also adds SwiftLint as a dependency in Package.swift, however that one only vends a Build Plugin so can't be called. Because of this I've added a Command Plugin to allow us to `swift package plugin swiftlint` and as this is custom we don't need to worry about targets like with SwiftFormat. The plugin lives in `Tools/Plugins/SwiftLint`, but we could very well create `Plugins/SwiftLint` which is the default location that SPM expects to find all plug-ins.

Draft for now to see how CI handles the changes.