### PR TITLE
Sliding sync tweaks

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -143,6 +143,7 @@ class AppCoordinator: AppCoordinatorProtocol {
                 self.restoreUserSession()
             case (.restoringSession, .failedRestoringSession, .signedOut):
                 self.showLoginErrorToast()
+                self.presentSplashScreen(isSoftLogout: false)
             case (.restoringSession, .succeededRestoringSession, .signedIn):
                 self.hideLoadingIndicator()
                 self.setupUserSession()

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -391,6 +391,8 @@ class AppCoordinator: AppCoordinatorProtocol {
 
     @objc
     private func applicationWillResignActive() {
+        MXLog.info("Application will resign active")
+        
         guard backgroundTask == nil else {
             return
         }
@@ -405,6 +407,8 @@ class AppCoordinator: AppCoordinatorProtocol {
 
     @objc
     private func applicationDidBecomeActive() {
+        MXLog.info("Application did become active")
+        
         backgroundTask?.stop()
         backgroundTask = nil
 
@@ -417,6 +421,8 @@ class AppCoordinator: AppCoordinatorProtocol {
     private func observeNetworkState() {
         let reachabilityNotificationIdentifier = "io.element.elementx.reachability.notification"
         ServiceLocator.shared.networkMonitor.reachabilityPublisher.sink { reachable in
+            MXLog.info("Reachability changed to \(reachable)")
+            
             if reachable {
                 ServiceLocator.shared.userNotificationController.retractNotificationWithId(reachabilityNotificationIdentifier)
             } else {

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -42,9 +42,18 @@ enum HomeScreenViewAction {
     case updatedVisibleItemRange(Range<Int>)
 }
 
-enum HomeScreenRoomListMode {
+enum HomeScreenRoomListMode: CustomStringConvertible {
     case skeletons
     case rooms
+    
+    var description: String {
+        switch self {
+        case .rooms:
+            return "Showing rooms"
+        case .skeletons:
+            return "Showing placeholders"
+        }
+    }
 }
 
 struct HomeScreenViewState: BindableState {

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -60,7 +60,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             .store(in: &cancellables)
         
         visibleItemRangePublisher
-            .debounce(for: 0.1, scheduler: RunLoop.main)
+            .debounce(for: 0.1, scheduler: DispatchQueue.main)
             .removeDuplicates()
             .sink { range in
                 self.updateVisibleRange(range)
@@ -245,7 +245,8 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
     }
     
     private func updateVisibleRange(_ range: Range<Int>) {
-        guard !range.isEmpty else { return }
+        guard visibleRoomsSummaryProvider?.statePublisher.value == .live,
+              !range.isEmpty else { return }
         
         guard let visibleRoomsSummaryProvider else {
             MXLog.error("Visible rooms summary provider unavailable")

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -35,7 +35,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
     
     // MARK: - Setup
     
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     init(userSession: UserSessionProtocol, attributedStringBuilder: AttributedStringBuilderProtocol) {
         self.userSession = userSession
         self.attributedStringBuilder = attributedStringBuilder

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -205,7 +205,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             case .empty, .invalidated:
                 guard let allRoomsRoomSummary = allRoomsSummaryProvider?.roomListPublisher.value[safe: index] else {
                     if case let .invalidated(details) = summary {
-                        rooms.append(buildRoom(with: details, invalidated: false))
+                        rooms.append(buildRoom(with: details))
                     } else {
                         rooms.append(HomeScreenRoom.placeholder())
                     }
@@ -216,18 +216,17 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 case .empty:
                     rooms.append(HomeScreenRoom.placeholder())
                 case .filled(let details), .invalidated(let details):
-                    let room = buildRoom(with: details, invalidated: true)
-                    rooms.append(room)
+                    rooms.append(buildRoom(with: details))
                 }
             case .filled(let details):
-                rooms.append(buildRoom(with: details, invalidated: false))
+                rooms.append(buildRoom(with: details))
             }
         }
         
         state.rooms = rooms
     }
     
-    private func buildRoom(with details: RoomSummaryDetails, invalidated: Bool) -> HomeScreenRoom {
+    private func buildRoom(with details: RoomSummaryDetails) -> HomeScreenRoom {
         let avatarImage = details.avatarURL.flatMap { userSession.mediaProvider.imageFromURL($0, avatarSize: .room(on: .home)) }
         
         var timestamp: String?
@@ -235,8 +234,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             timestamp = lastMessageTimestamp.formatted(date: .omitted, time: .shortened)
         }
         
-        let identifier = invalidated ? "invalidated-" + details.id : details.id
-        return HomeScreenRoom(id: identifier,
+        return HomeScreenRoom(id: details.id,
                               roomId: details.id,
                               name: details.name,
                               hasUnreads: details.unreadNotificationCount > 0,

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -92,16 +92,27 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                                   visibleRoomsSummaryProvider.roomListPublisher)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state, totalCount, rooms in
+                guard let self = self else { return }
+                
                 let isLoadingData = state != .live && (totalCount == 0 || rooms.count != totalCount)
                 let hasNoRooms = state == .live && totalCount == 0
                 
+                var newState = self.state.roomListMode
                 if isLoadingData {
-                    self?.state.roomListMode = .skeletons
+                    newState = .skeletons
                 } else if hasNoRooms {
-                    self?.state.roomListMode = .skeletons
+                    newState = .skeletons
                 } else {
-                    self?.state.roomListMode = .rooms
+                    newState = .rooms
                 }
+                
+                guard newState != self.state.roomListMode else {
+                    return
+                }
+                
+                self.state.roomListMode = newState
+                
+                MXLog.info("Received visibleRoomsSummaryProvider update, setting view room list mode to \"\(self.state.roomListMode)\"")
             }
             .store(in: &cancellables)
         

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -336,23 +336,19 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
     
-    private lazy var slidingSyncRequiredState: [RequiredState] = {
-        [RequiredState(key: "m.room.avatar", value: ""),
-         RequiredState(key: "m.room.encryption", value: "")]
-    }()
+    private lazy var slidingSyncRequiredState = [RequiredState(key: "m.room.avatar", value: ""),
+                                                 RequiredState(key: "m.room.encryption", value: "")]
     
-    private lazy var slidingSyncFilters: SlidingSyncRequestListFilters = {
-        SlidingSyncRequestListFilters(isDm: nil,
-                                      spaces: [],
-                                      isEncrypted: nil,
-                                      isInvite: false,
-                                      isTombstoned: false,
-                                      roomTypes: [],
-                                      notRoomTypes: ["m.space"],
-                                      roomNameLike: nil,
-                                      tags: [],
-                                      notTags: [])
-    }()
+    private lazy var slidingSyncFilters = SlidingSyncRequestListFilters(isDm: nil,
+                                                                        spaces: [],
+                                                                        isEncrypted: nil,
+                                                                        isInvite: false,
+                                                                        isTombstoned: false,
+                                                                        roomTypes: [],
+                                                                        notRoomTypes: ["m.space"],
+                                                                        roomNameLike: nil,
+                                                                        tags: [],
+                                                                        notTags: [])
     
     private func registerAllRoomSlidingSyncView() {
         guard let allRoomsSlidingSyncView else {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -31,16 +31,23 @@ private class WeakClientProxyWrapper: ClientDelegate, SlidingSyncObserver {
     func didReceiveSyncUpdate() { }
 
     func didReceiveAuthError(isSoftLogout: Bool) {
+        MXLog.error("Received authentication error, softlogout=\(isSoftLogout)")
         clientProxy?.didReceiveAuthError(isSoftLogout: isSoftLogout)
     }
 
     func didUpdateRestoreToken() {
+        MXLog.info("Did update restoration token")
         clientProxy?.didUpdateRestoreToken()
     }
     
     // MARK: - SlidingSyncDelegate
     
     func didReceiveSyncUpdate(summary: UpdateSummary) {
+        if summary.views.isEmpty, summary.rooms.isEmpty {
+            return
+        }
+        
+        MXLog.info("Received sliding sync update")
         clientProxy?.didReceiveSlidingSyncUpdate(summary: summary)
     }
 }
@@ -122,6 +129,7 @@ class ClientProxy: ClientProxyProtocol {
     }
     
     func startSync() {
+        MXLog.info("Starting sync")
         guard !client.isSoftLogout(), slidingSyncObserverToken == nil else {
             return
         }
@@ -130,6 +138,7 @@ class ClientProxy: ClientProxyProtocol {
     }
     
     func stopSync() {
+        MXLog.info("Stopping sync")
         slidingSyncObserverToken?.cancel()
         slidingSyncObserverToken = nil
     }
@@ -238,6 +247,7 @@ class ClientProxy: ClientProxyProtocol {
     // MARK: Private
     
     private func restartSync() {
+        MXLog.info("Restarting sync")
         stopSync()
         startSync()
     }
@@ -293,6 +303,7 @@ class ClientProxy: ClientProxyProtocol {
         
         // The allRoomsSlidingSyncView will be registered as soon as the visibleRoomsSlidingSyncView receives its first update
         visibleRoomsViewProxyStateObservationToken = visibleRoomsViewProxy.diffPublisher.sink { [weak self] _ in
+            MXLog.info("Visible rooms view received first update, registering all rooms view")
             self?.registerAllRoomSlidingSyncView()
             self?.visibleRoomsViewProxyStateObservationToken = nil
         }


### PR DESCRIPTION
* fix the splash screen not being shown after a session restoration error
* fix the cold cache for the visible rooms view
* remove custom room identifiers for invalid rooms (we still have duplicates on filled rooms)
* fixed the visible range debouncer, using the main run loop was wrong
* add more tracing