### PR TITLE
Sliding sync session reset manual backpagination

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -142,6 +142,14 @@ class TimelineTableViewController: UIViewController {
             }
             .store(in: &cancellables)
         
+        // The sliding sync session can expire while the app is in the background. In that case the
+        // timeline receives a clear() diff. Run this to make sure we load up items if needed
+        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+            .sink { [weak self] _ in
+                self?.paginateBackwardsPublisher.send()
+            }
+            .store(in: &cancellables)
+        
         configureDataSource()
     }
     

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -48,6 +48,10 @@ class TimelineTableViewController: UIViewController {
             }
             
             applySnapshot()
+            
+            if timelineItems.isEmpty {
+                paginateBackwardsPublisher.send()
+            }
         }
     }
     
@@ -139,14 +143,6 @@ class TimelineTableViewController: UIViewController {
             .sink { [weak self] _ in
                 guard let self, let layout = self.keyboardWillShowLayout, layout.isBottomVisible else { return }
                 self.scrollToBottom(animated: false) // Force the bottom to be visible as some timelines misbehave.
-            }
-            .store(in: &cancellables)
-        
-        // The sliding sync session can expire while the app is in the background. In that case the
-        // timeline receives a clear() diff. Run this to make sure we load up items if needed
-        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
-            .sink { [weak self] _ in
-                self?.paginateBackwardsPublisher.send()
             }
             .store(in: &cancellables)
         

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
@@ -45,10 +45,6 @@ struct TimelineView: UIViewControllerRepresentable {
         
         init(viewModelContext: RoomScreenViewModel.Context) {
             context = viewModelContext
-            
-            if viewModelContext.viewState.items.isEmpty {
-                viewModelContext.send(viewAction: .paginateBackwards)
-            }
         }
         
         /// Updates the specified table view's properties from the current view state.


### PR DESCRIPTION
Request backpagination whenever the timeline item list is empty. This can happen when first loading loading the timeline or after a sliding sync session reset