### PR TITLE
Add SwiftFormat wraparguments rule.

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 --swiftversion 5.6
 
---exclude ElementX/Sources/Generated,vendor
+--exclude ElementX/Sources/Generated,vendor,**/Package.swift
 
 --disable wrapMultiLineStatementBraces
 --disable hoistPatternLet
@@ -10,6 +10,7 @@
 --nospaceoperators ...,..<
 --stripunusedargs closure-only
 --trimwhitespace nonblank-lines
+--wraparguments after-first
 --wrapparameters after-first
 --redundanttype inferred
 --emptybraces spaced

--- a/ElementX/Sources/Other/BlurHashDecode.swift
+++ b/ElementX/Sources/Other/BlurHashDecode.swift
@@ -80,11 +80,9 @@ private func decodeAC(_ value: Int, maximumValue: Float) -> (Float, Float, Float
     let quantG = (value / 19) % 19
     let quantB = value % 19
 
-    let rgb = (
-        signPow((Float(quantR) - 9) / 9, 2) * maximumValue,
-        signPow((Float(quantG) - 9) / 9, 2) * maximumValue,
-        signPow((Float(quantB) - 9) / 9, 2) * maximumValue
-    )
+    let rgb = (signPow((Float(quantR) - 9) / 9, 2) * maximumValue,
+               signPow((Float(quantG) - 9) / 9, 2) * maximumValue,
+               signPow((Float(quantB) - 9) / 9, 2) * maximumValue)
 
     return rgb
 }

--- a/ElementX/Sources/Other/UserAgentBuilder.swift
+++ b/ElementX/Sources/Other/UserAgentBuilder.swift
@@ -31,39 +31,31 @@ final class UserAgentBuilder {
         let clientVersion = InfoPlistReader.main.bundleShortVersionString
 
         #if os(iOS)
-        return String(
-            format: "%@/%@ (%@; iOS %@; Scale/%0.2f)",
-            clientName,
-            clientVersion,
-            Device.current.safeDescription,
-            UIDevice.current.systemVersion,
-            UIScreen.main.scale
-        )
+        return String(format: "%@/%@ (%@; iOS %@; Scale/%0.2f)",
+                      clientName,
+                      clientVersion,
+                      Device.current.safeDescription,
+                      UIDevice.current.systemVersion,
+                      UIScreen.main.scale)
         #elseif os(tvOS)
-        return String(
-            format: "%@/%@ (%@; tvOS %@; Scale/%0.2f)",
-            clientName,
-            clientVersion,
-            Device.current.safeDescription,
-            UIDevice.current.systemVersion,
-            UIScreen.main.scale
-        )
+        return String(format: "%@/%@ (%@; tvOS %@; Scale/%0.2f)",
+                      clientName,
+                      clientVersion,
+                      Device.current.safeDescription,
+                      UIDevice.current.systemVersion,
+                      UIScreen.main.scale)
         #elseif os(watchOS)
-        return String(
-            format: "%@/%@ (%@; watchOS %@; Scale/%0.2f)",
-            clientName,
-            clientVersion,
-            Device.current.safeDescription,
-            WKInterfaceDevice.current.systemVersion,
-            WKInterfaceDevice.currentDevice.screenScale
-        )
+        return String(format: "%@/%@ (%@; watchOS %@; Scale/%0.2f)",
+                      clientName,
+                      clientVersion,
+                      Device.current.safeDescription,
+                      WKInterfaceDevice.current.systemVersion,
+                      WKInterfaceDevice.currentDevice.screenScale)
         #elseif os(OSX)
-        return String(
-            format: "%@/%@ (Mac; Mac OS X %@)",
-            clientName,
-            clientVersion,
-            NSProcessInfo.processInfo.operatingSystemVersionString
-        )
+        return String(format: "%@/%@ (Mac; Mac OS X %@)",
+                      clientName,
+                      clientVersion,
+                      NSProcessInfo.processInfo.operatingSystemVersionString)
         #else
         return nil
         #endif

--- a/ElementX/Sources/Services/Authentication/OIDCService.swift
+++ b/ElementX/Sources/Services/Authentication/OIDCService.swift
@@ -64,15 +64,13 @@ class OIDCService {
             "policy_uri": "https://element.io/privacy"
         ]
         
-        let nonTemplatizedRequest = OIDRegistrationRequest(
-            configuration: metadata,
-            redirectURIs: [redirectURI],
-            responseTypes: nil,
-            grantTypes: [OIDGrantTypeAuthorizationCode, OIDGrantTypeRefreshToken],
-            subjectType: nil,
-            tokenEndpointAuthMethod: "none",
-            additionalParameters: extraParams
-        )
+        let nonTemplatizedRequest = OIDRegistrationRequest(configuration: metadata,
+                                                           redirectURIs: [redirectURI],
+                                                           responseTypes: nil,
+                                                           grantTypes: [OIDGrantTypeAuthorizationCode, OIDGrantTypeRefreshToken],
+                                                           subjectType: nil,
+                                                           tokenEndpointAuthMethod: "none",
+                                                           additionalParameters: extraParams)
         
         let registrationResponse = try await OIDAuthorizationService.perform(nonTemplatizedRequest)
         

--- a/UnitTests/Sources/NotificationManager/UNNotification+Creator.swift
+++ b/UnitTests/Sources/NotificationManager/UNNotification+Creator.swift
@@ -22,11 +22,9 @@ extension UNNotification {
     static func with(userInfo: [AnyHashable: Any], actionIdentifier: String = UNNotificationDefaultActionIdentifier) throws -> UNNotification {
         let content = UNMutableNotificationContent()
         content.userInfo = userInfo
-        let request = UNNotificationRequest(
-            identifier: "",
-            content: content,
-            trigger: nil
-        )
+        let request = UNNotificationRequest(identifier: "",
+                                            content: content,
+                                            trigger: nil)
         let archiver = MockCoder(requiringSecureCoding: false)
         let notification = try XCTUnwrap(UNNotification(coder: archiver))
         notification.setValue(request, forKey: "request")

--- a/UnitTests/Sources/NotificationManager/UNTextInputNotificationResponse+Creator.swift
+++ b/UnitTests/Sources/NotificationManager/UNTextInputNotificationResponse+Creator.swift
@@ -21,11 +21,9 @@ extension UNTextInputNotificationResponse {
     static func with(userInfo: [AnyHashable: Any], actionIdentifier: String = UNNotificationDefaultActionIdentifier) throws -> UNNotificationResponse {
         let content = UNMutableNotificationContent()
         content.userInfo = userInfo
-        let request = UNNotificationRequest(
-            identifier: "",
-            content: content,
-            trigger: nil
-        )
+        let request = UNNotificationRequest(identifier: "",
+                                            content: content,
+                                            trigger: nil)
         let archiver = MockCoder(requiringSecureCoding: false)
         let notification = try XCTUnwrap(UNNotification(coder: archiver))
         notification.setValue(request, forKey: "request")


### PR DESCRIPTION
Matches the wrapparameters rule, seems it was missed and left an inconsistency between `func` and `init` styles.

Maybe controversial, I've disabled formatting on the Package manifests.