### PR TITLE
Enable shorthand_optional_binding SwiftLint rule.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,7 @@ opt_in_rules:
   - force_unwrapping
   - private_action
   - explicit_init
+  - shorthand_optional_binding
 
 included:
   - ElementX

--- a/ElementX/Sources/Other/UserIndicator/UserIndicatorModalView.swift
+++ b/ElementX/Sources/Other/UserIndicator/UserIndicatorModalView.swift
@@ -24,7 +24,7 @@ struct UserIndicatorModalView: View {
     var body: some View {
         ZStack {
             VStack(spacing: 12.0) {
-                if let progressFraction = progressFraction {
+                if let progressFraction {
                     ProgressView(value: progressFraction)
                 } else {
                     ProgressView()

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginCoordinator.swift
@@ -205,7 +205,7 @@ final class LoginCoordinator: CoordinatorProtocol {
         
         let coordinator = ServerSelectionCoordinator(parameters: parameters)
         coordinator.callback = { [weak self, weak coordinator] action in
-            guard let self, let coordinator = coordinator else { return }
+            guard let self, let coordinator else { return }
             self.serverSelectionCoordinator(coordinator, didCompleteWith: action)
         }
         

--- a/ElementX/Sources/Services/Emojis/EmojiProvider.swift
+++ b/ElementX/Sources/Services/Emojis/EmojiProvider.swift
@@ -40,7 +40,7 @@ class EmojiProvider: EmojiProviderProtocol {
     
     func getCategories(searchString: String? = nil) async -> [EmojiCategory] {
         let emojiCategories = await loadIfNeeded()
-        if let searchString = searchString, searchString.isEmpty == false {
+        if let searchString, searchString.isEmpty == false {
             return search(searchString: searchString, emojiCategories: emojiCategories)
         } else {
             return emojiCategories

--- a/changelog.d/pr-579.build
+++ b/changelog.d/pr-579.build
@@ -1,0 +1,1 @@
+Update SwiftLint and SwiftFormat rules.


### PR DESCRIPTION
Changelog covers this and the previous SwiftFormat PR.