### PR TITLE
Cache lproj bundles so that so we stop recreating them every time we …

### DIFF
--- a/ElementX/Sources/Other/Extensions/Bundle.swift
+++ b/ElementX/Sources/Other/Extensions/Bundle.swift
@@ -17,12 +17,24 @@
 import Foundation
 
 public extension Bundle {
+    private static var cachedLocalizationBundles = [String: Bundle]()
+    
     /// Get an lproj language bundle from the receiver bundle.
     /// - Parameter language: The language to try to load.
     /// - Returns: The lproj bundle if found otherwise nil.
     func lprojBundle(for language: String) -> Bundle? {
-        guard let lprojURL = url(forResource: language, withExtension: "lproj") else { return nil }
-        return Bundle(url: lprojURL)
+        if let bundle = Self.cachedLocalizationBundles[language] {
+            return bundle
+        }
+        
+        guard let lprojURL = url(forResource: language, withExtension: "lproj") else {
+            return nil
+        }
+        
+        let bundle = Bundle(url: lprojURL)
+        Self.cachedLocalizationBundles[language] = bundle
+        
+        return bundle
     }
 
     /// Preferred app language for translations. Takes the highest priority in translations. The priority list for translations:


### PR DESCRIPTION
…request a localizable string

[Requesting localizable strings](https://github.com/vector-im/element-x-ios/blob/develop/ElementX/Sources/Generated/Strings.swift#L5842) tries to find the first supported language for a particular key and recreates the lproj bundle every time it does so. 

This PR caches those bundles to improve overall performance.