### PR TITLE
Update PR Build workflow.

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,17 +1,14 @@
-name: Alpha release
+name: PR Build
 
 on:
   pull_request:
-
-  workflow_dispatch:
+    types: [ labeled, synchronize, opened, reopened ]
 
 jobs:
   build:
-    # Don't run for forks as secrets are unavailable.
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Trigger-PR-Build')))
+    # Only run for PRs that contain the trigger label. The action will fail for forks due to
+    # missing secrets, but there's no need to handle this as it won't run automatically.
+    if: contains(github.event.pull_request.labels.*.name, 'Trigger-PR-Build')
 
     name: Release
     runs-on: macos-12

--- a/changelog.d/pr-564.build
+++ b/changelog.d/pr-564.build
@@ -1,0 +1,1 @@
+Update PR Build workflow triggers.


### PR DESCRIPTION
- Allows the workflow to run when the PR is labelled after being created.
- Removes manual runs as there isn't anywhere to post the link.
- Simplifies the run conditions seeing as this is a manual action now.