### PR TITLE
Fix navigationStackCoordinator getting torn down when being reset on …

### DIFF
--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -138,6 +138,10 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
             return
         }
         
+        if sidebarModule?.coordinator === coordinator {
+            fatalError("Cannot use the same coordinator more than once")
+        }
+        
         sidebarModule = NavigationModule(coordinator, dismissalCallback: dismissalCallback)
     }
     
@@ -149,6 +153,10 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
         guard let coordinator else {
             detailModule = nil
             return
+        }
+        
+        if detailModule?.coordinator === coordinator {
+            fatalError("Cannot use the same coordinator more than once")
         }
         
         detailModule = NavigationModule(coordinator, dismissalCallback: dismissalCallback)
@@ -164,6 +172,10 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
             return
         }
         
+        if sheetModule?.coordinator === coordinator {
+            fatalError("Cannot use the same coordinator more than once")
+        }
+        
         sheetModule = NavigationModule(coordinator, dismissalCallback: dismissalCallback)
     }
     
@@ -175,6 +187,10 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
         guard let coordinator else {
             fullScreenCoverModule = nil
             return
+        }
+        
+        if fullScreenCoverModule?.coordinator === coordinator {
+            fatalError("Cannot use the same coordinator more than once")
         }
         
         fullScreenCoverModule = NavigationModule(coordinator, dismissalCallback: dismissalCallback)
@@ -509,6 +525,10 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
             return
         }
         
+        if rootModule?.coordinator === coordinator {
+            fatalError("Cannot use the same coordinator more than once")
+        }
+        
         popToRoot(animated: false)
         
         rootModule = NavigationModule(coordinator, dismissalCallback: dismissalCallback)
@@ -565,6 +585,10 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
             return
         }
         
+        if sheetModule?.coordinator === coordinator {
+            fatalError("Cannot use the same coordinator more than once")
+        }
+        
         sheetModule = NavigationModule(coordinator, dismissalCallback: dismissalCallback)
     }
     
@@ -582,6 +606,10 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
         guard let coordinator else {
             fullScreenCoverModule = nil
             return
+        }
+        
+        if fullScreenCoverModule?.coordinator === coordinator {
+            fatalError("Cannot use the same coordinator more than once")
         }
         
         fullScreenCoverModule = NavigationModule(coordinator, dismissalCallback: dismissalCallback)

--- a/ElementX/Sources/Services/UserSession/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionFlowCoordinator.swift
@@ -168,8 +168,7 @@ class UserSessionFlowCoordinator: CoordinatorProtocol {
                                                              emojiProvider: emojiProvider)
             let coordinator = RoomScreenCoordinator(parameters: parameters)
             
-            detailNavigationStackCoordinator.setRootCoordinator(coordinator)
-            navigationSplitCoordinator.setDetailCoordinator(detailNavigationStackCoordinator) { [weak self, roomIdentifier] in
+            detailNavigationStackCoordinator.setRootCoordinator(coordinator) { [weak self, roomIdentifier] in
                 guard let self else { return }
                 
                 // Move the state machine to no room selected if the room currently being dimissed
@@ -179,6 +178,10 @@ class UserSessionFlowCoordinator: CoordinatorProtocol {
                     self.stateMachine.processEvent(.deselectRoom)
                     self.detailNavigationStackCoordinator.setRootCoordinator(nil)
                 }
+            }
+            
+            if navigationSplitCoordinator.detailCoordinator == nil {
+                navigationSplitCoordinator.setDetailCoordinator(detailNavigationStackCoordinator)
             }
         }
     }

--- a/UnitTests/Sources/NavigationSplitCoordinatorTests.swift
+++ b/UnitTests/Sources/NavigationSplitCoordinatorTests.swift
@@ -123,22 +123,6 @@ class NavigationSplitCoordinatorTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
     
-    func testNavigationStackDetailRootReplacement() {
-        let detailCoordinator = SomeTestCoordinator()
-        
-        let navigationStackCoordinator = NavigationStackCoordinator()
-        navigationStackCoordinator.setRootCoordinator(detailCoordinator)
-        
-        navigationSplitCoordinator.setDetailCoordinator(navigationStackCoordinator)
-        
-        let newDetailCoordinator = SomeTestCoordinator()
-        navigationStackCoordinator.setRootCoordinator(newDetailCoordinator)
-        
-        navigationSplitCoordinator.setDetailCoordinator(navigationStackCoordinator)
-        
-        assertCoordinatorsEqual(navigationStackCoordinator.rootCoordinator, nil)
-    }
-    
     func testSheetDismissalCallback() {
         let sheetCoordinator = SomeTestCoordinator()
         

--- a/UnitTests/Sources/NavigationSplitCoordinatorTests.swift
+++ b/UnitTests/Sources/NavigationSplitCoordinatorTests.swift
@@ -123,6 +123,22 @@ class NavigationSplitCoordinatorTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
     
+    func testNavigationStackDetailRootReplacement() {
+        let detailCoordinator = SomeTestCoordinator()
+        
+        let navigationStackCoordinator = NavigationStackCoordinator()
+        navigationStackCoordinator.setRootCoordinator(detailCoordinator)
+        
+        navigationSplitCoordinator.setDetailCoordinator(navigationStackCoordinator)
+        
+        let newDetailCoordinator = SomeTestCoordinator()
+        navigationStackCoordinator.setRootCoordinator(newDetailCoordinator)
+        
+        navigationSplitCoordinator.setDetailCoordinator(navigationStackCoordinator)
+        
+        assertCoordinatorsEqual(navigationStackCoordinator.rootCoordinator, nil)
+    }
+    
     func testSheetDismissalCallback() {
         let sheetCoordinator = SomeTestCoordinator()
         
@@ -259,9 +275,13 @@ class NavigationSplitCoordinatorTests: XCTestCase {
     // MARK: - Private
     
     private func assertCoordinatorsEqual(_ lhs: CoordinatorProtocol?, _ rhs: CoordinatorProtocol?) {
+        if lhs == nil, rhs == nil {
+            return
+        }
+        
         guard let lhs = lhs as? SomeTestCoordinator,
               let rhs = rhs as? SomeTestCoordinator else {
-            XCTFail("Coordinators are not the same")
+            XCTFail("Coordinators are not the same: \(String(describing: lhs)) != \(String(describing: rhs))")
             return
         }
         

--- a/changelog.d/pr-613.bugfix
+++ b/changelog.d/pr-613.bugfix
@@ -1,0 +1,1 @@
+Fix broken split layout room navigation


### PR DESCRIPTION
…the navigationSplitCoordinator, added unit tests for it

Navigating to rooms in split mode is currently broken. This happens because we set the `detailNavigationStackCoordinator` multiple times as the `splitCoordinator`'s detail. This in turn make the `splitCoordinator` tear down its previous detail which just happens to be the same as the current one. As the detail is a `navigationStack` that makes it reset itself and release all coordinators

As Coordinators are not currently equatable there's no good way to prevent this on the navigation coordinators level so instead we check against resetting that detail multiple times to the same instance