### PR TITLE
Put back the initial pagination.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
@@ -45,6 +45,10 @@ struct TimelineView: UIViewControllerRepresentable {
         
         init(viewModelContext: RoomScreenViewModel.Context) {
             context = viewModelContext
+            
+            if viewModelContext.viewState.items.isEmpty {
+                viewModelContext.send(viewAction: .paginateBackwards)
+            }
         }
         
         /// Updates the specified table view's properties from the current view state.


### PR DESCRIPTION
The initial pagination removed in #628 is fine if the view appears with enough items to require the user to scroll, but if it doesn't then they will be shown an empty looking room with out any more content being loaded for them.

This PR reverts that change.