### PR TITLE
Minor fixes.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -32,7 +32,7 @@ struct RoomScreen: View {
             .overlay { loadingIndicator }
             .alert(item: $context.alertInfo) { $0.alert }
             .sheet(item: $context.debugInfo) { DebugScreen(info: $0) }
-            .task {
+            .task(id: context.viewState.roomId) {
                 // Give a couple of seconds for items to load and to see them.
                 try? await Task.sleep(for: .seconds(2))
                 

--- a/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
@@ -37,6 +37,7 @@ struct SessionVerificationScreen: View {
             .safeAreaInset(edge: .bottom) { actionButtons.padding() }
         }
         .navigationViewStyle(.stack)
+        .interactiveDismissDisabled() // Make sure dismissal goes through the state machine(s).
     }
     
     // MARK: - Private


### PR DESCRIPTION
- Marking a room as read on iPad (the task wasn't being called after the first room was presented).
- Potential state machine crash if you swipe to dismiss verification.