### PR TITLE
Workaround #418 - Allow swiping back from file previews

### DIFF
--- a/ElementX/Sources/Screens/FilePreview/View/FilePreviewScreen.swift
+++ b/ElementX/Sources/Screens/FilePreview/View/FilePreviewScreen.swift
@@ -22,10 +22,20 @@ struct FilePreviewScreen: View {
     @ObservedObject var context: FilePreviewViewModel.Context
     
     var body: some View {
-        PreviewView(context: context,
-                    fileURL: context.viewState.fileURL,
-                    title: context.viewState.title)
-            .ignoresSafeArea()
+        ZStack(alignment: .leading) {
+            PreviewView(context: context,
+                        fileURL: context.viewState.fileURL,
+                        title: context.viewState.title)
+                .ignoresSafeArea()
+            
+            // Drop a random view on top to make QLPreviewController stop
+            // swallowing all gestures and allow swiping backwards
+            Rectangle()
+                .frame(maxWidth: 20.0)
+                .foregroundColor(.red)
+                .opacity(0.005)
+                .ignoresSafeArea()
+        }
     }
 }
 
@@ -37,12 +47,6 @@ private struct PreviewView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UINavigationController {
         let controller = QLPreviewController()
         controller.dataSource = context.coordinator
-        
-        let doneButton = UIBarButtonItem(title: "Done",
-                                         style: .done,
-                                         target: context.coordinator,
-                                         action: #selector(Coordinator.done))
-        controller.navigationItem.rightBarButtonItem = doneButton
 
         return UINavigationController(rootViewController: controller)
     }

--- a/ElementX/Sources/Screens/FilePreview/View/FilePreviewScreen.swift
+++ b/ElementX/Sources/Screens/FilePreview/View/FilePreviewScreen.swift
@@ -26,7 +26,7 @@ struct FilePreviewScreen: View {
             PreviewView(context: context,
                         fileURL: context.viewState.fileURL,
                         title: context.viewState.title)
-                .ignoresSafeArea()
+                .ignoresSafeArea(edges: .bottom)
             
             // Drop a random view on top to make QLPreviewController stop
             // swallowing all gestures and allow swiping backwards

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -84,10 +84,10 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
         let params = FilePreviewCoordinatorParameters(fileURL: fileURL, title: title)
         let coordinator = FilePreviewCoordinator(parameters: params)
         coordinator.callback = { [weak self] _ in
-            self?.navigationStackCoordinator.setFullScreenCoverCoordinator(nil)
+            self?.navigationStackCoordinator.pop()
         }
         
-        navigationStackCoordinator.setFullScreenCoverCoordinator(coordinator)
+        navigationStackCoordinator.push(coordinator)
     }
     
     private func displayEmojiPickerScreen(for itemId: String) {


### PR DESCRIPTION
After trying to hack my way through the QLPreviewController I basically gave up on the idea
What I did instead was to change the file preview presentation to a stack push and add an extra (invisible) view on top of the hierarchy so that swiping backwards works again. While it's not perfect it's probably better than what we had.