### PR TITLE
Various fixes

### DIFF
--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -229,15 +229,13 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
     ///
     /// For added complexity, the NavigationSplitCoordinator has an internal compact layout NavigationStack for which we need to manually nil things again
     private func releaseAllCoordinatorReferences() {
-        sidebarModule?.tearDown()
-        detailModule?.tearDown()
-        sheetModule?.tearDown()
-        fullScreenCoverModule?.tearDown()
+        sidebarModule = nil
+        detailModule = nil
+        sheetModule = nil
+        fullScreenCoverModule = nil
         
-        compactLayoutRootModule?.tearDown()
-        compactLayoutStackModules.forEach { module in
-            module.tearDown()
-        }
+        compactLayoutRootModule = nil
+        compactLayoutStackModules.removeAll()
     }
     
     private func logPresentationChange(_ change: String, _ module: NavigationModule) {
@@ -626,13 +624,10 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
     /// when a NavigationModule is dismissed. As the NavigationModule is just a wrapper multiple instances of it continuing living is of no consequence
     /// https://stackoverflow.com/questions/73885353/found-a-strange-behaviour-of-state-when-combined-to-the-new-navigation-stack/
     func stop() {
-        rootModule?.tearDown()
-        sheetModule?.tearDown()
-        fullScreenCoverModule?.tearDown()
-        
-        stackModules.forEach { module in
-            module.tearDown()
-        }
+        rootModule = nil
+        sheetModule = nil
+        fullScreenCoverModule = nil
+        stackModules.removeAll()
     }
     
     // MARK: - CustomStringConvertible

--- a/ElementX/Sources/Screens/Settings/SettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreenViewModel.swift
@@ -27,10 +27,16 @@ class SettingsScreenViewModel: SettingsScreenViewModelType, SettingsScreenViewMo
     init(withUserSession userSession: UserSessionProtocol) {
         self.userSession = userSession
         let bindings = SettingsScreenViewStateBindings(timelineStyle: ServiceLocator.shared.settings.timelineStyle)
+        
+        var showSessionVerificationSection = false
+        if let sessionVerificationController = userSession.sessionVerificationController {
+            showSessionVerificationSection = !sessionVerificationController.isVerified
+        }
+        
         super.init(initialViewState: .init(bindings: bindings,
                                            deviceID: userSession.deviceID,
                                            userID: userSession.userID,
-                                           showSessionVerificationSection: !(userSession.sessionVerificationController?.isVerified ?? false),
+                                           showSessionVerificationSection: showSessionVerificationSection,
                                            showDeveloperOptions: ServiceLocator.shared.settings.canShowDeveloperOptions),
                    imageProvider: userSession.mediaProvider)
         

--- a/changelog.d/pr-650.bugfix
+++ b/changelog.d/pr-650.bugfix
@@ -1,0 +1,1 @@
+Fixed crash on the settings screen when showing the "complete verification" button before the session verification controller proxy was ready


### PR DESCRIPTION
This PR fixes 2 bugs:
1) Incorrect stack and split coordinator teardowns leading to possible multiple stops for the same coordinator
2) Crashes on the settings screen which was showing the "complete verification" button before the session verification controller proxy was ready