### PR TITLE
Update danger image, fix snapshots

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -16,6 +16,6 @@ jobs:
           key: danger-swift-cache-key
 
       - name: Danger
-        uses: docker://ghcr.io/danger/danger-swift-with-swiftlint:3.14.2
+        uses: docker://ghcr.io/danger/danger-swift-with-swiftlint:3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/UITests/Sources/__Snapshots__/Application/de-DE-iPhone-14.roomLayoutMiddle-1.png
+++ b/UITests/Sources/__Snapshots__/Application/de-DE-iPhone-14.roomLayoutMiddle-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ebdcd4e127c2187bc1f58a4569de526151f6b1b9633d28c543d6391fc69f71a
-size 338537
+oid sha256:7dce2910cc89ed74a016c5237cd6616357f5f7551cc81541d40ddb8b0e80b39a
+size 318257

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.roomLayoutMiddle-1.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.roomLayoutMiddle-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7c7103f6194cd4d4f51ef67a2b4d40ebc54dcc0336ffdd8fcdbed760f2991a2
-size 338396
+oid sha256:6a16c74e701cc80bc0cc7a36e9ee344248a1c36b721679cf4ee3e704c5c70283
+size 318225


### PR DESCRIPTION
Update the docker tag used for Danger, and fix some snapshots captured with the hardware keyboard connected.