### PR TITLE
BrowserStack support

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -56,6 +56,8 @@ jobs:
           APPSTORECONNECT_KEY_CONTENT: ${{ secrets.APPSTORECONNECT_KEY_CONTENT }}
           DIAWI_API_TOKEN: ${{ secrets.DIAWI_API_TOKEN }}
           GITHUB_PR_NUMBER: ${{ github.event.number }}
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
       - name: Add release notes and Diawi info
         uses: NejcZdovc/comment-pr@v1

--- a/ElementX/Sources/Other/Extensions/URL.swift
+++ b/ElementX/Sources/Other/Extensions/URL.swift
@@ -28,8 +28,16 @@ extension URL {
     /// The URL of the primary app group container.
     static var appGroupContainerDirectory: URL {
         guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: InfoPlistReader.main.appGroupIdentifier) else {
-            fatalError("Should always be able to retrieve the container directory")
+            // Browserstack doesn't properly handle AppGroup entitlements so this fails, presumably because of the resigning happening on their side
+            // Try using the normal app folder instead of the app group
+            // https://www.browserstack.com/docs/app-automate/appium/troubleshooting/entitlements-error
+            guard let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?.deletingLastPathComponent().deletingLastPathComponent() else {
+                fatalError("Should always be able to retrieve the app directory")
+            }
+            
+            return url
         }
+        
         return url
     }
 

--- a/ElementX/Sources/Other/Extensions/URL.swift
+++ b/ElementX/Sources/Other/Extensions/URL.swift
@@ -28,6 +28,7 @@ extension URL {
     /// The URL of the primary app group container.
     static var appGroupContainerDirectory: URL {
         guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: InfoPlistReader.main.appGroupIdentifier) else {
+            MXLog.error("Application Group unavailable, falling back to the application folder")
             // Browserstack doesn't properly handle AppGroup entitlements so this fails, presumably because of the resigning happening on their side
             // Try using the normal app folder instead of the app group
             // https://www.browserstack.com/docs/app-automate/appium/troubleshooting/entitlements-error

--- a/ElementX/Sources/Other/Extensions/URL.swift
+++ b/ElementX/Sources/Other/Extensions/URL.swift
@@ -32,11 +32,8 @@ extension URL {
             // Browserstack doesn't properly handle AppGroup entitlements so this fails, presumably because of the resigning happening on their side
             // Try using the normal app folder instead of the app group
             // https://www.browserstack.com/docs/app-automate/appium/troubleshooting/entitlements-error
-            guard let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?.deletingLastPathComponent().deletingLastPathComponent() else {
-                fatalError("Should always be able to retrieve the app directory")
-            }
             
-            return url
+            return URL.applicationSupportDirectory.deletingLastPathComponent().deletingLastPathComponent()
         }
         
         return url

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-brew (0.1.1)
+    fastlane-plugin-browserstack (0.3.2)
+      rest-client (~> 2.0, >= 2.0.2)
     fastlane-plugin-diawi (2.1.0)
       rest-client (>= 2.0.0)
     fastlane-plugin-sentry (1.15.0)
@@ -254,6 +256,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane
+  fastlane-plugin-browserstack
   fastlane-plugin-diawi
   fastlane-plugin-sentry
   fastlane-plugin-xcodegen

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -69,6 +69,8 @@ lane :alpha do
   )
 
   upload_to_diawi()
+
+  upload_to_browserstack()
 end
 
 lane :app_store_release do
@@ -277,6 +279,21 @@ private_lane :upload_to_diawi do
   # Set "DIAWI_FILE_LINK" to GitHub environment variables for Github actions
   sh("echo DIAWI_FILE_LINK=#{diawi_link} >> $GITHUB_ENV")
   sh("echo DIAWI_QR_CODE_LINK=#{diawi_qr_code_link} >> $GITHUB_ENV")
+end
+
+private_lane :upload_to_browserstack do
+  browserstack_username = ENV["BROWSERSTACK_USERNAME"]
+  UI.user_error!("Invalid BrowserStack username.") unless !browserstack_username.to_s.empty?
+
+  browserstack_access_key = ENV["BROWSERSTACK_ACCESS_KEY"]
+  UI.user_error!("Invalid BrowserStack access key.") unless !browserstack_access_key.to_s.empty?
+
+  upload_to_browserstack_app_automate(
+    browserstack_username: browserstack_username,
+    browserstack_access_key: browserstack_access_key,
+    file_path: lane_context[SharedValues::IPA_OUTPUT_PATH],
+    custom_id: "element-x-ios-pr"
+  )
 end
 
 private_lane :bump_build_number do

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -5,3 +5,4 @@
 gem 'fastlane-plugin-diawi'
 gem 'fastlane-plugin-xcodegen'
 gem 'fastlane-plugin-sentry'
+gem 'fastlane-plugin-browserstack'


### PR DESCRIPTION
We want to be able to test the app through BrowserStack and they do not currently support Application Groups. In order to get that working I slightly changed the way we create the path where we store user data. It shouldn't affect normal users in any way
I also added support for automatic ipa file uplods to BrowserStack for PR builds