### PR TITLE
Navigation fixes

### DIFF
--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -229,13 +229,15 @@ class NavigationSplitCoordinator: CoordinatorProtocol, ObservableObject, CustomS
     ///
     /// For added complexity, the NavigationSplitCoordinator has an internal compact layout NavigationStack for which we need to manually nil things again
     private func releaseAllCoordinatorReferences() {
-        sidebarModule = nil
-        detailModule = nil
-        sheetModule = nil
-        fullScreenCoverModule = nil
+        sidebarModule?.tearDown()
+        detailModule?.tearDown()
+        sheetModule?.tearDown()
+        fullScreenCoverModule?.tearDown()
         
-        compactLayoutRootModule = nil
-        compactLayoutStackModules.removeAll()
+        compactLayoutRootModule?.tearDown()
+        compactLayoutStackModules.forEach { module in
+            module.tearDown()
+        }
     }
     
     private func logPresentationChange(_ change: String, _ module: NavigationModule) {
@@ -624,10 +626,13 @@ class NavigationStackCoordinator: ObservableObject, CoordinatorProtocol, CustomS
     /// when a NavigationModule is dismissed. As the NavigationModule is just a wrapper multiple instances of it continuing living is of no consequence
     /// https://stackoverflow.com/questions/73885353/found-a-strange-behaviour-of-state-when-combined-to-the-new-navigation-stack/
     func stop() {
-        rootModule = nil
-        sheetModule = nil
-        fullScreenCoverModule = nil
-        stackModules.removeAll()
+        rootModule?.tearDown()
+        sheetModule?.tearDown()
+        fullScreenCoverModule?.tearDown()
+        
+        stackModules.forEach { module in
+            module.tearDown()
+        }
     }
     
     // MARK: - CustomStringConvertible

--- a/ElementX/Sources/Application/Navigation/NavigationModule.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationModule.swift
@@ -36,9 +36,11 @@ class NavigationModule: Identifiable, Hashable {
     
     func tearDown() {
         coordinator?.stop()
-        dismissalCallback?()
         coordinator = nil
+        
+        let callback = dismissalCallback
         dismissalCallback = nil
+        callback?()
     }
     
     nonisolated static func == (lhs: NavigationModule, rhs: NavigationModule) -> Bool {


### PR DESCRIPTION
This PR is a better fix for https://github.com/vector-im/element-x-ios/pull/650/commits/4ae3b3b2dba033d560fe5321686635c96bd53f95

The original problem was that the UserSessionFlowCoordinator sets the split coordinator's detail to nil in the stack coordinator's dismissal callback. This in turn makes tearDown be called multiple times on the stack's root.

The initial fix was to nil out everything on tearDown but that has the side effect of introducing UI level changes e.g. the login screen gets popped when switching the `NavigationRootCoordinator`'s root.

I've reverted that change and now making sure that the callback is nilled out in the NavigationModule level and prevents re-entry