### PR TITLE
Sliding sync tweaks

### DIFF
--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "a119a8f16bbe3adc34cfdf2e092886d44e01705a",
-        "version" : "1.0.32-alpha"
+        "revision" : "2d702d0d52805e4f81924507b39ad81c8a74a63f",
+        "version" : "1.0.33-alpha"
       }
     },
     {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -252,7 +252,7 @@ class ClientProxy: ClientProxyProtocol {
             // Build the visibleRoomsSlidingSyncView here so that it can take advantage of the SS builder cold cache
             // We will still register the allRoomsSlidingSyncView later, and than will have no cache
             let visibleRoomsView = try SlidingSyncViewBuilder()
-                .timelineLimit(limit: 20)
+                .timelineLimit(limit: 1)
                 .requiredState(requiredState: slidingSyncRequiredState)
                 .filters(filters: slidingSyncFilters)
                 .name(name: "CurrentlyVisibleRooms")

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -311,7 +311,6 @@ class ClientProxy: ClientProxyProtocol {
                 .name(name: "AllRooms")
                 .syncMode(mode: .growingFullSync)
                 .batchSize(batchSize: 100)
-                .roomLimit(limit: 500)
                 .sendUpdatesForItems(enable: true)
                 .build()
             

--- a/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
+++ b/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
@@ -31,7 +31,7 @@ private class SlidingSyncViewObserver: SlidingSyncViewRoomListObserver, SlidingS
     // MARK: - SlidingSyncViewRoomListObserver
     
     func didReceiveUpdate(diff: SlidingSyncViewRoomsListDiff) {
-        MXLog.info("Received room diff")
+        MXLog.verbose("Received room diff")
         roomListDiffPublisher.send(diff)
     }
     

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
@@ -44,8 +44,6 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
         }
     }
     
-    func updateRoomsWithIdentifiers(_ identifiers: [String]) { }
-    
     func updateVisibleRange(_ range: Range<Int>) { }
     
     // MARK: - Private

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
@@ -49,11 +49,6 @@ protocol RoomSummaryProviderProtocol {
     
     /// Publishes the total number of rooms
     var countPublisher: CurrentValueSubject<UInt, Never> { get }
-    
-    /// Invoked by the sliding sync controller whenever certain rooms have updated
-    /// without necessarily changing their position in the list
-    /// - Parameter identifiers: the identifiers for the rooms that have changed
-    func updateRoomsWithIdentifiers(_ identifiers: [String])
-    
+        
     func updateVisibleRange(_ range: Range<Int>)
 }

--- a/ElementX/Sources/Services/UserSession/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStore.swift
@@ -108,6 +108,7 @@ class UserSessionStore: UserSessionStoreProtocol {
             .username(username: credentials.userID)
             .homeserverUrl(url: credentials.restorationToken.session.homeserverUrl)
             .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent() ?? "unknown")
+            .serverVersions(versions: ["v1.0", "v1.1", "v1.2", "v1.3", "v1.4", "v1.5"]) // FIXME: Quick and dirty fix for stopping version requests on startup https://github.com/matrix-org/matrix-rust-sdk/pull/1376
 
         do {
             let client: Client = try await Task.dispatch(on: .global()) {


### PR DESCRIPTION
* Stop updating room list items based on sliding sync identifier changes
* Remove 500 room hard limit from the all rooms view
* Hardcode server versions
* Drop the timeline limit to 1 on the visible rooms view