### PR TITLE
Hardcode the sliding sync proxy.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -130,16 +130,16 @@
 		39929D29B265C3F6606047DE /* AlignedScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8872E9C5E91E9F2BFC4EBCCA /* AlignedScrollView.swift */; };
 		3A08584ECDD4A4541DBF21F8 /* EmojiLoaderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201305507D7DFD16E544563A /* EmojiLoaderProtocol.swift */; };
 		3A64A93A651A3CB8774ADE8E /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 21C83087604B154AA30E9A8F /* SnapshotTesting */; };
-		3C549A0BF39F8A854D45D9FD /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 4278261E147DB2DE5CFB7FC5 /* PostHog */; };
+		3C549A0BF39F8A854D45D9FD /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 0DD568A494247444A4B56031 /* Kingfisher */; };
 		3C73442084BF8A6939F0F80B /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5445FCE0CE15E634FDC1A2E2 /* AnalyticsService.swift */; };
 		3DA57CA0D609A6B37CA1DC2F /* BugReportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DC38E64A5ED3FDB201029A /* BugReportService.swift */; };
 		3ED2725734568F6B8CC87544 /* AttributedStringBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5C6FBF97B6EED3D4FA5EFF /* AttributedStringBuilder.swift */; };
 		3F2148F11164C7C5609984EB /* SwiftState in Frameworks */ = {isa = PBXBuildFile; productRef = 19CD5B074D7DD44AF4C58BB6 /* SwiftState */; };
 		3F327A62D233933F54F0F33A /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = BA93CD75CCE486660C9040BD /* Collections */; };
 		3F70E237CE4C3FAB02FC227F /* NotificationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C830A64609CBD152F06E0457 /* NotificationConstants.swift */; };
-		407DCE030E0F9B7C9861D38A /* GZIP in Frameworks */ = {isa = PBXBuildFile; productRef = 997C7385E1A07E061D7E2100 /* GZIP */; };
+		407DCE030E0F9B7C9861D38A /* SwiftState in Frameworks */ = {isa = PBXBuildFile; productRef = 9573B94B1C86C6DF751AF3FD /* SwiftState */; };
 		414F50CFCFEEE2611127DCFB /* RestorationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3558A15CFB934F9229301527 /* RestorationToken.swift */; };
-		41DFDD212D1BE57CA50D783B /* SwiftyBeaver in Frameworks */ = {isa = PBXBuildFile; productRef = FD43A50D9B75C9D6D30F006B /* SwiftyBeaver */; };
+		41DFDD212D1BE57CA50D783B /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 4278261E147DB2DE5CFB7FC5 /* PostHog */; };
 		4219391CD2351E410554B3E8 /* AggregratedReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B858A61F2A570DFB8DE570A7 /* AggregratedReaction.swift */; };
 		42F1C8731166633E35A6D7E6 /* RoomEventStringBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A307A44F952CD73E63AE31 /* RoomEventStringBuilder.swift */; };
 		43BD17BC8794BB9B04F2A26B /* MediaSourceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179423E34EE846E048E49CBF /* MediaSourceProxy.swift */; };
@@ -193,7 +193,7 @@
 		60ED66E63A169E47489348A8 /* GZIP in Frameworks */ = {isa = PBXBuildFile; productRef = 2B788C81F6369D164ADEB917 /* GZIP */; };
 		6126CC51654E159804999E6A /* UNMutableNotificationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5741CD0691019B32FE74CE9E /* UNMutableNotificationContent.swift */; };
 		617624A97BDBB75ED3DD8156 /* RoomScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00C7A331B72C0F05C00392F /* RoomScreenViewModelProtocol.swift */; };
-		6298AB0906DDD3525CD78C6B /* SwiftState in Frameworks */ = {isa = PBXBuildFile; productRef = 9573B94B1C86C6DF751AF3FD /* SwiftState */; };
+		6298AB0906DDD3525CD78C6B /* SwiftyBeaver in Frameworks */ = {isa = PBXBuildFile; productRef = FD43A50D9B75C9D6D30F006B /* SwiftyBeaver */; };
 		63C9AF0FB8278AF1C0388A0C /* TemplateModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB10E673916D2B8D21FD197 /* TemplateModels.swift */; };
 		64F43D7390DA2A0AFD6BA911 /* VideoRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1941C8817E6B6971BA4415F5 /* VideoRoomTimelineView.swift */; };
 		64FF5CB4E35971255872E1BB /* AuthenticationServiceProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0CB536D1C3CC15AA740CC6 /* AuthenticationServiceProxyProtocol.swift */; };
@@ -219,7 +219,7 @@
 		6E47D126DD7585E8F8237CE7 /* LoadableAvatarImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B590BD4507D4F0A377FDE01A /* LoadableAvatarImage.swift */; };
 		6E6E0AAF6C44C0B117EBBE5A /* SlidingSyncViewProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F3B445BD6EF1C751806B22 /* SlidingSyncViewProxy.swift */; };
 		6EC7A40A537CFB3D526A111C /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47EBB5D698CE9A25BB553A2D /* Strings.swift */; };
-		6F2AB43A1EFAD8A97AF41A15 /* DeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = A7CA6F33C553805035C3B114 /* DeviceKit */; };
+		6F2AB43A1EFAD8A97AF41A15 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 9C73F37731C9FDED1BB24C1C /* Collections */; };
 		6FC10A00D268FCD48B631E37 /* ViewFrameReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF7BF82A950B91BC5469E91 /* ViewFrameReader.swift */; };
 		6FF51EB400DBA0668FC38B97 /* TimelineStartRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9ED8E731E21055F728E5FED /* TimelineStartRoomTimelineView.swift */; };
 		7002C55A4C917F3715765127 /* MediaProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C888BCD78E2A55DCE364F160 /* MediaProviderProtocol.swift */; };
@@ -290,7 +290,7 @@
 		8D3E1FADD78E72504DE0E402 /* UserAgentBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3B237387B8288A5A938F1B /* UserAgentBuilderTests.swift */; };
 		8E650379587C31D7912ED67B /* UNNotification+Creator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0AEA686E425F86F6BA0404 /* UNNotification+Creator.swift */; };
 		8EF63DDDC1B54F122070B04D /* ReadMarkerRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6311F21F911E23BE4DF51B4 /* ReadMarkerRoomTimelineView.swift */; };
-		8F2FAA98457750D9D664136F /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 7731767AE437BA3BD2CC14A8 /* Sentry */; };
+		8F2FAA98457750D9D664136F /* GZIP in Frameworks */ = {isa = PBXBuildFile; productRef = 997C7385E1A07E061D7E2100 /* GZIP */; };
 		90DF83A6A347F7EE7EDE89EE /* AttributedStringBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF25E364AE85090A70AE4644 /* AttributedStringBuilderTests.swift */; };
 		90EB25D13AE6EEF034BDE9D2 /* Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D52BAA5BADB06E5E8C295D /* Assets.swift */; };
 		91DFCB641FBA03EE2DA0189E /* FilePreviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB27E1BE894F9F9F0134372 /* FilePreviewScreen.swift */; };
@@ -298,7 +298,7 @@
 		92B95779840CD749117B3615 /* EmojiMartStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38AE3617D7619EF30CDD229 /* EmojiMartStore.swift */; };
 		930556A6E30010A551A9DB50 /* RoomDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FB6F5ECCF51ECE98ACFEEC /* RoomDetailsViewModel.swift */; };
 		93875ADD456142D20823ED24 /* ServerSelectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAA4472821985BF868CC21C /* ServerSelectionViewModelTests.swift */; };
-		93BA4A81B6D893271101F9F0 /* DTCoreText in Frameworks */ = {isa = PBXBuildFile; productRef = 531CE4334AC5CA8DFF6AEB84 /* DTCoreText */; };
+		93BA4A81B6D893271101F9F0 /* DeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = A7CA6F33C553805035C3B114 /* DeviceKit */; };
 		9462C62798F47E39DCC182D2 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA89A2DD51B6BBE1DA55E263 /* Application.swift */; };
 		94A65DD8A353DF112EBEF67A /* SessionVerificationControllerProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D56469A9EE0CFA2B7BA9760 /* SessionVerificationControllerProxyProtocol.swift */; };
 		94D0F36A87E596A93C0C178A /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E89E530A8E92EC44301CA1 /* Bundle.swift */; };
@@ -316,7 +316,7 @@
 		99ED42B8F8D6BFB1DBCF4C45 /* AnalyticsEvents in Frameworks */ = {isa = PBXBuildFile; productRef = D661CAB418C075A94306A792 /* AnalyticsEvents */; };
 		9A3B0CDF097E3838FB1B9595 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E89E530A8E92EC44301CA1 /* Bundle.swift */; };
 		9A47B7EFE3793760EEF68FFE /* UITestScreenIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6FE34A0A47D010BBB4D4D4 /* UITestScreenIdentifier.swift */; };
-		9AC5F8142413862A9E3A2D98 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 020597E28A4BC8E1BE8EDF6E /* KeychainAccess */; };
+		9AC5F8142413862A9E3A2D98 /* DTCoreText in Frameworks */ = {isa = PBXBuildFile; productRef = 531CE4334AC5CA8DFF6AEB84 /* DTCoreText */; };
 		9B582B3EEFEA615D4A6FBF1A /* TimelineReactionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351E89CE2ED9B73C5CC47955 /* TimelineReactionsView.swift */; };
 		9BD3A773186291560DF92B62 /* RoomTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F2402D738694F98729A441 /* RoomTimelineProvider.swift */; };
 		9BE7A9CF6C593251D734B461 /* MockServerSelectionScreenState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A20AE75FF4FF35B1FF6CA7 /* MockServerSelectionScreenState.swift */; };
@@ -409,7 +409,7 @@
 		C7B251DC896C0867C51B616D /* AnalyticsPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541542F5AC323709D8563458 /* AnalyticsPrompt.swift */; };
 		C7CFDB4929DDD9A3B5BA085D /* BugReportViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB7ED3A898B07976F3AA90F /* BugReportViewModelTests.swift */; };
 		CA45758F08DF42D41D8A4B29 /* FilePreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF38B69D2C331A499276F400 /* FilePreviewViewModelTests.swift */; };
-		CB137BFB3E083C33E398A6CB /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 0DD568A494247444A4B56031 /* Kingfisher */; };
+		CB137BFB3E083C33E398A6CB /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 020597E28A4BC8E1BE8EDF6E /* KeychainAccess */; };
 		CB498F4E27AA0545DCEF0F6F /* DeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4003BC24B24C9E63D3304177 /* DeviceKit */; };
 		CB6BCBF28E4B76EA08C2926D /* StateRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16048D30F0438731C41F775 /* StateRoomTimelineItem.swift */; };
 		CB99B0FA38A4AC596F38CC13 /* KeychainControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E94DCFEE803E5ABAE8ACCE /* KeychainControllerProtocol.swift */; };
@@ -467,6 +467,7 @@
 		EA31DD9043B91ECB8E45A9A6 /* ScreenshotDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03C9D319676F3C0DC6B0203 /* ScreenshotDetectorTests.swift */; };
 		EA65360A0EC026DD83AC0CF5 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CA5F386C7701C129398945 /* AuthenticationCoordinator.swift */; };
 		EA974337FA7D040E7C74FE6E /* RoomDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFE1922F39398ABFB36DF3F /* RoomDetailsViewModelTests.swift */; };
+		EAC6FE2CD4F50A43068ADCD8 /* Version in Frameworks */ = {isa = PBXBuildFile; productRef = A05AF81DDD14AD58CB0E1B9B /* Version */; };
 		EBE13FAB4E29738AC41BD3E5 /* InfoPlistReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A580295A56B55A856CC4084 /* InfoPlistReader.swift */; };
 		EC280623A42904341363EAAF /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 886A0A498FA01E8EDD451D05 /* Sentry */; };
 		EC4C31963E755EEC77BD778C /* AnalyticsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B362E695A7103C11F64B185 /* AnalyticsSettings.swift */; };
@@ -496,7 +497,7 @@
 		FA2BBAE9FC5E2E9F960C0980 /* NavigationCoordinators.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F28602AC7AC881AED37EBA /* NavigationCoordinators.swift */; };
 		FA9C427FFB11B1AA2DCC5602 /* RoomProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47111410B6E659A697D472B5 /* RoomProxyProtocol.swift */; };
 		FBF09B6C900415800DDF2A21 /* EmojiProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C113E0CB7E15E9765B1817A /* EmojiProvider.swift */; };
-		FC10228E73323BDC09526F97 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 9C73F37731C9FDED1BB24C1C /* Collections */; };
+		FC10228E73323BDC09526F97 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 7731767AE437BA3BD2CC14A8 /* Sentry */; };
 		FCD3F2B82CAB29A07887A127 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 2B43F2AF7456567FE37270A7 /* KeychainAccess */; };
 		FE4593FC2A02AAF92E089565 /* ElementAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1593DD87F974F8509BB619 /* ElementAnimations.swift */; };
 		FE8D76708280968F7A670852 /* MockUserNotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9080CDD3881D0D1B2F280A7C /* MockUserNotificationController.swift */; };
@@ -1156,16 +1157,17 @@
 				1F3232BD368DF430AB433907 /* DesignKit in Frameworks */,
 				F656F92A63D3DC1978D79427 /* AnalyticsEvents in Frameworks */,
 				9D2E03DB175A6AB14589076D /* AppAuth in Frameworks */,
-				6F2AB43A1EFAD8A97AF41A15 /* DeviceKit in Frameworks */,
-				93BA4A81B6D893271101F9F0 /* DTCoreText in Frameworks */,
-				9AC5F8142413862A9E3A2D98 /* KeychainAccess in Frameworks */,
-				CB137BFB3E083C33E398A6CB /* Kingfisher in Frameworks */,
-				3C549A0BF39F8A854D45D9FD /* PostHog in Frameworks */,
-				41DFDD212D1BE57CA50D783B /* SwiftyBeaver in Frameworks */,
-				6298AB0906DDD3525CD78C6B /* SwiftState in Frameworks */,
-				407DCE030E0F9B7C9861D38A /* GZIP in Frameworks */,
-				8F2FAA98457750D9D664136F /* Sentry in Frameworks */,
-				FC10228E73323BDC09526F97 /* Collections in Frameworks */,
+				6F2AB43A1EFAD8A97AF41A15 /* Collections in Frameworks */,
+				93BA4A81B6D893271101F9F0 /* DeviceKit in Frameworks */,
+				9AC5F8142413862A9E3A2D98 /* DTCoreText in Frameworks */,
+				CB137BFB3E083C33E398A6CB /* KeychainAccess in Frameworks */,
+				3C549A0BF39F8A854D45D9FD /* Kingfisher in Frameworks */,
+				41DFDD212D1BE57CA50D783B /* PostHog in Frameworks */,
+				6298AB0906DDD3525CD78C6B /* SwiftyBeaver in Frameworks */,
+				407DCE030E0F9B7C9861D38A /* SwiftState in Frameworks */,
+				8F2FAA98457750D9D664136F /* GZIP in Frameworks */,
+				FC10228E73323BDC09526F97 /* Sentry in Frameworks */,
+				EAC6FE2CD4F50A43068ADCD8 /* Version in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2570,6 +2572,7 @@
 				A5A56C4F47C368EBE5C5E870 /* DesignKit */,
 				2A3F7BCCB18C15B30CCA39A9 /* AnalyticsEvents */,
 				AA4E1BEB4E9BC2467006E12B /* AppAuth */,
+				9C73F37731C9FDED1BB24C1C /* Collections */,
 				A7CA6F33C553805035C3B114 /* DeviceKit */,
 				531CE4334AC5CA8DFF6AEB84 /* DTCoreText */,
 				020597E28A4BC8E1BE8EDF6E /* KeychainAccess */,
@@ -2579,7 +2582,7 @@
 				9573B94B1C86C6DF751AF3FD /* SwiftState */,
 				997C7385E1A07E061D7E2100 /* GZIP */,
 				7731767AE437BA3BD2CC14A8 /* Sentry */,
-				9C73F37731C9FDED1BB24C1C /* Collections */,
+				A05AF81DDD14AD58CB0E1B9B /* Version */,
 			);
 			productName = ElementX;
 			productReference = 4CD6AC7546E8D7E5C73CEA48 /* ElementX.app */;
@@ -2767,6 +2770,7 @@
 				E9C4F3A12AA1F65C13A8C8EB /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 				6582B5AF3F104B0F7E031E7D /* XCRemoteSwiftPackageReference "SwiftState" */,
 				25B4484A6A20B9F1705DEEDA /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
+				EC6D0C817B1C21D9D096505A /* XCRemoteSwiftPackageReference "Version" */,
 			);
 			projectDirPath = "";
 			projectRoot = "";
@@ -3708,7 +3712,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				KEYCHAIN_ACCESS_GROUP_IDENTIFIER = "$(AppIdentifierPrefix)$(BASE_BUNDLE_IDENTIFIER)";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.0.16;
+				MARKETING_VERSION = 1.0.17;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3780,7 +3784,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				KEYCHAIN_ACCESS_GROUP_IDENTIFIER = "$(AppIdentifierPrefix)$(BASE_BUNDLE_IDENTIFIER)";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.0.16;
+				MARKETING_VERSION = 1.0.17;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -4075,6 +4079,14 @@
 				minimumVersion = 1.10.0;
 			};
 		};
+		EC6D0C817B1C21D9D096505A /* XCRemoteSwiftPackageReference "Version" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mxcl/Version";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.1;
+			};
+		};
 		F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections";
@@ -4215,6 +4227,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F76A08D0EA29A07A54F4EB4D /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = Collections;
+		};
+		A05AF81DDD14AD58CB0E1B9B /* Version */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EC6D0C817B1C21D9D096505A /* XCRemoteSwiftPackageReference "Version" */;
+			productName = Version;
 		};
 		A20EA00CCB9DBE0FFB17DD09 /* Collections */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -4012,7 +4012,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "1.0.35-alpha";
+				version = "1.0.36-alpha";
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "f6b5ccd904da60ccf39f41161c7db19e87b09870",
-        "version" : "1.0.35-alpha"
+        "revision" : "f001ac9e4b72647a2b5a9f3f210d72384915164f",
+        "version" : "1.0.36-alpha"
       }
     },
     {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -152,6 +152,15 @@
         "revision" : "12b5acf96d98f91d50de447369bd18df74600f1a",
         "version" : "1.9.6"
       }
+    },
+    {
+      "identity" : "version",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/Version",
+      "state" : {
+        "revision" : "1fe824b80d89201652e7eca7c9252269a1d85e25",
+        "version" : "2.0.1"
+      }
     }
   ],
   "version" : 2

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -20,7 +20,7 @@ import SwiftUI
 /// Store Element specific app settings.
 final class AppSettings: ObservableObject {
     private enum UserDefaultsKeys: String {
-        case hasAppLaunchedOnce
+        case lastVersionLaunched
         case timelineStyle
         case enableAnalytics
         case isIdentifiedForAnalytics
@@ -50,10 +50,11 @@ final class AppSettings: ObservableObject {
     
     // MARK: - Application
     
-    /// Simple flag to check if app has been deleted between runs.
-    /// Used to clear data stored in the shared container and keychain
-    @AppStorage(UserDefaultsKeys.hasAppLaunchedOnce.rawValue, store: store)
-    var hasAppLaunchedOnce = false
+    /// The last known version of the app that was launched on this device, which is
+    /// used to detect when migrations should be run. When `nil` the app may have been
+    /// deleted between runs so should clear data in the shared container and keychain.
+    @AppStorage(UserDefaultsKeys.lastVersionLaunched.rawValue, store: store)
+    var lastVersionLaunched: String?
     
     /// The default homeserver address used. This is intentionally a string without a scheme
     /// so that it can be passed to Rust as a ServerName for well-known discovery.

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -55,7 +55,13 @@ final class AppSettings: ObservableObject {
     @AppStorage(UserDefaultsKeys.hasAppLaunchedOnce.rawValue, store: store)
     var hasAppLaunchedOnce = false
     
+    /// The default homeserver address used. This is intentionally a string without a scheme
+    /// so that it can be passed to Rust as a ServerName for well-known discovery.
     let defaultHomeserverAddress = "matrix.org"
+    
+    /// An override of the homeserver's Sliding Sync proxy URL. This allows development against servers
+    /// that don't yet have an officially trusted proxy configured in their well-known.
+    let slidingSyncProxyURL = URL(staticString: "https://slidingsync.lab.matrix.org")
     
     // MARK: - Notifications
     
@@ -116,11 +122,6 @@ final class AppSettings: ObservableObject {
     
     @AppStorage(UserDefaultsKeys.timelineStyle.rawValue, store: store)
     var timelineStyle = TimelineStyle.bubbles
-
-    // MARK: - Client
-
-    @AppStorage(UserDefaultsKeys.slidingSyncProxyBaseURLString.rawValue, store: store)
-    var slidingSyncProxyBaseURLString = "https://slidingsync.lab.element.dev"
 
     // MARK: - Notifications
 

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -29,7 +29,7 @@ final class AppSettings: ObservableObject {
         case pusherProfileTag
     }
     
-    private static var suiteName: String = InfoPlistReader.target.appGroupIdentifier
+    private static var suiteName: String = InfoPlistReader.main.appGroupIdentifier
 
     /// UserDefaults to be used on reads and writes.
     private static var store: UserDefaults! = UserDefaults(suiteName: suiteName)
@@ -68,9 +68,9 @@ final class AppSettings: ObservableObject {
     
     var pusherAppId: String {
         #if DEBUG
-        InfoPlistReader.target.baseBundleIdentifier + ".ios.dev"
+        InfoPlistReader.main.baseBundleIdentifier + ".ios.dev"
         #else
-        InfoPlistReader.target.baseBundleIdentifier + ".ios.prod"
+        InfoPlistReader.main.baseBundleIdentifier + ".ios.prod"
         #endif
     }
     
@@ -91,14 +91,14 @@ final class AppSettings: ObservableObject {
     #if DEBUG
     /// The configuration to use for analytics during development. Set `isEnabled` to false to disable analytics in debug builds.
     /// **Note:** Analytics are disabled by default for forks. If you are maintaining a fork, set custom configurations.
-    let analyticsConfiguration = AnalyticsConfiguration(isEnabled: InfoPlistReader.target.bundleIdentifier.starts(with: "io.element.elementx"),
+    let analyticsConfiguration = AnalyticsConfiguration(isEnabled: InfoPlistReader.main.bundleIdentifier.starts(with: "io.element.elementx"),
                                                         host: "https://posthog.element.dev",
                                                         apiKey: "phc_VtA1L35nw3aeAtHIx1ayrGdzGkss7k1xINeXcoIQzXN",
                                                         termsURL: URL(staticString: "https://element.io/cookie-policy"))
     #else
     /// The configuration to use for analytics. Set `isEnabled` to false to disable analytics.
     /// **Note:** Analytics are disabled by default for forks. If you are maintaining a fork, set custom configurations.
-    let analyticsConfiguration = AnalyticsConfiguration(isEnabled: InfoPlistReader.target.bundleIdentifier.starts(with: "io.element.elementx"),
+    let analyticsConfiguration = AnalyticsConfiguration(isEnabled: InfoPlistReader.main.bundleIdentifier.starts(with: "io.element.elementx"),
                                                         host: "https://posthog.hss.element.io",
                                                         apiKey: "phc_Jzsm6DTm6V2705zeU5dcNvQDlonOR68XvX2sh1sEOHO",
                                                         termsURL: URL(staticString: "https://element.io/cookie-policy"))

--- a/ElementX/Sources/Other/Extensions/UIDevice.swift
+++ b/ElementX/Sources/Other/Extensions/UIDevice.swift
@@ -23,6 +23,6 @@ extension UIDevice {
     }
 
     var initialDisplayName: String {
-        ElementL10n.defaultSessionDisplayName(InfoPlistReader.target.bundleDisplayName)
+        ElementL10n.defaultSessionDisplayName(InfoPlistReader.main.bundleDisplayName)
     }
 }

--- a/ElementX/Sources/Other/Extensions/URL.swift
+++ b/ElementX/Sources/Other/Extensions/URL.swift
@@ -27,7 +27,7 @@ extension URL {
 
     /// The URL of the primary app group container.
     static var appGroupContainerDirectory: URL {
-        guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: InfoPlistReader.target.appGroupIdentifier) else {
+        guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: InfoPlistReader.main.appGroupIdentifier) else {
             fatalError("Should always be able to retrieve the container directory")
         }
         return url
@@ -64,7 +64,7 @@ extension URL {
         var url = appGroupContainerDirectory
             .appendingPathComponent("Library", isDirectory: true)
             .appendingPathComponent("Application Support", isDirectory: true)
-            .appendingPathComponent(InfoPlistReader.target.baseBundleIdentifier, isDirectory: true)
+            .appendingPathComponent(InfoPlistReader.main.baseBundleIdentifier, isDirectory: true)
 
         try? FileManager.default.createDirectoryIfNeeded(at: url)
         

--- a/ElementX/Sources/Other/InfoPlistReader.swift
+++ b/ElementX/Sources/Other/InfoPlistReader.swift
@@ -25,8 +25,8 @@ struct InfoPlistReader {
         static let bundleDisplayName = "CFBundleDisplayName"
     }
 
-    /// Info.plist reader on the current target
-    static let target = InfoPlistReader(bundle: .main)
+    /// Info.plist reader on the bundle object that contains the current executable.
+    static let main = InfoPlistReader(bundle: .main)
 
     private let bundle: Bundle
 

--- a/ElementX/Sources/Other/Logging/MXLogger.swift
+++ b/ElementX/Sources/Other/Logging/MXLogger.swift
@@ -150,9 +150,9 @@ class MXLogger {
         MXLogger.logCrashes(false)
         
         // Extract running app information
-        let app = InfoPlistReader.target.bundleExecutable
-        let appId = InfoPlistReader.target.bundleIdentifier
-        let appVersion = "\(InfoPlistReader.target.bundleShortVersionString) (r\(InfoPlistReader.target.bundleVersion))"
+        let app = InfoPlistReader.main.bundleExecutable
+        let appId = InfoPlistReader.main.bundleIdentifier
+        let appVersion = "\(InfoPlistReader.main.bundleShortVersionString) (r\(InfoPlistReader.main.bundleVersion))"
         
         // Build the crash log
         let model = UIDevice.current.model

--- a/ElementX/Sources/Other/UserAgentBuilder.swift
+++ b/ElementX/Sources/Other/UserAgentBuilder.swift
@@ -27,8 +27,8 @@ final class UserAgentBuilder {
     }
     
     private class func makeUserAgent() -> String? {
-        let clientName = InfoPlistReader.target.bundleDisplayName
-        let clientVersion = InfoPlistReader.target.bundleShortVersionString
+        let clientName = InfoPlistReader.main.bundleDisplayName
+        let clientVersion = InfoPlistReader.main.bundleShortVersionString
 
         #if os(iOS)
         return String(

--- a/ElementX/Sources/Screens/AnalyticsPrompt/AnalyticsPromptModels.swift
+++ b/ElementX/Sources/Screens/AnalyticsPrompt/AnalyticsPromptModels.swift
@@ -44,10 +44,10 @@ struct AnalyticsPromptStrings {
     init() {
         // Create the opt in content with a placeholder.
         let linkPlaceholder = "{link}"
-        var optInContent = AttributedString(ElementL10n.analyticsOptInContent(InfoPlistReader.target.bundleDisplayName, linkPlaceholder))
+        var optInContent = AttributedString(ElementL10n.analyticsOptInContent(InfoPlistReader.main.bundleDisplayName, linkPlaceholder))
         
         guard let range = optInContent.range(of: linkPlaceholder) else {
-            self.optInContent = AttributedString(ElementL10n.analyticsOptInContent(InfoPlistReader.target.bundleDisplayName,
+            self.optInContent = AttributedString(ElementL10n.analyticsOptInContent(InfoPlistReader.main.bundleDisplayName,
                                                                                    ElementL10n.analyticsOptInContentLink))
             MXLog.failure("Failed to add a link attribute to the opt in content.")
             return

--- a/ElementX/Sources/Screens/AnalyticsPrompt/View/AnalyticsPrompt.swift
+++ b/ElementX/Sources/Screens/AnalyticsPrompt/View/AnalyticsPrompt.swift
@@ -59,7 +59,7 @@ struct AnalyticsPrompt: View {
             Image(uiImage: Asset.Images.analyticsLogo.image)
                 .padding(.bottom, 25)
             
-            Text(ElementL10n.analyticsOptInTitle(InfoPlistReader.target.bundleDisplayName))
+            Text(ElementL10n.analyticsOptInTitle(InfoPlistReader.main.bundleDisplayName))
                 .font(.element.title2Bold)
                 .multilineTextAlignment(.center)
                 .foregroundColor(.element.primaryContent)

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginScreen.swift
@@ -64,6 +64,7 @@ struct LoginScreen: View {
         LoginServerInfoSection(address: context.viewState.homeserver.address) {
             context.send(viewAction: .selectServer)
         }
+        .disabled(true) // The button is disabled for this demo.
     }
     
     /// The form with text fields for username and password, along with a submit button.

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginServerInfoSection.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginServerInfoSection.swift
@@ -48,6 +48,7 @@ struct LoginServerInfoSection: View {
                     Image(systemName: "chevron.right")
                         .foregroundColor(.element.tertiaryContent)
                         .padding(.trailing, 16)
+                        .hidden() // The button is disabled for this demo.
                 }
                 .background(RoundedRectangle(cornerRadius: 14).fill(Color.element.system))
             }

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionModels.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionModels.swift
@@ -55,8 +55,6 @@ struct ServerSelectionViewState: BindableState {
 struct ServerSelectionBindings {
     /// The homeserver address input by the user.
     var homeserverAddress: String
-    /// The sliding sync proxy address input by the user.
-    var slidingSyncProxyAddress: String
     /// Information describing the currently displayed alert.
     var alertInfo: AlertInfo<ServerSelectionErrorType>?
 }

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/ServerSelectionViewModel.swift
@@ -22,8 +22,7 @@ class ServerSelectionViewModel: ServerSelectionViewModelType, ServerSelectionVie
     var callback: (@MainActor (ServerSelectionViewModelAction) -> Void)?
 
     init(homeserverAddress: String, isModallyPresented: Bool) {
-        let bindings = ServerSelectionBindings(homeserverAddress: homeserverAddress,
-                                               slidingSyncProxyAddress: ServiceLocator.shared.settings.slidingSyncProxyBaseURLString)
+        let bindings = ServerSelectionBindings(homeserverAddress: homeserverAddress)
         
         super.init(initialViewState: ServerSelectionViewState(bindings: bindings,
                                                               isModallyPresented: isModallyPresented))
@@ -32,11 +31,6 @@ class ServerSelectionViewModel: ServerSelectionViewModelType, ServerSelectionVie
     override func process(viewAction: ServerSelectionViewAction) async {
         switch viewAction {
         case .confirm:
-            if !state.bindings.slidingSyncProxyAddress.isEmpty,
-               state.bindings.slidingSyncProxyAddress != ServiceLocator.shared.settings.slidingSyncProxyBaseURLString {
-                ServiceLocator.shared.settings.slidingSyncProxyBaseURLString = state.bindings.slidingSyncProxyAddress
-            }
-            
             callback?(.confirm(homeserverAddress: state.bindings.homeserverAddress))
         case .dismiss:
             callback?(.dismiss)

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/View/ServerSelectionScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/View/ServerSelectionScreen.swift
@@ -71,16 +71,6 @@ struct ServerSelectionScreen: View {
                 .onSubmit(submit)
                 .accessibilityIdentifier("addressTextField")
             
-            TextField(ElementL10n.ftueAuthChooseServerEntryHint, text: $context.slidingSyncProxyAddress)
-                .textFieldStyle(.elementInput(labelText: "Sliding sync proxy URL"))
-                .keyboardType(.URL)
-                .autocapitalization(.none)
-                .disableAutocorrection(true)
-                .submitLabel(.done)
-                .onSubmit(submit)
-                .accessibilityIdentifier("slidingSyncProxyAddressTextField")
-                .padding(.bottom, 8)
-            
             Button(action: submit) {
                 Text(context.viewState.buttonTitle)
             }

--- a/ElementX/Sources/Screens/OnboardingScreen/OnboardingModels.swift
+++ b/ElementX/Sources/Screens/OnboardingScreen/OnboardingModels.swift
@@ -62,7 +62,7 @@ struct OnboardingViewState: BindableState {
     init() {
         content = [
             OnboardingPageContent(title: ElementL10n.ftueAuthCarouselWelcomeTitle.tinting(".", color: .element.accent),
-                                  message: ElementL10n.ftueAuthCarouselWelcomeBody(InfoPlistReader.target.bundleDisplayName),
+                                  message: ElementL10n.ftueAuthCarouselWelcomeBody(InfoPlistReader.main.bundleDisplayName),
                                   image: Asset.Images.onboardingAppLogo)
         ]
         bindings = OnboardingBindings()

--- a/ElementX/Sources/Screens/Other/InviteFriendsCoordinator.swift
+++ b/ElementX/Sources/Screens/Other/InviteFriendsCoordinator.swift
@@ -23,7 +23,7 @@ struct InviteFriendsCoordinator: CoordinatorProtocol {
         guard let permalink = try? PermalinkBuilder.permalinkTo(userIdentifier: userId).absoluteString else {
             return AnyView(EmptyView())
         }
-        let shareText = ElementL10n.inviteFriendsText(InfoPlistReader.target.bundleDisplayName, permalink)
+        let shareText = ElementL10n.inviteFriendsText(InfoPlistReader.main.bundleDisplayName, permalink)
         
         return AnyView(UIActivityViewControllerWrapper(activityItems: [shareText])
             .presentationDetents([.medium])

--- a/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
@@ -57,7 +57,7 @@ struct SettingsScreen: View {
     }
 
     private var versionText: some View {
-        Text(ElementL10n.settingsVersion + ": " + InfoPlistReader.target.bundleShortVersionString + " (" + InfoPlistReader.target.bundleVersion + ")")
+        Text(ElementL10n.settingsVersion + ": " + InfoPlistReader.main.bundleShortVersionString + " (" + InfoPlistReader.main.bundleVersion + ")")
     }
 
     private var backgroundColor: Color {

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -61,7 +61,7 @@ class BugReportService: BugReportServiceProtocol {
         //  also enable logging crashes, to send them with bug reports
         MXLogger.logCrashes(true)
         //  set build version for logger
-        MXLogger.buildVersion = InfoPlistReader.target.bundleShortVersionString
+        MXLogger.buildVersion = InfoPlistReader.main.bundleShortVersionString
     }
 
     // MARK: - BugReportServiceProtocol
@@ -148,8 +148,8 @@ class BugReportService: BugReportServiceProtocol {
         return [
             MultipartFormData(key: "user_agent", type: .text(value: "iOS")),
             MultipartFormData(key: "app", type: .text(value: applicationId)),
-            MultipartFormData(key: "version", type: .text(value: InfoPlistReader.target.bundleShortVersionString)),
-            MultipartFormData(key: "build", type: .text(value: InfoPlistReader.target.bundleVersion)),
+            MultipartFormData(key: "version", type: .text(value: InfoPlistReader.main.bundleShortVersionString)),
+            MultipartFormData(key: "build", type: .text(value: InfoPlistReader.main.bundleVersion)),
             MultipartFormData(key: "os", type: .text(value: os)),
             MultipartFormData(key: "resolved_language", type: .text(value: Bundle.preferredLanguages[0])),
             MultipartFormData(key: "user_language", type: .text(value: Bundle.elementLanguage ?? "null")),

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -254,7 +254,7 @@ class ClientProxy: ClientProxyProtocol {
         }
         
         do {
-            let slidingSyncBuilder = try client.slidingSync().homeserver(url: ServiceLocator.shared.settings.slidingSyncProxyBaseURLString)
+            let slidingSyncBuilder = try client.slidingSync().homeserver(url: ServiceLocator.shared.settings.slidingSyncProxyURL.absoluteString)
             
             // Build the visibleRoomsSlidingSyncView here so that it can take advantage of the SS builder cold cache
             // We will still register the allRoomsSlidingSyncView later, and than will have no cache

--- a/ElementX/Sources/Services/Keychain/KeychainController.swift
+++ b/ElementX/Sources/Services/Keychain/KeychainController.swift
@@ -22,7 +22,7 @@ enum KeychainControllerService: String {
     case tests
 
     var identifier: String {
-        InfoPlistReader.target.baseBundleIdentifier + "." + rawValue
+        InfoPlistReader.main.baseBundleIdentifier + "." + rawValue
     }
 }
 

--- a/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
+++ b/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
@@ -87,7 +87,7 @@ class NotificationManager: NSObject, NotificationManagerProtocol {
             try await clientProxy.setPusher(pushkey: deviceToken.base64EncodedString(),
                                             kind: .http,
                                             appId: ServiceLocator.shared.settings.pusherAppId,
-                                            appDisplayName: "\(InfoPlistReader.target.bundleDisplayName) (iOS)",
+                                            appDisplayName: "\(InfoPlistReader.main.bundleDisplayName) (iOS)",
                                             deviceDisplayName: UIDevice.current.name,
                                             profileTag: pusherProfileTag(),
                                             lang: Bundle.preferredLanguages.first ?? "en",

--- a/ElementX/Sources/Services/UserSession/UserSessionStore.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStore.swift
@@ -30,7 +30,7 @@ class UserSessionStore: UserSessionStoreProtocol {
     
     init(backgroundTaskService: BackgroundTaskServiceProtocol) {
         keychainController = KeychainController(service: .sessions,
-                                                accessGroup: InfoPlistReader.target.keychainAccessGroupIdentifier)
+                                                accessGroup: InfoPlistReader.main.keychainAccessGroupIdentifier)
         self.backgroundTaskService = backgroundTaskService
         baseDirectory = .sessionsBaseDirectory
         MXLog.info("Setup base directory at: \(baseDirectory)")

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -115,6 +115,7 @@ targets:
     - package: DesignKit
     - package: AnalyticsEvents
     - package: AppAuth
+    - package: Collections
     - package: DeviceKit
     - package: DTCoreText
     - package: KeychainAccess
@@ -124,7 +125,7 @@ targets:
     - package: SwiftState
     - package: GZIP
     - package: Sentry
-    - package: Collections
+    - package: Version
 
     sources:
     - path: ../Sources

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -20,7 +20,7 @@ import UserNotifications
 
 class NotificationServiceExtension: UNNotificationServiceExtension {
     private lazy var keychainController = KeychainController(service: .sessions,
-                                                             accessGroup: InfoPlistReader.target.keychainAccessGroupIdentifier)
+                                                             accessGroup: InfoPlistReader.main.keychainAccessGroupIdentifier)
     var handler: ((UNNotificationContent) -> Void)?
     var modifiedContent: UNMutableNotificationContent?
 

--- a/UnitTests/Sources/KeychainControllerTests.swift
+++ b/UnitTests/Sources/KeychainControllerTests.swift
@@ -22,7 +22,7 @@ class KeychainControllerTests: XCTestCase {
     
     override func setUp() {
         keychain = KeychainController(service: .tests,
-                                      accessGroup: InfoPlistReader.target.keychainAccessGroupIdentifier)
+                                      accessGroup: InfoPlistReader.main.keychainAccessGroupIdentifier)
         keychain.removeAllRestorationTokens()
     }
     

--- a/UnitTests/Sources/NotificationManager/NotificationManagerTests.swift
+++ b/UnitTests/Sources/NotificationManager/NotificationManagerTests.swift
@@ -60,7 +60,7 @@ final class NotificationManagerTests: XCTestCase {
         XCTAssertEqual(clientProxy.setPusherAppId, settings?.pusherAppId)
         XCTAssertEqual(clientProxy.setPusherKind, .http)
         XCTAssertEqual(clientProxy.setPusherAppId, settings?.pusherAppId)
-        XCTAssertEqual(clientProxy.setPusherAppDisplayName, "\(InfoPlistReader.target.bundleDisplayName) (iOS)")
+        XCTAssertEqual(clientProxy.setPusherAppDisplayName, "\(InfoPlistReader.main.bundleDisplayName) (iOS)")
         XCTAssertEqual(clientProxy.setPusherDeviceDisplayName, UIDevice.current.name)
         XCTAssertNotNil(clientProxy.setPusherProfileTag)
         XCTAssertEqual(clientProxy.setPusherLang, Bundle.preferredLanguages.first)

--- a/UnitTests/Sources/UserAgentBuilderTests.swift
+++ b/UnitTests/Sources/UserAgentBuilderTests.swift
@@ -25,11 +25,11 @@ class UserAgentBuilderTests: XCTestCase {
     
     func testContainsClientName() {
         let userAgent = UserAgentBuilder.makeASCIIUserAgent()
-        XCTAssert(userAgent?.contains(InfoPlistReader.target.bundleDisplayName) == true, "\(userAgent ?? "nil") does not contain client name")
+        XCTAssert(userAgent?.contains(InfoPlistReader.main.bundleDisplayName) == true, "\(userAgent ?? "nil") does not contain client name")
     }
     
     func testContainsClientVersion() {
         let userAgent = UserAgentBuilder.makeASCIIUserAgent()
-        XCTAssert(userAgent?.contains(InfoPlistReader.target.bundleShortVersionString) == true, "\(userAgent ?? "nil") does not contain client version")
+        XCTAssert(userAgent?.contains(InfoPlistReader.main.bundleShortVersionString) == true, "\(userAgent ?? "nil") does not contain client version")
     }
 }

--- a/changelog.d/pr-502.change
+++ b/changelog.d/pr-502.change
@@ -1,0 +1,1 @@
+Hardcode the sliding sync proxy to matrix.org for FOSDEM demo.

--- a/project.yml
+++ b/project.yml
@@ -26,7 +26,7 @@ settings:
   APP_GROUP_IDENTIFIER: group.$(BASE_APP_GROUP_IDENTIFIER)
   BASE_BUNDLE_IDENTIFIER: io.element.elementx
   KEYCHAIN_ACCESS_GROUP_IDENTIFIER: $(AppIdentifierPrefix)$(BASE_BUNDLE_IDENTIFIER)
-  MARKETING_VERSION: 1.0.16
+  MARKETING_VERSION: 1.0.17
   CURRENT_PROJECT_VERSION: 1
   DEVELOPMENT_TEAM: 7J4U792NQT
 
@@ -50,6 +50,9 @@ packages:
   AppAuth:
     url: https://github.com/openid/AppAuth-iOS
     majorVersion: 1.5.0
+  Collections:
+    url: https://github.com/apple/swift-collections
+    majorVersion: 1.0.4
   DeviceKit:
     url: https://github.com/devicekit/DeviceKit
     majorVersion: 4.7.0
@@ -83,6 +86,6 @@ packages:
   SnapshotTesting:
     url: https://github.com/pointfreeco/swift-snapshot-testing
     majorVersion: 1.10.0
-  Collections:
-    url: https://github.com/apple/swift-collections
-    majorVersion: 1.0.4
+  Version:
+    url: https://github.com/mxcl/Version
+    majorVersion: 2.0.1

--- a/project.yml
+++ b/project.yml
@@ -40,7 +40,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.35-alpha
+    exactVersion: 1.0.36-alpha
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
This PR hard codes the sliding sync proxy to the new matrix.org one for the demo. It removes the proxy input field on server selection (as this won't be needed in the future anyway) and disables the server selection button on the login screen (as no other servers are going to work for now anyway).

Merging this PR is blocked until the Rust SDK has been updated to handle the new JSON response format for sliding sync.

| Login Screen |
| - |
| ![Simulator Screen Shot - iPhone 14 - 2023-01-30 at 12 26 09](https://user-images.githubusercontent.com/6060466/215476569-9577e239-cbfa-4cc4-9137-ed4fd4daf07c.png) |