### PR TITLE
Memory management

### DIFF
--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -28,9 +28,7 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove sidebar", oldValue)
-                oldValue.coordinator?.stop()
-                oldValue.dismissalCallback?()
-                oldValue.coordinator = nil
+                oldValue.dismiss()
             }
             
             if let sidebarModule {
@@ -51,9 +49,7 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove detail", oldValue)
-                oldValue.coordinator?.stop()
-                oldValue.dismissalCallback?()
-                oldValue.coordinator = nil
+                oldValue.dismiss()
             }
             
             if let detailModule {
@@ -74,9 +70,7 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove sheet", oldValue)
-                oldValue.coordinator?.stop()
-                oldValue.dismissalCallback?()
-                oldValue.coordinator = nil
+                oldValue.dismiss()
             }
             
             if let sheetModule {
@@ -97,9 +91,7 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove fullscreen cover", oldValue)
-                oldValue.coordinator?.stop()
-                oldValue.dismissalCallback?()
-                oldValue.coordinator = nil
+                oldValue.dismiss()
             }
             
             if let fullScreenCoverModule {
@@ -413,9 +405,7 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove root", oldValue)
-                oldValue.coordinator?.stop()
-                oldValue.dismissalCallback?()
-                oldValue.coordinator = nil
+                oldValue.dismiss()
             }
             
             if let rootModule {
@@ -434,9 +424,7 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove sheet", oldValue)
-                oldValue.coordinator?.stop()
-                oldValue.dismissalCallback?()
-                oldValue.coordinator = nil
+                oldValue.dismiss()
             }
             
             if let sheetModule {
@@ -462,9 +450,7 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove fullscreen cover", oldValue)
-                oldValue.coordinator?.stop()
-                oldValue.dismissalCallback?()
-                oldValue.coordinator = nil
+                oldValue.dismiss()
             }
             
             if let fullScreenCoverModule {
@@ -494,9 +480,7 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
                     module.coordinator?.start()
                 case .remove(_, let module, _):
                     logPresentationChange("Pop", module)
-                    module.coordinator?.stop()
-                    module.dismissalCallback?()
-                    module.coordinator = nil
+                    module.dismiss()
                 }
             }
         }

--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -28,7 +28,7 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove sidebar", oldValue)
-                oldValue.dismiss()
+                oldValue.tearDown()
             }
             
             if let sidebarModule {
@@ -49,7 +49,7 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove detail", oldValue)
-                oldValue.dismiss()
+                oldValue.tearDown()
             }
             
             if let detailModule {
@@ -70,7 +70,7 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove sheet", oldValue)
-                oldValue.dismiss()
+                oldValue.tearDown()
             }
             
             if let sheetModule {
@@ -91,7 +91,7 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove fullscreen cover", oldValue)
-                oldValue.dismiss()
+                oldValue.tearDown()
             }
             
             if let fullScreenCoverModule {
@@ -405,7 +405,7 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove root", oldValue)
-                oldValue.dismiss()
+                oldValue.tearDown()
             }
             
             if let rootModule {
@@ -424,7 +424,7 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove sheet", oldValue)
-                oldValue.dismiss()
+                oldValue.tearDown()
             }
             
             if let sheetModule {
@@ -450,7 +450,7 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
         didSet {
             if let oldValue {
                 logPresentationChange("Remove fullscreen cover", oldValue)
-                oldValue.dismiss()
+                oldValue.tearDown()
             }
             
             if let fullScreenCoverModule {
@@ -480,7 +480,7 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
                     module.coordinator?.start()
                 case .remove(_, let module, _):
                     logPresentationChange("Pop", module)
-                    module.dismiss()
+                    module.tearDown()
                 }
             }
         }

--- a/ElementX/Sources/Application/Navigation/NavigationModule.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationModule.swift
@@ -34,7 +34,7 @@ class NavigationModule: Identifiable, Hashable {
         self.dismissalCallback = dismissalCallback
     }
     
-    func dismiss() {
+    func tearDown() {
         coordinator?.stop()
         dismissalCallback?()
         coordinator = nil

--- a/ElementX/Sources/Application/Navigation/NavigationModule.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationModule.swift
@@ -18,9 +18,14 @@ import Foundation
 
 /// A CoordinatorProtocol wrapper and type erasing component that allows
 /// dynamically presenting arbitrary screens
-struct NavigationModule: Identifiable, Hashable {
+class NavigationModule: Identifiable, Hashable {
     let id = UUID()
-    let coordinator: any CoordinatorProtocol
+    
+    /// The NavigationStack has a tendency to hold on to path items for longer than needed. We work around that by manually nilling the coordinator
+    /// when a NavigationModule is dismissed, reason why this is an optional property
+    /// As the NavigationModule is just a wrapper multiple instances of it continuing living is of no consequence
+    /// https://stackoverflow.com/questions/73885353/found-a-strange-behaviour-of-state-when-combined-to-the-new-navigation-stack/
+    var coordinator: (any CoordinatorProtocol)?
     let dismissalCallback: (() -> Void)?
     
     init(_ coordinator: any CoordinatorProtocol, dismissalCallback: (() -> Void)? = nil) {

--- a/ElementX/Sources/Application/Navigation/NavigationModule.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationModule.swift
@@ -18,6 +18,7 @@ import Foundation
 
 /// A CoordinatorProtocol wrapper and type erasing component that allows
 /// dynamically presenting arbitrary screens
+@MainActor
 class NavigationModule: Identifiable, Hashable {
     let id = UUID()
     
@@ -33,11 +34,17 @@ class NavigationModule: Identifiable, Hashable {
         self.dismissalCallback = dismissalCallback
     }
     
-    static func == (lhs: NavigationModule, rhs: NavigationModule) -> Bool {
+    func dismiss() {
+        coordinator?.stop()
+        dismissalCallback?()
+        coordinator = nil
+    }
+    
+    nonisolated static func == (lhs: NavigationModule, rhs: NavigationModule) -> Bool {
         lhs.id == rhs.id
     }
     
-    func hash(into hasher: inout Hasher) {
+    nonisolated func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }
 }

--- a/ElementX/Sources/Application/Navigation/NavigationRootCoordinator.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationRootCoordinator.swift
@@ -20,13 +20,14 @@ class NavigationRootCoordinator: ObservableObject, CoordinatorProtocol, CustomSt
     @Published fileprivate var rootModule: NavigationModule? {
         didSet {
             if let oldValue {
-                oldValue.coordinator.stop()
+                oldValue.coordinator?.stop()
                 oldValue.dismissalCallback?()
+                oldValue.coordinator = nil
             }
             
             if let rootModule {
                 logPresentationChange("Set root", rootModule)
-                rootModule.coordinator.start()
+                rootModule.coordinator?.start()
             }
         }
     }
@@ -66,7 +67,9 @@ class NavigationRootCoordinator: ObservableObject, CoordinatorProtocol, CustomSt
     // MARK: - Private
     
     private func logPresentationChange(_ change: String, _ module: NavigationModule) {
-        MXLog.info("\(self) \(change): \(module.coordinator)")
+        if let coordinator = module.coordinator {
+            MXLog.info("\(self) \(change): \(coordinator)")
+        }
     }
 }
 
@@ -75,7 +78,7 @@ private struct NavigationRootCoordinatorView: View {
     
     var body: some View {
         ZStack {
-            rootCoordinator.rootModule?.coordinator.toPresentable()
+            rootCoordinator.rootModule?.coordinator?.toPresentable()
         }
         .animation(.elementDefault, value: rootCoordinator.rootModule)
     }

--- a/ElementX/Sources/Application/Navigation/NavigationRootCoordinator.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationRootCoordinator.swift
@@ -20,9 +20,7 @@ class NavigationRootCoordinator: ObservableObject, CoordinatorProtocol, CustomSt
     @Published fileprivate var rootModule: NavigationModule? {
         didSet {
             if let oldValue {
-                oldValue.coordinator?.stop()
-                oldValue.dismissalCallback?()
-                oldValue.coordinator = nil
+                oldValue.dismiss()
             }
             
             if let rootModule {

--- a/ElementX/Sources/Application/Navigation/NavigationRootCoordinator.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationRootCoordinator.swift
@@ -20,7 +20,7 @@ class NavigationRootCoordinator: ObservableObject, CoordinatorProtocol, CustomSt
     @Published fileprivate var rootModule: NavigationModule? {
         didSet {
             if let oldValue {
-                oldValue.dismiss()
+                oldValue.tearDown()
             }
             
             if let rootModule {

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -35,8 +35,6 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
     
     var callback: ((HomeScreenViewModelAction) -> Void)?
     
-    // MARK: - Setup
-    
     // swiftlint:disable:next function_body_length
     init(userSession: UserSessionProtocol, attributedStringBuilder: AttributedStringBuilderProtocol) {
         self.userSession = userSession

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -91,7 +91,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                                   visibleRoomsSummaryProvider.roomListPublisher)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state, totalCount, rooms in
-                guard let self = self else { return }
+                guard let self else { return }
                 
                 let isLoadingData = state != .live && (totalCount == 0 || rooms.count != totalCount)
                 let hasNoRooms = state == .live && totalCount == 0

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -65,8 +65,8 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
         visibleItemRangePublisher
             .debounce(for: 0.1, scheduler: DispatchQueue.main)
             .removeDuplicates()
-            .sink { range in
-                self.updateVisibleRange(range)
+            .sink { [weak self] range in
+                self?.updateVisibleRange(range)
             }
             .store(in: &cancellables)
         

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -44,7 +44,7 @@ enum RoomScreenViewAction {
     case cancelEdit
     /// Mark the entire room as read - this is heavy handed as a starting point for now.
     case markRoomAsRead
-    case handleContextMenuAction(itemID: String, action: TimelineItemContextMenuAction)
+    case contextMenuAction(itemID: String, action: TimelineItemContextMenuAction)
 }
 
 struct RoomScreenViewState: BindableState {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -44,6 +44,7 @@ enum RoomScreenViewAction {
     case cancelEdit
     /// Mark the entire room as read - this is heavy handed as a starting point for now.
     case markRoomAsRead
+    case handleContextMenuAction(itemID: String, action: TimelineItemContextMenuAction)
 }
 
 struct RoomScreenViewState: BindableState {
@@ -56,7 +57,7 @@ struct RoomScreenViewState: BindableState {
     var showLoading = false
     var bindings: RoomScreenViewStateBindings
     
-    var contextMenuBuilder: (@MainActor (_ itemId: String) -> TimelineItemContextMenu)?
+    var contextMenuActionProvider: (@MainActor (_ itemId: String) -> TimelineItemContextMenuActions?)?
     
     var composerMode: RoomScreenComposerMode = .default
     

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -71,7 +71,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             .store(in: &cancellables)
         
         state.contextMenuActionProvider = { [weak self] itemId -> TimelineItemContextMenuActions? in
-            guard let self = self else {
+            guard let self else {
                 return nil
             }
             
@@ -113,7 +113,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             state.bindings.composerText = ""
         case .markRoomAsRead:
             await markRoomAsRead()
-        case .handleContextMenuAction(let itemID, let action):
+        case .contextMenuAction(let itemID, let action):
             processContentMenuAction(action, itemID: itemID)
         }
     }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModelProtocol.swift
@@ -20,6 +20,4 @@ import Foundation
 protocol RoomScreenViewModelProtocol {
     var callback: ((RoomScreenViewModelAction) -> Void)? { get set }
     var context: RoomScreenViewModelType.Context { get }
-
-    func stop()
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemContextMenu.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemContextMenu.swift
@@ -19,6 +19,15 @@ import SwiftUI
 struct TimelineItemContextMenuActions {
     let actions: [TimelineItemContextMenuAction]
     let debugActions: [TimelineItemContextMenuAction]
+    
+    init?(actions: [TimelineItemContextMenuAction], debugActions: [TimelineItemContextMenuAction]) {
+        if actions.isEmpty, debugActions.isEmpty {
+            return nil
+        }
+        
+        self.actions = actions
+        self.debugActions = debugActions
+    }
 }
 
 enum TimelineItemContextMenuAction: Identifiable, Hashable {

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemContextMenu.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemContextMenu.swift
@@ -17,11 +17,8 @@
 import SwiftUI
 
 struct TimelineItemContextMenuActions {
-    static var empty: TimelineItemContextMenuActions { .init(actions: [], debugActions: []) }
-    
     let actions: [TimelineItemContextMenuAction]
     let debugActions: [TimelineItemContextMenuAction]
-    var isEmpty: Bool { actions.isEmpty && debugActions.isEmpty }
 }
 
 enum TimelineItemContextMenuAction: Identifiable, Hashable {
@@ -52,16 +49,11 @@ public struct TimelineItemContextMenu: View {
     let callback: (TimelineItemContextMenuAction) -> Void
     
     public var body: some View {
-        if contextMenuActions.isEmpty {
-            // When there are no actions make sure then menu isn't shown.
-            EmptyView()
-        } else {
-            viewsForActions(contextMenuActions.actions)
-            Menu {
-                viewsForActions(contextMenuActions.debugActions)
-            } label: {
-                Label("Developer", systemImage: "hammer")
-            }
+        viewsForActions(contextMenuActions.actions)
+        Menu {
+            viewsForActions(contextMenuActions.debugActions)
+        } label: {
+            Label("Developer", systemImage: "hammer")
         }
     }
     

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -72,7 +72,7 @@ class TimelineTableViewController: UIViewController {
         }
     }
         
-    var contextMenuBuilder: (@MainActor (_ itemId: String) -> TimelineItemContextMenu)?
+    var contextMenuActionProvider: (@MainActor (_ itemId: String) -> TimelineItemContextMenuActions?)?
     
     @Binding private var scrollToBottomButtonVisible: Bool
     
@@ -189,7 +189,7 @@ class TimelineTableViewController: UIViewController {
             // A local reference to avoid capturing self in the cell configuration.
             let coordinator = self.coordinator
             let opacity = self.opacity(for: timelineItem)
-            let contextMenuBuilder = self.contextMenuBuilder
+            let contextMenuActionProvider = self.contextMenuActionProvider
             
             cell.item = timelineItem
             cell.contentConfiguration = UIHostingConfiguration {
@@ -198,7 +198,11 @@ class TimelineTableViewController: UIViewController {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .opacity(opacity)
                     .contextMenu {
-                        contextMenuBuilder?(timelineItem.id)
+                        contextMenuActionProvider?(timelineItem.id).map { actions in
+                            TimelineItemContextMenu(contextMenuActions: actions) { action in
+                                coordinator.send(viewAction: .handleContextMenuAction(itemID: timelineItem.id, action: action))
+                            }
+                        }
                     }
                     .onAppear {
                         coordinator.send(viewAction: .itemAppeared(id: timelineItem.id))

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -200,7 +200,7 @@ class TimelineTableViewController: UIViewController {
                     .contextMenu {
                         contextMenuActionProvider?(timelineItem.id).map { actions in
                             TimelineItemContextMenu(contextMenuActions: actions) { action in
-                                coordinator.send(viewAction: .handleContextMenuAction(itemID: timelineItem.id, action: action))
+                                coordinator.send(viewAction: .contextMenuAction(itemID: timelineItem.id, action: action))
                             }
                         }
                     }

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
@@ -70,7 +70,7 @@ struct TimelineView: UIViewControllerRepresentable {
             }
             
             // Doesn't have an equatable conformance :(
-            tableViewController.contextMenuBuilder = context.viewState.contextMenuBuilder
+            tableViewController.contextMenuActionProvider = context.viewState.contextMenuActionProvider
         }
         
         func send(viewAction: RoomScreenViewAction) {

--- a/ElementX/Sources/Services/Session/UserSession.swift
+++ b/ElementX/Sources/Services/Session/UserSession.swift
@@ -66,10 +66,10 @@ class UserSession: UserSessionProtocol {
                 
                 self.sessionVerificationController = sessionVerificationController
                 
-                sessionVerificationController.callbacks.sink { callback in
+                sessionVerificationController.callbacks.sink { [weak self] callback in
                     switch callback {
                     case .finished:
-                        self.callbacks.send(.didVerifySession)
+                        self?.callbacks.send(.didVerifySession)
                     default:
                         break
                     }


### PR DESCRIPTION
Starting from the user session not getting dealocated properly I ended up fixing retain cycles caused by SwiftUI's NavigationStack, which seems to hold on to it's path based object for longer than expected.

The solution here is to manually nil a NavigationModule's coordinator and let it deallocate properly. We don't care much about navigationModules being retained as they're of no consequence

This PR will also fix a long standing retaing cycle in the timeline item contex menu builder and clean up various other parts of the code.

NB I haven't gone through the whole app, there might still very well be other memory mangement issues