### PR TITLE
Explicitly pass the context into the cell's environment.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -197,6 +197,7 @@ class TimelineTableViewController: UIViewController {
                     .id(timelineItem.id)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .opacity(opacity)
+                    .environmentObject(coordinator.context) // Attempted fix at a crash in TimelineItemContextMenu
                     .onAppear {
                         coordinator.send(viewAction: .itemAppeared(id: timelineItem.id))
                     }

--- a/changelog.d/532.bugfix
+++ b/changelog.d/532.bugfix
@@ -1,0 +1,1 @@
+Context Menu Crash: Attempted fix by explicitly passing in the context to each cell.


### PR DESCRIPTION
Potential fix for #532 on the assumption that at times the UIKit components of the timeline may not be part of the view hierarchy/have access to the environment 🤞