### PR TITLE
Fixes #388 - Prevent long room names from breaking the room navigatio…

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -31,7 +31,7 @@ enum RoomScreenComposerMode: Equatable {
 }
 
 enum RoomScreenViewAction {
-    case headerTapped
+    case displayRoomDetails
     case displayEmojiPicker(itemId: String)
     case paginateBackwards
     case itemAppeared(id: String)

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -94,7 +94,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     // swiftlint:disable:next cyclomatic_complexity
     override func process(viewAction: RoomScreenViewAction) async {
         switch viewAction {
-        case .headerTapped:
+        case .displayRoomDetails:
             callback?(.displayRoomDetails)
         case .paginateBackwards:
             await paginateBackwards()

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
@@ -24,16 +24,16 @@ struct RoomHeaderView: View {
     @ObservedObject var context: RoomScreenViewModel.Context
 
     var body: some View {
-        Button {
-            context.send(viewAction: .headerTapped)
-        } label: {
-            HStack(spacing: 8) {
-                roomAvatar
-                    .accessibilityHidden(true)
-                Text(context.viewState.roomTitle)
-                    .font(.element.headline)
-                    .accessibilityIdentifier("roomNameLabel")
-            }
+        HStack(spacing: 8) {
+            roomAvatar
+                .accessibilityHidden(true)
+            Text(context.viewState.roomTitle)
+                .font(.element.headline)
+                .accessibilityIdentifier("roomNameLabel")
+        }
+        // Using a button stops is from getting truncated in the navigation bar
+        .onTapGesture {
+            context.send(viewAction: .displayRoomDetails)
         }
     }
 

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -75,9 +75,20 @@ struct RoomScreen: View {
         }
     }
     
+    @ToolbarContentBuilder
     var toolbar: some ToolbarContent {
-        ToolbarItem(placement: .navigationBarLeading) {
+        // .principal + .primaryAction works better than .navigation leading + trailing
+        // as the latter disables interaction in the action button for rooms with long names
+        ToolbarItem(placement: .principal) {
             RoomHeaderView(context: context)
+        }
+        
+        ToolbarItem(placement: .primaryAction) {
+            Button {
+                context.send(viewAction: .displayRoomDetails)
+            } label: {
+                Image(systemName: "ellipsis.circle")
+            }
         }
     }
     

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -83,11 +83,11 @@ struct RoomScreen: View {
             RoomHeaderView(context: context)
         }
         
-        ToolbarItem(placement: .primaryAction) {
+        ToolbarItem(id: "RoomDetailsAction", placement: .secondaryAction, showsByDefault: false) {
             Button {
                 context.send(viewAction: .displayRoomDetails)
             } label: {
-                Image(systemName: "ellipsis.circle")
+                Label("Room Details", systemImage: "info.circle")
             }
         }
     }

--- a/changelog.d/388.bugfix
+++ b/changelog.d/388.bugfix
@@ -1,0 +1,1 @@
+Prevent long room names from breaking the room navigation bar layout


### PR DESCRIPTION
…n bar layout

<img width="392" alt="Screenshot 2023-01-15 at 19 35 15" src="https://user-images.githubusercontent.com/637564/212557244-20fd5879-42d9-4577-896f-a97ac9030752.png">


