### PR TITLE
Allow different states for the last message.

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Untranslated.strings
@@ -4,7 +4,7 @@
 "action_confirm" = "Confirm";
 "action_match" = "Match";
 
-"new_message" = "New message";
+"message" = "Message";
 
 "screenshot_detected_title" = "You took a screenshot";
 "screenshot_detected_message" = "Would you like to submit a bug report?";

--- a/ElementX/Sources/Generated/Strings+Untranslated.swift
+++ b/ElementX/Sources/Generated/Strings+Untranslated.swift
@@ -40,8 +40,8 @@ extension ElementL10n {
   public static let loginMobileDevice = ElementL10n.tr("Untranslated", "login_mobile_device")
   /// Tablet
   public static let loginTabletDevice = ElementL10n.tr("Untranslated", "login_tablet_device")
-  /// New message
-  public static let newMessage = ElementL10n.tr("Untranslated", "new_message")
+  /// Message
+  public static let message = ElementL10n.tr("Untranslated", "message")
   /// %1$@ accepted the invite
   public static func noticeRoomInviteAccepted(_ p1: Any) -> String {
     return ElementL10n.tr("Untranslated", "noticeRoomInviteAccepted", String(describing: p1))

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -97,7 +97,23 @@ struct HomeScreenViewStateBindings {
 }
 
 struct HomeScreenRoom: Identifiable, Equatable {
-    private static let placeholderLastMessage = AttributedString("Last message")
+    static let placeholderLastMessage = AttributedString("Hidden last message")
+    
+    enum LastMessage: Equatable {
+        case loaded(AttributedString)
+        case loading
+        case unknown
+        
+        init(attributedString: AttributedString?, isLoading: Bool) {
+            if let message = attributedString, !message.characters.isEmpty {
+                self = .loaded(message)
+            } else if isLoading {
+                self = .loading
+            } else {
+                self = .unknown
+            }
+        }
+    }
     
     /// The list item identifier can be a real room identifier, a custom one for invalidated entries
     /// or a completely unique one for empty items and skeletons
@@ -112,7 +128,7 @@ struct HomeScreenRoom: Identifiable, Equatable {
     
     var timestamp: String?
     
-    var lastMessage: AttributedString?
+    var lastMessage: LastMessage
     
     var avatarURL: URL?
     
@@ -124,7 +140,7 @@ struct HomeScreenRoom: Identifiable, Equatable {
                        name: "Placeholder room name",
                        hasUnreads: false,
                        timestamp: "Now",
-                       lastMessage: Self.placeholderLastMessage,
+                       lastMessage: .loading,
                        isPlaceholder: true)
     }
 }

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -200,7 +200,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             case .empty, .invalidated:
                 guard let allRoomsRoomSummary = allRoomsSummaryProvider?.roomListPublisher.value[safe: index] else {
                     if case let .invalidated(details) = summary {
-                        rooms.append(buildRoom(with: details, invalidated: true))
+                        rooms.append(buildRoom(with: details, invalidated: true, isLoading: false))
                     } else {
                         rooms.append(HomeScreenRoom.placeholder())
                     }
@@ -211,10 +211,10 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 case .empty:
                     rooms.append(HomeScreenRoom.placeholder())
                 case .filled(let details), .invalidated(let details):
-                    rooms.append(buildRoom(with: details, invalidated: false))
+                    rooms.append(buildRoom(with: details, invalidated: false, isLoading: true))
                 }
             case .filled(let details):
-                rooms.append(buildRoom(with: details, invalidated: false))
+                rooms.append(buildRoom(with: details, invalidated: false, isLoading: false))
             }
         }
         
@@ -223,7 +223,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
         MXLog.info("Finished updating rooms")
     }
     
-    private func buildRoom(with details: RoomSummaryDetails, invalidated: Bool) -> HomeScreenRoom {
+    private func buildRoom(with details: RoomSummaryDetails, invalidated: Bool, isLoading: Bool) -> HomeScreenRoom {
         let identifier = invalidated ? "invalidated-" + details.id : details.id
         
         return HomeScreenRoom(id: identifier,
@@ -231,7 +231,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                               name: details.name,
                               hasUnreads: details.unreadNotificationCount > 0,
                               timestamp: details.lastMessageFormattedTimestamp,
-                              lastMessage: details.lastMessage,
+                              lastMessage: .init(attributedString: details.lastMessage, isLoading: isLoading),
                               avatarURL: details.avatarURL)
     }
     

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
@@ -81,11 +81,16 @@ struct HomeScreenRoomCell: View {
                 // Hidden text with 2 lines to maintain consistent height, scaling with dynamic text.
                 Text(" \n ").lastMessageFormatting().hidden()
                 
-                if let lastMessage = room.lastMessage, !String(lastMessage.characters).isEmpty {
+                switch room.lastMessage {
+                case .loaded(let lastMessage):
                     Text(lastMessage)
                         .lastMessageFormatting()
-                } else {
-                    Text(ElementL10n.newMessage)
+                case .loading:
+                    Text(HomeScreenRoom.placeholderLastMessage)
+                        .lastMessageFormatting()
+                        .redacted(reason: .placeholder)
+                case .unknown:
+                    Text(ElementL10n.message)
                         .lastMessageFormatting()
                 }
             }
@@ -156,7 +161,8 @@ struct HomeScreenRoomCell_Previews: PreviewProvider {
                                       name: details.name,
                                       hasUnreads: details.unreadNotificationCount > 0,
                                       timestamp: Date.now.formattedMinimal(),
-                                      lastMessage: details.lastMessage)
+                                      lastMessage: .init(attributedString: details.lastMessage,
+                                                         isLoading: false))
             }
         }
 

--- a/changelog.d/pr-514.change
+++ b/changelog.d/pr-514.change
@@ -1,0 +1,1 @@
+Add different states for a room's last message to distinguish loading from loaded from unknown.


### PR DESCRIPTION
This PR makes a small change to the last message in the room list. It now has 3 states defined in an enum and we choose whether to display the message, a loading placeholder, or a placeholder string when the message is unknown.

https://user-images.githubusercontent.com/6060466/216105909-0a475d52-055f-49fc-a740-bbb06ec1ba63.mp4

