### PR TITLE
Manually cancel timeline listeners when a RoomScreen is torn down ins…

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -60,6 +60,7 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
     }
     
     func stop() {
+        parameters.roomProxy.removeTimelineListener()
         viewModel.context.send(viewAction: .markRoomAsRead)
     }
     

--- a/ElementX/Sources/Services/Room/MockRoomProxy.swift
+++ b/ElementX/Sources/Services/Room/MockRoomProxy.swift
@@ -44,11 +44,11 @@ struct MockRoomProxy: RoomProxyProtocol {
         .failure(.failedRetrievingMemberAvatarURL)
     }
     
-    func startLiveEventListener() { }
-    
     func addTimelineListener(listener: TimelineListener) -> Result<[TimelineItem], RoomProxyError> {
         .failure(.failedAddingTimelineListener)
     }
+    
+    func removeTimelineListener() { }
     
     func paginateBackwards(requestSize: UInt, untilNumberOfItems: UInt) async -> Result<Void, RoomProxyError> {
         .failure(.failedPaginatingBackwards)

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -34,11 +34,7 @@ class RoomProxy: RoomProxyProtocol {
     private(set) var displayName: String?
     
     private var timelineObservationToken: StoppableSpawn?
-    
-    deinit {
-        timelineObservationToken?.cancel()
-    }
-    
+        
     init(slidingSyncRoom: SlidingSyncRoomProtocol,
          room: RoomProtocol,
          backgroundTaskService: BackgroundTaskServiceProtocol) {
@@ -149,6 +145,11 @@ class RoomProxy: RoomProxyProtocol {
         } else {
             return .failure(.failedAddingTimelineListener)
         }
+    }
+    
+    func removeTimelineListener() {
+        timelineObservationToken?.cancel()
+        timelineObservationToken = nil
     }
     
     func paginateBackwards(requestSize: UInt, untilNumberOfItems: UInt) async -> Result<Void, RoomProxyError> {

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -60,6 +60,8 @@ protocol RoomProxyProtocol {
     
     func addTimelineListener(listener: TimelineListener) -> Result<[TimelineItem], RoomProxyError>
     
+    func removeTimelineListener()
+    
     func paginateBackwards(requestSize: UInt, untilNumberOfItems: UInt) async -> Result<Void, RoomProxyError>
     
     func sendReadReceipt(for eventID: String) async -> Result<Void, RoomProxyError>


### PR DESCRIPTION
…tead of waiting for a delayed deinit

Potential (partial?) fix for https://github.com/vector-im/element-x-ios/issues/615