### PR TITLE
Collapsible timeline item tweaks

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/CollapsibleRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/CollapsibleRoomTimelineView.swift
@@ -53,7 +53,7 @@ struct CollapsibleRoomTimelineView_Previews: PreviewProvider {
 
 private struct CollapsibleRoomTimelineItemDisclosureGroupStyle: DisclosureGroupStyle {
     func makeBody(configuration: Configuration) -> some View {
-        VStack {
+        VStack(spacing: 0.0) {
             HStack(alignment: .center) {
                 configuration.label
                 Text(Image(systemName: "chevron.forward"))
@@ -63,8 +63,10 @@ private struct CollapsibleRoomTimelineItemDisclosureGroupStyle: DisclosureGroupS
             .frame(maxWidth: .infinity)
             .font(.element.footnote)
             .foregroundColor(.element.secondaryContent)
-            .padding(.horizontal, 36)
-            .padding(.vertical, 8)
+            .padding(.horizontal, 36.0)
+            .padding(.top, 20.0)
+            .padding(.bottom, 12.0)
+
             .onTapGesture {
                 configuration.isExpanded.toggle()
             }

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/SeparatorRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/SeparatorRoomTimelineView.swift
@@ -23,9 +23,9 @@ struct SeparatorRoomTimelineView: View {
         Text(timelineItem.text)
             .font(.element.footnote)
             .foregroundColor(.element.secondaryContent)
-            .padding(.top, 12)
-            .padding(.bottom, 8)
             .frame(maxWidth: .infinity)
+            .padding(.horizontal, 36.0)
+            .padding(.vertical, 8.0)
     }
 }
 

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/StateRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/StateRoomTimelineView.swift
@@ -25,8 +25,8 @@ struct StateRoomTimelineView: View {
             .multilineTextAlignment(.center)
             .foregroundColor(.element.secondaryContent)
             .frame(maxWidth: .infinity, alignment: .center)
-            .padding(.horizontal, 36)
-            .padding(.vertical, 8)
+            .padding(.horizontal, 36.0)
+            .padding(.vertical, 8.0)
     }
 }
 

--- a/changelog.d/631.bugfix
+++ b/changelog.d/631.bugfix
@@ -1,0 +1,1 @@
+Prevent creating collapsible groups for one single event. Increase their padding and touch area.


### PR DESCRIPTION
* Fix collapsible timeline items grouping just one item, remove duplicate timeline item checking, clean up the logic
* Cleanup collapsible, separator and state room timeline view paddings
* Increase collapsible button tappable area

![Screenshot 2023-02-27 at 16 33 53](https://user-images.githubusercontent.com/637564/221594359-bae5d7f9-28e3-4c3d-acf0-6d325a362eea.png)
