### PR TITLE
Various sliding sync tweaks

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -173,7 +173,6 @@
 		5B8B51CEC4717AF487794685 /* NotificationServiceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B490675B8E31423AF116BDA /* NotificationServiceProxy.swift */; };
 		5C02841B2A86327B2C377682 /* NotificationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C830A64609CBD152F06E0457 /* NotificationConstants.swift */; };
 		5C8AFBF168A41E20835F3B86 /* LoginScreenUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB34B0C74CD242FED9DD069 /* LoginScreenUITests.swift */; };
-		5D1C6D4E3583700DF7A64834 /* UITestsSignalling.swift in Sources */ = {isa = PBXBuildFile; fileRef = D619626288AAB513B7620BB6 /* UITestsSignalling.swift */; };
 		5D2AF8C0DF872E7985F8FE54 /* TimelineDeliveryStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AC06FC11B6638F7BF1670E /* TimelineDeliveryStatusView.swift */; };
 		5D430CDE11EAC3E8E6B80A66 /* RoomTimelineViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEE631F3A4AFDC6652DD9DA /* RoomTimelineViewFactory.swift */; };
 		5D70FAE4D2BF4553AFFFFE41 /* NotificationItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F7FE40EF7490A7E09D7BE6 /* NotificationItemProxy.swift */; };
@@ -217,6 +216,7 @@
 		7002C55A4C917F3715765127 /* MediaProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C888BCD78E2A55DCE364F160 /* MediaProviderProtocol.swift */; };
 		702694459B649B9D3A3C34F8 /* TimelineTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9212AE02CBDD692C56A879F /* TimelineTableViewController.swift */; };
 		70558528EF68CAAEF09972D5 /* RoomTimelineItemFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96ED747FF90332EA1333C22 /* RoomTimelineItemFixtures.swift */; };
+		706289B086B0A6B0C211763F /* UITestsSignalling.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F0192CE2F891141A25B49F /* UITestsSignalling.swift */; };
 		706F79A39BDB32F592B8C2C7 /* UIKitBackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FCD9116ADDE820E4E30F92 /* UIKitBackgroundTask.swift */; };
 		7096FA3AC218D914E88BFB70 /* AggregratedReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15BE37BE2FB86E00C8D150A /* AggregratedReaction.swift */; };
 		719E7AAD1F8E68F68F30FECD /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40C19719687984FD9478FBE /* Task.swift */; };
@@ -258,6 +258,7 @@
 		81A7C020CB5F6232242A8414 /* UserSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36C0A6D59717193F49EA986 /* UserSessionTests.swift */; };
 		829062DD3C3F7016FE1A6476 /* RoomDetailsScreenUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFDAF6918BB096C44788FC9 /* RoomDetailsScreenUITests.swift */; };
 		83E5054739949181CA981193 /* LoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD667C4BB98CF4F3FE2CE3B0 /* LoginCoordinator.swift */; };
+		84EFCB95F9DA2979C8042B26 /* UITestsSignalling.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F0192CE2F891141A25B49F /* UITestsSignalling.swift */; };
 		85AFBB433AD56704A880F8A0 /* FramePreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4798B3B7A1E8AE3901CEE8C6 /* FramePreferenceKey.swift */; };
 		86675910612A12409262DFBD /* SessionVerificationStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C22B1B5FA3A765EADB2CC9 /* SessionVerificationStateMachineTests.swift */; };
 		8691186F9B99BCDDB7CACDD8 /* KeychainController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36CB905A2B9EC2C92A2DA7C /* KeychainController.swift */; };
@@ -461,7 +462,6 @@
 		F6E860FF7B18B81DF43B30B8 /* EncryptedRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FA7C8D4EF2B1873C180ED7 /* EncryptedRoomTimelineItem.swift */; };
 		F6F49E37272AD7397CD29A01 /* HomeScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505208F28007C0FEC14E1FF0 /* HomeScreenViewModelTests.swift */; };
 		F7567DD6635434E8C563BF85 /* AnalyticsClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B97591B2D3D4D67553506D /* AnalyticsClientProtocol.swift */; };
-		F98333D53D85B0E029FDCA12 /* UITestsSignalling.swift in Sources */ = {isa = PBXBuildFile; fileRef = D619626288AAB513B7620BB6 /* UITestsSignalling.swift */; };
 		F9981191DC408AED537C1749 /* MediaProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12C9E0B61A77C7F0EE7918C /* MediaProxy.swift */; };
 		F99FB21EFC6D99D247FE7CBE /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = DE8DC9B3FBA402117DC4C49F /* Kingfisher */; };
 		F9F6D2883BBEBB9A3789A137 /* OnboardingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A941F289F6AB876BA3361A /* OnboardingViewModelTests.swift */; };
@@ -802,7 +802,7 @@
 		8D6094DEAAEB388E1AE118C6 /* MockRoomTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRoomTimelineProvider.swift; sourceTree = "<group>"; };
 		8D8169443E5AC5FF71BFB3DB /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8DC2C9E0E15C79BBDA80F0A2 /* TimelineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStyle.swift; sourceTree = "<group>"; };
-		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
+		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; path = UITests.xctestplan; sourceTree = "<group>"; };
 		8ED2D2F6A137A95EA50413BE /* UserNotificationControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationControllerProtocol.swift; sourceTree = "<group>"; };
 		8F7D42E66E939B709C1EC390 /* MockRoomSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRoomSummaryProvider.swift; sourceTree = "<group>"; };
 		8FC26871038FB0E4AAE22605 /* apple_emojis_data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = apple_emojis_data.json; sourceTree = "<group>"; };
@@ -903,6 +903,7 @@
 		B6311F21F911E23BE4DF51B4 /* ReadMarkerRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadMarkerRoomTimelineView.swift; sourceTree = "<group>"; };
 		B6E89E530A8E92EC44301CA1 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		B7E035C6AC137C9392D98814 /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B7F0192CE2F891141A25B49F /* UITestsSignalling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestsSignalling.swift; sourceTree = "<group>"; };
 		B80D1901BA0B095E27793EDE /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B8108C8F0ACF6A7EB72D0117 /* RoomScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreenCoordinator.swift; sourceTree = "<group>"; };
 		B8347789959986B374DB25DD /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = sq; path = sq.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -965,7 +966,6 @@
 		D3D455BC2423D911A62ACFB2 /* NSELogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSELogger.swift; sourceTree = "<group>"; };
 		D4DA544B2520BFA65D6DB4BB /* target.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = target.yml; sourceTree = "<group>"; };
 		D5AC06FC11B6638F7BF1670E /* TimelineDeliveryStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineDeliveryStatusView.swift; sourceTree = "<group>"; };
-		D619626288AAB513B7620BB6 /* UITestsSignalling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestsSignalling.swift; sourceTree = "<group>"; };
 		D653265D006E708E4E51AD64 /* HomeScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenCoordinator.swift; sourceTree = "<group>"; };
 		D67CBAFA48ED0B6FCE74F88F /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D6CA5F386C7701C129398945 /* AuthenticationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinator.swift; sourceTree = "<group>"; };
@@ -1015,7 +1015,7 @@
 		EBE5502760CF6CA2D7201883 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ja; path = ja.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		ED044D00F2176681CC02CD54 /* HomeScreenRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenRoomCell.swift; sourceTree = "<group>"; };
 		ED1D792EB82506A19A72C8DE /* RoomTimelineItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemProtocol.swift; sourceTree = "<group>"; };
-		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = message.caf; sourceTree = "<group>"; };
+		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; path = message.caf; sourceTree = "<group>"; };
 		EDAA4472821985BF868CC21C /* ServerSelectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionViewModelTests.swift; sourceTree = "<group>"; };
 		EDB6E40BAD4504D899FAAC9A /* TemplateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateViewModel.swift; sourceTree = "<group>"; };
 		EE8BCD14EFED23459A43FDFF /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1253,8 +1253,8 @@
 			children = (
 				46C208DA43CE25D13E670F40 /* UITestsAppCoordinator.swift */,
 				CC6FE34A0A47D010BBB4D4D4 /* UITestScreenIdentifier.swift */,
-				D619626288AAB513B7620BB6 /* UITestsSignalling.swift */,
 				D751BB69BB7C38FD247517B4 /* UITestsRootCoordinator.swift */,
+				B7F0192CE2F891141A25B49F /* UITestsSignalling.swift */,
 			);
 			path = UITests;
 			sourceTree = "<group>";
@@ -3193,9 +3193,9 @@
 				706F79A39BDB32F592B8C2C7 /* UIKitBackgroundTask.swift in Sources */,
 				3097A0A867D2B19CE32DAE58 /* UIKitBackgroundTaskService.swift in Sources */,
 				D05A193AE63030F2CFCE2E9C /* UITestScreenIdentifier.swift in Sources */,
-				5D1C6D4E3583700DF7A64834 /* UITestsSignalling.swift in Sources */,
 				E96005321849DBD7C72A28F2 /* UITestsAppCoordinator.swift in Sources */,
 				086C2FA7750378EB2BFD0BEE /* UITestsRootCoordinator.swift in Sources */,
+				706289B086B0A6B0C211763F /* UITestsSignalling.swift in Sources */,
 				071A017E415AD378F2961B11 /* URL.swift in Sources */,
 				392D0519E5597A538BFB2CAB /* UnsupportedRoomTimelineItem.swift in Sources */,
 				E1F446C6B78A3A0FEA15079C /* UnsupportedRoomTimelineView.swift in Sources */,
@@ -3243,7 +3243,7 @@
 				B3357B00F1AA930E54F76609 /* Strings.swift in Sources */,
 				C4180F418235DAD9DD173951 /* TemplateScreenUITests.swift in Sources */,
 				9A47B7EFE3793760EEF68FFE /* UITestScreenIdentifier.swift in Sources */,
-				F98333D53D85B0E029FDCA12 /* UITestsSignalling.swift in Sources */,
+				84EFCB95F9DA2979C8042B26 /* UITestsSignalling.swift in Sources */,
 				B22D857D1E8FCA6DD74A58E3 /* UserSessionScreenTests.swift in Sources */,
 				588411C8FD72B2A2DFE5F7DE /* XCUIElement.swift in Sources */,
 			);
@@ -3905,7 +3905,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "1.0.28-alpha";
+				version = "1.0.30-alpha";
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "d8bd9bc10423fe68f54c89811950ca269af9da9e",
-        "version" : "1.0.28-alpha"
+        "revision" : "08db830ef3f0ab24f39a95705179713ea5382f9c",
+        "version" : "1.0.30-alpha"
       }
     },
     {

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -39,7 +39,7 @@ enum HomeScreenViewAction {
     case userMenu(action: HomeScreenViewUserMenuAction)
     case verifySession
     case skipSessionVerification
-    case updatedVisibleItemIdentifiers(Set<String>)
+    case updatedVisibleItemRange(Range<Int>)
 }
 
 enum HomeScreenRoomListMode {

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -185,7 +185,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
         
         for (index, summary) in visibleRoomsSummaryProvider.roomListPublisher.value.enumerated() {
             switch summary {
-            case .empty:
+            case .empty, .invalidated:
                 guard let allRoomsRoomSummary = allRoomsSummaryProvider?.roomListPublisher.value[safe: index] else {
                     rooms.append(HomeScreenRoom.placeholder())
                     continue
@@ -200,9 +200,6 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 }
             case .filled(let details):
                 let room = buildRoom(with: details, invalidated: false)
-                rooms.append(room)
-            case .invalidated(let details):
-                let room = buildRoom(with: details, invalidated: true)
                 rooms.append(room)
             }
         }

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -20,10 +20,16 @@ import SwiftUI
 typealias HomeScreenViewModelType = StateStoreViewModel<HomeScreenViewState, HomeScreenViewAction>
 
 class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol {
+    enum Constants {
+        static let slidingWindowBoundsPadding = 5
+    }
+    
     private let userSession: UserSessionProtocol
     private let visibleRoomsSummaryProvider: RoomSummaryProviderProtocol?
     private let allRoomsSummaryProvider: RoomSummaryProviderProtocol?
     private let attributedStringBuilder: AttributedStringBuilderProtocol
+    
+    private let visibleItemRangePublisher = CurrentValueSubject<Range<Int>, Never>(0..<0)
     
     var callback: ((HomeScreenViewModelAction) -> Void)?
     
@@ -50,6 +56,14 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 default:
                     break
                 }
+            }
+            .store(in: &cancellables)
+        
+        visibleItemRangePublisher
+            .debounce(for: 0.1, scheduler: RunLoop.main)
+            .removeDuplicates()
+            .sink { range in
+                self.updateVisibleRange(range)
             }
             .store(in: &cancellables)
         
@@ -136,8 +150,8 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             callback?(.presentSessionVerificationScreen)
         case .skipSessionVerification:
             state.showSessionVerificationBanner = false
-        case .updatedVisibleItemIdentifiers(let identifiers):
-            updateVisibleRange(visibleItemIdentifiers: identifiers)
+        case .updatedVisibleItemRange(let range):
+            visibleItemRangePublisher.send(range)
         }
     }
     
@@ -226,19 +240,17 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                               avatar: avatarImage)
     }
     
-    private func updateVisibleRange(visibleItemIdentifiers items: Set<String>) {
-        let result = items.compactMap { itemIdentifier in
-            state.rooms.firstIndex { $0.id == itemIdentifier }
-        }.sorted()
+    private func updateVisibleRange(_ range: Range<Int>) {
+        guard !range.isEmpty else { return }
         
-        guard !result.isEmpty else {
+        guard let visibleRoomsSummaryProvider else {
+            MXLog.error("Visible rooms summary provider unavailable")
             return
         }
         
-        guard let lowerBound = result.first, let upperBound = result.last else {
-            return
-        }
+        let lowerBound = max(0, range.lowerBound - Constants.slidingWindowBoundsPadding)
+        let upperBound = min(Int(visibleRoomsSummaryProvider.countPublisher.value), range.upperBound + Constants.slidingWindowBoundsPadding)
         
-        visibleRoomsSummaryProvider?.updateVisibleRange(lowerBound...upperBound)
+        visibleRoomsSummaryProvider.updateVisibleRange(lowerBound..<upperBound)
     }
 }

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -126,14 +126,10 @@ class ClientProxy: ClientProxyProtocol {
             return
         }
         
-        slidingSync?.setObserver(observer: WeakClientProxyWrapper(clientProxy: self))
         slidingSyncObserverToken = slidingSync?.sync()
     }
     
     func stopSync() {
-        client.setDelegate(delegate: nil)
-        
-        slidingSync?.setObserver(observer: nil)
         slidingSyncObserverToken?.cancel()
         slidingSyncObserverToken = nil
     }
@@ -236,8 +232,7 @@ class ClientProxy: ClientProxyProtocol {
     // MARK: Private
     
     private func restartSync() {
-        slidingSyncObserverToken?.cancel()
-        slidingSync?.setObserver(observer: WeakClientProxyWrapper(clientProxy: self))
+        stopSync()
         slidingSyncObserverToken = slidingSync?.sync()
     }
     
@@ -253,6 +248,9 @@ class ClientProxy: ClientProxyProtocol {
                 .withCommonExtensions()
                 .coldCache(name: "ElementX")
                 .build()
+            
+            slidingSync.setObserver(observer: WeakClientProxyWrapper(clientProxy: self))
+            
             self.slidingSync = slidingSync
             
             configureSlidingSyncViews(slidingSync: slidingSync)

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -46,9 +46,6 @@ private class WeakClientProxyWrapper: ClientDelegate, SlidingSyncObserver {
 }
 
 class ClientProxy: ClientProxyProtocol {
-    /// The maximum number of timeline events required during a sync request.
-    static let syncLimit: UInt16 = 50
-    
     private let client: ClientProtocol
     private let backgroundTaskService: BackgroundTaskServiceProtocol
     private var sessionVerificationControllerProxy: SessionVerificationControllerProxy?
@@ -58,9 +55,13 @@ class ClientProxy: ClientProxyProtocol {
     private var slidingSyncObserverToken: StoppableSpawn?
     private var slidingSync: SlidingSync?
     
+    var visibleRoomsSlidingSyncView: SlidingSyncViewProtocol?
     var visibleRoomsSummaryProvider: RoomSummaryProviderProtocol?
     
+    var allRoomsSlidingSyncView: SlidingSyncViewProtocol?
     var allRoomsSummaryProvider: RoomSummaryProviderProtocol?
+    
+    private var cancellables = Set<AnyCancellable>()
     
     deinit {
         // These need to be inlined instead of using stopSync()
@@ -72,77 +73,16 @@ class ClientProxy: ClientProxyProtocol {
     
     let callbacks = PassthroughSubject<ClientProxyCallback, Never>()
     
-    // swiftlint:disable:next function_body_length
-    init(client: ClientProtocol,
-         backgroundTaskService: BackgroundTaskServiceProtocol) async {
+    init(client: ClientProtocol, backgroundTaskService: BackgroundTaskServiceProtocol) async {
         self.client = client
         self.backgroundTaskService = backgroundTaskService
-        clientQueue = .init(label: "ClientProxyQueue",
-                            attributes: .concurrent)
-        mediaProxy = MediaProxy(client: client,
-                                clientQueue: clientQueue)
+        clientQueue = .init(label: "ClientProxyQueue", attributes: .concurrent)
         
-        await Task.dispatch(on: clientQueue) {
-            do {
-                let slidingSyncBuilder = try client.slidingSync().homeserver(url: ServiceLocator.shared.settings.slidingSyncProxyBaseURLString)
-                
-                let requiredState = [RequiredState(key: "m.room.avatar", value: ""),
-                                     RequiredState(key: "m.room.encryption", value: "")]
-                
-                let filters = SlidingSyncRequestListFilters(isDm: nil,
-                                                            spaces: [],
-                                                            isEncrypted: nil,
-                                                            isInvite: false,
-                                                            isTombstoned: false,
-                                                            roomTypes: [],
-                                                            notRoomTypes: ["m.space"],
-                                                            roomNameLike: nil,
-                                                            tags: [],
-                                                            notTags: [])
-                
-                let visibleRoomsView = try SlidingSyncViewBuilder()
-                    .timelineLimit(limit: 20)
-                    .requiredState(requiredState: requiredState)
-                    .filters(filters: filters)
-                    .name(name: "CurrentlyVisibleRooms")
-                    .syncMode(mode: .selective)
-                    .addRange(from: 0, to: 20)
-                    .build()
-                
-                let allRoomsView = try SlidingSyncViewBuilder()
-                    .noTimelineLimit()
-                    .requiredState(requiredState: requiredState)
-                    .filters(filters: filters)
-                    .name(name: "AllRooms")
-                    .syncMode(mode: .growingFullSync)
-                    .batchSize(batchSize: 100)
-                    .roomLimit(limit: 500)
-                    .build()
-
-                let slidingSync = try slidingSyncBuilder
-                    .addView(v: visibleRoomsView)
-                    .addView(v: allRoomsView)
-                    .withCommonExtensions()
-                    .coldCache(name: "ElementX")
-                    .build()
-                
-                let visibleRoomsViewProxy = SlidingSyncViewProxy(clientProxy: self, slidingSync: slidingSync, slidingSyncView: visibleRoomsView)
-                
-                let allRoomsViewProxy = SlidingSyncViewProxy(clientProxy: self, slidingSync: slidingSync, slidingSyncView: allRoomsView)
-                
-                self.visibleRoomsSummaryProvider = RoomSummaryProvider(slidingSyncViewProxy: visibleRoomsViewProxy,
-                                                                       roomMessageFactory: RoomMessageFactory())
-                
-                self.allRoomsSummaryProvider = RoomSummaryProvider(slidingSyncViewProxy: allRoomsViewProxy,
-                                                                   roomMessageFactory: RoomMessageFactory())
-                
-                self.slidingSync = slidingSync
-            } catch {
-                MXLog.error("Failed configuring sliding sync with error: \(error)")
-            }
-        }
-
+        mediaProxy = MediaProxy(client: client, clientQueue: clientQueue)
+        
         client.setDelegate(delegate: WeakClientProxyWrapper(clientProxy: self))
+        
+        configureSlidingSync()
     }
     
     var userIdentifier: String {
@@ -297,6 +237,109 @@ class ClientProxy: ClientProxyProtocol {
     }
     
     // MARK: Private
+    
+    private func configureSlidingSync() {
+        do {
+            let slidingSyncBuilder = try client.slidingSync().homeserver(url: ServiceLocator.shared.settings.slidingSyncProxyBaseURLString)
+            
+            let slidingSync = try slidingSyncBuilder
+                .withCommonExtensions()
+                .coldCache(name: "ElementX")
+                .build()
+            self.slidingSync = slidingSync
+            
+            configureSlidingSyncViews(slidingSync: slidingSync)
+            
+            guard let visibleRoomsSlidingSyncView else {
+                MXLog.error("Visible rooms sliding sync view unavailable")
+                return
+            }
+            
+            registerSlidingSyncView(visibleRoomsSlidingSyncView)
+            
+        } catch {
+            MXLog.error("Failed building sliding sync with error: \(error)")
+        }
+    }
+    
+    // swiftlint:disable:next function_body_length
+    private func configureSlidingSyncViews(slidingSync: SlidingSyncProtocol) {
+        let requiredState = [RequiredState(key: "m.room.avatar", value: ""),
+                             RequiredState(key: "m.room.encryption", value: "")]
+        
+        let filters = SlidingSyncRequestListFilters(isDm: nil,
+                                                    spaces: [],
+                                                    isEncrypted: nil,
+                                                    isInvite: false,
+                                                    isTombstoned: false,
+                                                    roomTypes: [],
+                                                    notRoomTypes: ["m.space"],
+                                                    roomNameLike: nil,
+                                                    tags: [],
+                                                    notTags: [])
+        
+        do {
+            let visibleRoomsView = try SlidingSyncViewBuilder()
+                .timelineLimit(limit: 20)
+                .requiredState(requiredState: requiredState)
+                .filters(filters: filters)
+                .name(name: "CurrentlyVisibleRooms")
+                .syncMode(mode: .selective)
+                .addRange(from: 0, to: 20)
+                .build()
+            
+            let allRoomsView = try SlidingSyncViewBuilder()
+                .noTimelineLimit()
+                .requiredState(requiredState: requiredState)
+                .filters(filters: filters)
+                .name(name: "AllRooms")
+                .syncMode(mode: .growingFullSync)
+                .batchSize(batchSize: 100)
+                .roomLimit(limit: 500)
+                .build()
+            
+            let visibleRoomsViewProxy = SlidingSyncViewProxy(slidingSync: slidingSync, slidingSyncView: visibleRoomsView)
+            
+            let allRoomsViewProxy = SlidingSyncViewProxy(slidingSync: slidingSync, slidingSyncView: allRoomsView)
+            
+            visibleRoomsSummaryProvider = RoomSummaryProvider(slidingSyncViewProxy: visibleRoomsViewProxy,
+                                                              roomMessageFactory: RoomMessageFactory())
+            
+            allRoomsSummaryProvider = RoomSummaryProvider(slidingSyncViewProxy: allRoomsViewProxy,
+                                                          roomMessageFactory: RoomMessageFactory())
+            
+            visibleRoomsViewProxy.visibleRangeUpdatePublisher.sink { [weak self] in
+                self?.restartSync()
+            }
+            .store(in: &cancellables)
+            
+            visibleRoomsViewProxy.statePublisher.sink { [weak self] state in
+                if state == .live {
+                    self?.registerAllRoomSlidingSyncView()
+                }
+            }
+            .store(in: &cancellables)
+            
+            visibleRoomsSlidingSyncView = visibleRoomsView
+            allRoomsSlidingSyncView = allRoomsView
+            
+        } catch {
+            MXLog.error("Failed building sliding sync views with error: \(error)")
+        }
+    }
+    
+    private func registerAllRoomSlidingSyncView() {
+        guard let allRoomsSlidingSyncView else {
+            MXLog.error("All rooms sliding sync view unavailable")
+            return
+        }
+        
+        registerSlidingSyncView(allRoomsSlidingSyncView)
+    }
+    
+    private func registerSlidingSyncView(_ view: SlidingSyncViewProtocol) {
+        
+    }
 
     private func roomTupleForIdentifier(_ identifier: String) -> (SlidingSyncRoom?, Room?) {
         do {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -233,7 +233,7 @@ class ClientProxy: ClientProxyProtocol {
     
     private func restartSync() {
         stopSync()
-        slidingSyncObserverToken = slidingSync?.sync()
+        startSync()
     }
     
     private func configureSlidingSync() {

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -79,8 +79,6 @@ protocol ClientProxyProtocol: AnyObject, MediaProxyProtocol {
     
     func stopSync()
     
-    func restartSync()
-    
     func roomForIdentifier(_ identifier: String) async -> RoomProxyProtocol?
     
     func loadUserDisplayName() async -> Result<String, ClientProxyError>

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -40,8 +40,6 @@ class MockClientProxy: ClientProxyProtocol {
     
     func stopSync() { }
     
-    func restartSync() { }
-    
     func roomForIdentifier(_ identifier: String) async -> RoomProxyProtocol? {
         guard let room = visibleRoomsSummaryProvider?.roomListPublisher.value.first(where: { $0.id == identifier }) else {
             return nil

--- a/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
+++ b/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
@@ -51,7 +51,6 @@ private class SlidingSyncViewObserver: SlidingSyncViewRoomListObserver, SlidingS
 }
 
 class SlidingSyncViewProxy {
-    private weak var clientProxy: ClientProxyProtocol?
     private let slidingSync: SlidingSyncProtocol
     private let slidingSyncView: SlidingSyncViewProtocol
     
@@ -64,6 +63,7 @@ class SlidingSyncViewProxy {
     let diffPublisher = PassthroughSubject<SlidingSyncViewRoomsListDiff, Never>()
     let statePublisher = PassthroughSubject<SlidingSyncState, Never>()
     let countPublisher = PassthroughSubject<UInt, Never>()
+    let visibleRangeUpdatePublisher = PassthroughSubject<Void, Never>()
     
     deinit {
         listUpdateObserverToken?.cancel()
@@ -71,8 +71,7 @@ class SlidingSyncViewProxy {
         countUpdateObserverToken?.cancel()
     }
     
-    init(clientProxy: ClientProxyProtocol, slidingSync: SlidingSyncProtocol, slidingSyncView: SlidingSyncViewProtocol) {
-        self.clientProxy = clientProxy
+    init(slidingSync: SlidingSyncProtocol, slidingSyncView: SlidingSyncViewProtocol) {
         self.slidingSync = slidingSync
         self.slidingSyncView = slidingSyncView
         
@@ -108,6 +107,6 @@ class SlidingSyncViewProxy {
         
         slidingSyncView.setRange(start: UInt32(range.lowerBound), end: UInt32(range.upperBound))
         
-        clientProxy?.restartSync()
+        visibleRangeUpdatePublisher.send(())
     }
 }

--- a/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
+++ b/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
@@ -102,7 +102,7 @@ class SlidingSyncViewProxy {
         try slidingSync.getRoom(roomId: identifier)
     }
     
-    func updateVisibleRange(_ range: ClosedRange<Int>) {
+    func updateVisibleRange(_ range: Range<Int>) {
         MXLog.info("Setting sliding sync view range to \(range)")
         
         slidingSyncView.setRange(start: UInt32(range.lowerBound), end: UInt32(range.upperBound))

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
@@ -46,7 +46,7 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
     
     func updateRoomsWithIdentifiers(_ identifiers: [String]) { }
     
-    func updateVisibleRange(_ range: ClosedRange<Int>) { }
+    func updateVisibleRange(_ range: Range<Int>) { }
     
     // MARK: - Private
     

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -68,7 +68,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         }
     }
     
-    func updateVisibleRange(_ range: ClosedRange<Int>) {
+    func updateVisibleRange(_ range: Range<Int>) {
         slidingSyncViewProxy.updateVisibleRange(range)
     }
     

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -181,6 +181,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         }
     }
     
+    // swiftlint:disable:next cyclomatic_complexity
     private func buildDiff(from diff: SlidingSyncViewRoomsListDiff, on rooms: [RoomSummary]) -> CollectionDifference<RoomSummary>? {
         var changes = [CollectionDifference<RoomSummary>.Change]()
         
@@ -216,6 +217,18 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
             for (index, value) in values.enumerated() {
                 changes.append(.insert(offset: index, element: buildSummaryForRoomListEntry(value), associatedWith: nil))
             }
+        case .clear:
+            MXLog.verbose("Clear all items, current total count: \(rooms.count)")
+            for (index, value) in rooms.enumerated() {
+                changes.append(.remove(offset: index, element: value, associatedWith: nil))
+            }
+        case .pop:
+            MXLog.verbose("Pop, current total count: \(rooms.count)")
+            guard let value = rooms.last else {
+                fatalError()
+            }
+            
+            changes.append(.remove(offset: rooms.count - 1, element: value, associatedWith: nil))
         }
         
         return CollectionDifference(changes)

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
@@ -55,5 +55,5 @@ protocol RoomSummaryProviderProtocol {
     /// - Parameter identifiers: the identifiers for the rooms that have changed
     func updateRoomsWithIdentifiers(_ identifiers: [String])
     
-    func updateVisibleRange(_ range: ClosedRange<Int>)
+    func updateVisibleRange(_ range: Range<Int>)
 }

--- a/project.yml
+++ b/project.yml
@@ -40,7 +40,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.28-alpha
+    exactVersion: 1.0.30-alpha
     # path: ../matrix-rust-sdk
   DesignKit:
     path: ./


### PR DESCRIPTION
- [x] refactor the sliding sync setup and make so it's possibly to add views to it later
- [x] implement pop and clear diff support on the room summary provider
- [x] use allRoomsView room summaries for invalidated visibleRoomsView entries
- [x] switch visible range setting from the ScrollViewAdapter to a publisher + debounce
- [ ] ~fix room subscriptions on entering~ currently broken rust side
- [ ] ~fix visibleRoomsView going into live before any networking is done (rust side)~ switched to waiting for the first diff update

