### PR TITLE
Add required state on subscribe.

### DIFF
--- a/ElementX/Sources/Other/Logging/RustTracing.swift
+++ b/ElementX/Sources/Other/Logging/RustTracing.swift
@@ -38,6 +38,7 @@ struct TracingConfiguration {
         case matrix_sdk_ffi_uniffi_api = "matrix_sdk_ffi::uniffi_api"
         case matrix_sdk_sliding_sync = "matrix_sdk::sliding_sync"
         case matrix_sdk_base_sliding_sync = "matrix_sdk_base::sliding_sync"
+        case matrix_sdk_room_timeline = "matrix_sdk::room::timeline"
     }
     
     let targets: OrderedDictionary<Target, LogLevel> = [
@@ -48,7 +49,8 @@ struct TracingConfiguration {
         .matrix_sdk_crypto: .debug,
         .matrix_sdk_http_client: .debug,
         .matrix_sdk_sliding_sync: .trace,
-        .matrix_sdk_base_sliding_sync: .trace
+        .matrix_sdk_base_sliding_sync: .trace,
+        .matrix_sdk_room_timeline: .info
     ]
     
     var overrides = [Target: LogLevel]()

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -137,7 +137,10 @@ class RoomProxy: RoomProxyProtocol {
     }
         
     func addTimelineListener(listener: TimelineListener) -> Result<Void, RoomProxyError> {
-        if let token = slidingSyncRoom.subscribeAndAddTimelineListener(listener: listener, settings: nil) {
+        let settings = RoomSubscription(requiredState: [RequiredState(key: "m.room.topic", value: ""),
+                                                        RequiredState(key: "m.room.canonical_alias", value: "")],
+                                        timelineLimit: nil)
+        if let token = slidingSyncRoom.subscribeAndAddTimelineListener(listener: listener, settings: settings) {
             timelineObservationToken = token
             Task {
                 await fetchMembers()


### PR DESCRIPTION
Small PR to request the room's topic and canonical alias for display in the room details screen. Its a little bit slow initially, but remembers it when you've opened the room once.