### PR TITLE
Small tweaks

### DIFF
--- a/ElementX/Sources/Screens/EmojiPickerScreen/View/EmojiPickerHeaderView.swift
+++ b/ElementX/Sources/Screens/EmojiPickerScreen/View/EmojiPickerHeaderView.swift
@@ -22,6 +22,8 @@ struct EmojiPickerHeaderView: View {
     var body: some View {
         HStack {
             Text(title)
+                .font(.element.subheadline.bold())
+                .foregroundColor(.element.primaryContent)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
     }

--- a/ElementX/Sources/Screens/EmojiPickerScreen/View/EmojiPickerScreen.swift
+++ b/ElementX/Sources/Screens/EmojiPickerScreen/View/EmojiPickerScreen.swift
@@ -19,24 +19,27 @@ import SwiftUI
 struct EmojiPickerScreen: View {
     @ObservedObject var context: EmojiPickerScreenViewModel.Context
     @State var searchString = ""
+    @ScaledMetric(relativeTo: .title) var minimumWidth: Double = 50
     
     var body: some View {
         ScrollView {
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 45))], spacing: 3) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: minimumWidth))], spacing: 16) {
                 ForEach(context.viewState.categories) { category in
                     Section(header: EmojiPickerHeaderView(title: category.name)
                         .padding(.horizontal, 13)
                         .padding(.top, 10)) {
                             ForEach(category.emojis) { emoji in
-                                Text(emoji.value)
-                                    .frame(width: 45, height: 45)
-                                    .onTapGesture {
-                                        context.send(viewAction: .emojiTapped(emoji: emoji))
-                                    }
+                                Button {
+                                    context.send(viewAction: .emojiTapped(emoji: emoji))
+                                } label: {
+                                    Text(emoji.value)
+                                        .font(.element.title1)
+                                }
                             }
                         }
                 }
             }
+            .padding(.horizontal, 6)
         }
         .navigationTitle(ElementL10n.reactions)
         .navigationBarTitleDisplayMode(.inline)
@@ -65,5 +68,6 @@ struct EmojiPickerScreen_Previews: PreviewProvider {
         NavigationStack {
             EmojiPickerScreen(context: EmojiPickerScreenViewModel(emojiProvider: EmojiProvider()).context)
         }
+        .tint(.element.accent)
     }
 }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -67,6 +67,7 @@ struct HomeScreen: View {
                 .disableAutocorrection(true)
             }
         }
+        .scrollDismissesKeyboard(.immediately)
         .disabled(context.viewState.roomListMode == .skeletons)
         .animation(.elementDefault, value: context.viewState.showSessionVerificationBanner)
         .animation(.elementDefault, value: context.viewState.roomListMode)


### PR DESCRIPTION
- Fixes #449 by dismissing the keyboard when scrolling a room search.
- Make the reactions larger in the picker and use a `Button` for voiceover.

| Old Layout | Updated Layout |
| - | - |
| ![Simulator Screen Shot - iPhone 14 - 2023-01-23 at 17 51 46](https://user-images.githubusercontent.com/6060466/214113770-2382b34c-6ee1-444c-98c9-1da67f5302e7.png) | ![Simulator Screen Shot - iPhone 14 - 2023-01-23 at 17 37 11](https://user-images.githubusercontent.com/6060466/214113779-e58e5e17-c3ab-4fdd-9340-6a39d4d05f62.png) |
