### PR TITLE
Load member profiles through the timeline

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -4012,7 +4012,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "1.0.36-alpha";
+				version = "1.0.37-alpha";
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "f001ac9e4b72647a2b5a9f3f210d72384915164f",
-        "version" : "1.0.36-alpha"
+        "revision" : "79ead18b0db04f898d5ba9ce1a0b609a518f44ec",
+        "version" : "1.0.37-alpha"
       }
     },
     {

--- a/ElementX/Sources/Services/Room/MockRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/MockRoomProxy.swift
@@ -40,18 +40,10 @@ struct MockRoomProxy: RoomProxyProtocol {
         .failure(.failedRetrievingMemberDisplayName)
     }
     
-    func avatarURLForUserId(_ userId: String) -> URL? {
-        nil
-    }
-    
     func loadAvatarURLForUserId(_ userId: String) async -> Result<URL?, RoomProxyError> {
         .failure(.failedRetrievingMemberAvatarURL)
     }
     
-    func displayNameForUserId(_ userId: String) -> String? {
-        nil
-    }
-        
     func startLiveEventListener() { }
     
     func addTimelineListener(listener: TimelineListener) -> Result<Void, RoomProxyError> {

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -31,9 +31,6 @@ class RoomProxy: RoomProxyProtocol {
     
     private var sendMessageBackgroundTask: BackgroundTaskProtocol?
     
-    private var memberAvatars = [String: URL]()
-    private var memberDisplayNames = [String: String]()
-    
     private(set) var displayName: String?
     
     private var timelineObservationToken: StoppableSpawn?
@@ -109,10 +106,6 @@ class RoomProxy: RoomProxyProtocol {
         return Asset.Images.encryptionTrusted.image
     }
     
-    func avatarURLForUserId(_ userId: String) -> URL? {
-        memberAvatars[userId]
-    }
-    
     func loadAvatarURLForUserId(_ userId: String) async -> Result<URL?, RoomProxyError> {
         do {
             guard let urlString = try await Task.dispatch(on: lowPriorityDispatchQueue, {
@@ -126,15 +119,10 @@ class RoomProxy: RoomProxyProtocol {
                 return .failure(.failedRetrievingMemberAvatarURL)
             }
             
-            update(url: avatarURL, forUserId: userId)
             return .success(avatarURL)
         } catch {
             return .failure(.failedRetrievingMemberAvatarURL)
         }
-    }
-    
-    func displayNameForUserId(_ userId: String) -> String? {
-        memberDisplayNames[userId]
     }
     
     func loadDisplayNameForUserId(_ userId: String) async -> Result<String?, RoomProxyError> {
@@ -142,7 +130,6 @@ class RoomProxy: RoomProxyProtocol {
             let displayName = try await Task.dispatch(on: lowPriorityDispatchQueue) {
                 try self.room.memberDisplayName(userId: userId)
             }
-            update(displayName: displayName, forUserId: userId)
             return .success(displayName)
         } catch {
             return .failure(.failedRetrievingMemberDisplayName)
@@ -290,15 +277,7 @@ class RoomProxy: RoomProxyProtocol {
             self.room.fetchMembers()
         }
     }
-    
-    private func update(url: URL?, forUserId userId: String) {
-        memberAvatars[userId] = url
-    }
-    
-    private func update(displayName: String?, forUserId userId: String) {
-        memberDisplayNames[userId] = displayName
-    }
-    
+        
     private func update(displayName: String) {
         self.displayName = displayName
     }

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -51,11 +51,7 @@ protocol RoomProxyProtocol {
     
     var avatarURL: URL? { get }
     
-    func avatarURLForUserId(_ userId: String) -> URL?
-    
     func loadAvatarURLForUserId(_ userId: String) async -> Result<URL?, RoomProxyError>
-    
-    func displayNameForUserId(_ userId: String) -> String?
     
     func loadDisplayNameForUserId(_ userId: String) async -> Result<String?, RoomProxyError>
     

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
@@ -97,15 +97,7 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
         }
     }
     
-    func processItemAppearance(_ itemID: String) async {
-        guard let timelineItem = timelineItems.first(where: { $0.id == itemID }) else {
-            return
-        }
-        
-        if let item = timelineItem as? EventBasedTimelineItemProtocol {
-            await loadUserDisplayNameForTimelineItem(item)
-        }
-    }
+    func processItemAppearance(_ itemID: String) async { }
     
     func processItemDisappearance(_ itemID: String) { }
 
@@ -431,28 +423,6 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
 
             item.cachedFileURL = fileURL
             timelineItems[index] = item
-        case .failure:
-            break
-        }
-    }
-        
-    #warning("This is here because sender profiles aren't working properly. Remove it entirely later")
-    private func loadUserDisplayNameForTimelineItem(_ timelineItem: EventBasedTimelineItemProtocol) async {
-        if timelineItem.shouldShowSenderDetails == false || timelineItem.sender.displayName != nil {
-            return
-        }
-        
-        switch await roomProxy.loadDisplayNameForUserId(timelineItem.sender.id) {
-        case .success(let displayName):
-            guard let displayName,
-                  let index = timelineItems.firstIndex(where: { $0.id == timelineItem.id }),
-                  var item = timelineItems[index] as? EventBasedTimelineItemProtocol else {
-                return
-            }
-            
-            item.sender.displayName = displayName
-            timelineItems[index] = item
-            callbacks.send(.updatedTimelineItem(timelineItem.id))
         case .failure:
             break
         }

--- a/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
@@ -106,9 +106,17 @@ struct EventTimelineItemProxy: CustomDebugStringConvertible {
     
     var sender: TimelineItemSender {
         let profile = item.senderProfile()
-        return .init(id: item.sender(),
-                     displayName: profile.displayName,
-                     avatarURL: profile.avatarUrl.flatMap(URL.init(string:)))
+        
+        switch profile {
+        case let .ready(displayName, _, avatarUrl):
+            return .init(id: item.sender(),
+                         displayName: displayName,
+                         avatarURL: avatarUrl.flatMap(URL.init(string:)))
+        default:
+            return .init(id: item.sender(),
+                         displayName: nil,
+                         avatarURL: nil)
+        }
     }
 
     var reactions: [Reaction] {

--- a/project.yml
+++ b/project.yml
@@ -40,7 +40,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.36-alpha
+    exactVersion: 1.0.37-alpha
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
This PR simplifies the way we load data for timeline item sender profiles. It replaces the need to call `loadDisplayNameForUserId` with a `fetchMembers` internal to the room proxy any time we add a timeline listener.
It also fixes flashing display names in the timeline and avatars that don't load