### PR TITLE
Associated Domains 

### DIFF
--- a/ElementX/SupportingFiles/ElementX.entitlements
+++ b/ElementX/SupportingFiles/ElementX.entitlements
@@ -4,6 +4,20 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.vector.im</string>
+		<string>applinks:vector.im</string>
+		<string>applinks:riot.im</string>
+		<string>applinks:www.riot.im</string>
+		<string>webcredentials:riot.im</string>
+		<string>applinks:element.io</string>
+		<string>applinks:app.element.io</string>
+		<string>applinks:staging.element.io</string>
+		<string>applinks:develop.element.io</string>
+		<string>applinks:mobile.element.io</string>
+		<string>webcredentials:*.element.io</string>
+	</array>
 	<key>com.apple.developer.usernotifications.communication</key>
 	<true/>
 	<key>com.apple.security.app-sandbox</key>

--- a/ElementX/SupportingFiles/ElementX.entitlements
+++ b/ElementX/SupportingFiles/ElementX.entitlements
@@ -6,11 +6,6 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:www.vector.im</string>
-		<string>applinks:vector.im</string>
-		<string>applinks:riot.im</string>
-		<string>applinks:www.riot.im</string>
-		<string>webcredentials:riot.im</string>
 		<string>applinks:element.io</string>
 		<string>applinks:app.element.io</string>
 		<string>applinks:staging.element.io</string>

--- a/changelog.d/301.change
+++ b/changelog.d/301.change
@@ -1,0 +1,1 @@
+Added associated domains applinks.


### PR DESCRIPTION
For now I just added all the domains of the current El-iOS app, and opened up an issue [here](https://github.com/vector-im/element.io-website/issues/137) to ask the website to update the apple-app-associated-domains file on the website and on all related website that we still host and have one.

In case some of this website do not have such file anymore, we can remove them later from the entitlments, now just in case, for backwards compatibility let's keep all of them.