### PR TITLE
Dynamically adjusting the visibleRoomsView's timeline limit based on …

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import Combine
 import Foundation
 import UIKit
 
@@ -89,6 +90,8 @@ struct HomeScreenViewState: BindableState {
 
 struct HomeScreenViewStateBindings {
     var searchQuery = ""
+    
+    var isScrolling = false
     
     var alertInfo: AlertInfo<UUID>?
 }

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -58,6 +58,12 @@ enum PushFormat {
 //    }
 }
 
+enum SlidingSyncConstants {
+    static let initialTimelineLimit: UInt = 0
+    static let lastMessageTimelineLimit: UInt = 1
+    static let timelinePrecachingTimelineLimit: UInt = 20
+}
+
 protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     var callbacks: PassthroughSubject<ClientProxyCallback, Never> { get }
     

--- a/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
+++ b/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
@@ -102,10 +102,11 @@ class SlidingSyncViewProxy {
         try slidingSync.getRoom(roomId: identifier)
     }
     
-    func updateVisibleRange(_ range: Range<Int>) {
-        MXLog.info("Setting sliding sync view range to \(range)")
+    func updateVisibleRange(_ range: Range<Int>, timelineLimit: UInt) {
+        MXLog.info("Setting sliding sync view range to \(range), timelineLimit: \(timelineLimit)")
         
         slidingSyncView.setRange(start: UInt32(range.lowerBound), end: UInt32(range.upperBound))
+        slidingSyncView.setTimelineLimit(value: UInt32(timelineLimit))
         
         visibleRangeUpdatePublisher.send(())
     }

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
@@ -44,7 +44,7 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
         }
     }
     
-    func updateVisibleRange(_ range: Range<Int>) { }
+    func updateVisibleRange(_ range: Range<Int>, timelineLimit: UInt) { }
     
     // MARK: - Private
     

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -61,8 +61,8 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
             .store(in: &cancellables)
     }
     
-    func updateVisibleRange(_ range: Range<Int>) {
-        slidingSyncViewProxy.updateVisibleRange(range)
+    func updateVisibleRange(_ range: Range<Int>, timelineLimit: UInt) {
+        slidingSyncViewProxy.updateVisibleRange(range, timelineLimit: timelineLimit)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
@@ -50,5 +50,5 @@ protocol RoomSummaryProviderProtocol {
     /// Publishes the total number of rooms
     var countPublisher: CurrentValueSubject<UInt, Never> { get }
         
-    func updateVisibleRange(_ range: Range<Int>)
+    func updateVisibleRange(_ range: Range<Int>, timelineLimit: UInt)
 }


### PR DESCRIPTION
…the app state

Requires https://github.com/matrix-org/matrix-rust-sdk/pull/1399 and https://github.com/vector-im/element-x-ios/pull/502

This will start the app with `visibleRooms[timelineLimit=0]`, then, as soon as that receives updates, switch to `visibleRooms[timeline=1]` + `allRooms` and later, once the initial data has been displayed, switch to `visibleRooms[timeline=20]`+`allRooms`

After that, while scrolling and chaning the visible range the timeline limit with be set to 1 and then set again to 20 when the scrolling has stopped to precache room history