### PR TITLE
Remove unused media loading from URL.

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -404,10 +404,6 @@ class ClientProxy: ClientProxyProtocol {
 }
 
 extension ClientProxy: MediaLoaderProtocol {
-    func mediaSourceForURL(_ url: URL) async -> MediaSourceProxy {
-        await mediaLoader.mediaSourceForURL(url)
-    }
-
     func loadMediaContentForSource(_ source: MediaSourceProxy) async throws -> Data {
         try await mediaLoader.loadMediaContentForSource(source)
     }

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -69,10 +69,6 @@ class MockClientProxy: ClientProxyProtocol {
         .failure(.failedSettingAccountData)
     }
     
-    func mediaSourceForURL(_ url: URL) -> MediaSourceProxy {
-        .init(url: url)
-    }
-    
     func loadMediaContentForSource(_ source: MediaSourceProxy) async throws -> Data {
         throw ClientProxyError.failedLoadingMedia
     }

--- a/ElementX/Sources/Services/Media/ImageProviderProtocol.swift
+++ b/ElementX/Sources/Services/Media/ImageProviderProtocol.swift
@@ -20,10 +20,6 @@ protocol ImageProviderProtocol {
     func imageFromSource(_ source: MediaSourceProxy?, size: CGSize?) -> UIImage?
     
     @discardableResult func loadImageFromSource(_ source: MediaSourceProxy, size: CGSize?) async -> Result<UIImage, MediaProviderError>
-    
-    func imageFromURL(_ url: URL?, size: CGSize?) -> UIImage?
-    
-    @discardableResult func loadImageFromURL(_ url: URL, size: CGSize?) async -> Result<UIImage, MediaProviderError>
 }
 
 extension ImageProviderProtocol {
@@ -33,13 +29,5 @@ extension ImageProviderProtocol {
     
     @discardableResult func loadImageFromSource(_ source: MediaSourceProxy) async -> Result<UIImage, MediaProviderError> {
         await loadImageFromSource(source, size: nil)
-    }
-    
-    func imageFromURL(_ url: URL?) -> UIImage? {
-        imageFromURL(url, size: nil)
-    }
-    
-    @discardableResult func loadImageFromURL(_ url: URL) async -> Result<UIImage, MediaProviderError> {
-        await loadImageFromURL(url, size: nil)
     }
 }

--- a/ElementX/Sources/Services/Media/MediaLoader.swift
+++ b/ElementX/Sources/Services/Media/MediaLoader.swift
@@ -33,10 +33,6 @@ actor MediaLoader: MediaLoaderProtocol {
         self.client = client
         self.clientQueue = clientQueue
     }
-
-    func mediaSourceForURL(_ url: URL) -> MediaSourceProxy {
-        .init(url: url)
-    }
     
     func loadMediaContentForSource(_ source: MediaSourceProxy) async throws -> Data {
         try await enqueueLoadMediaRequest(forSource: source) {

--- a/ElementX/Sources/Services/Media/MediaLoaderProtocol.swift
+++ b/ElementX/Sources/Services/Media/MediaLoaderProtocol.swift
@@ -17,8 +17,6 @@
 import Foundation
 
 protocol MediaLoaderProtocol {
-    func mediaSourceForURL(_ url: URL) async -> MediaSourceProxy
-
     func loadMediaContentForSource(_ source: MediaSourceProxy) async throws -> Data
 
     func loadMediaThumbnailForSource(_ source: MediaSourceProxy, width: UInt, height: UInt) async throws -> Data

--- a/ElementX/Sources/Services/Media/MediaProvider.swift
+++ b/ElementX/Sources/Services/Media/MediaProvider.swift
@@ -43,18 +43,6 @@ struct MediaProvider: MediaProviderProtocol {
         return imageCache.retrieveImageInMemoryCache(forKey: cacheKey, options: nil)
     }
     
-    func imageFromURL(_ url: URL?, size: CGSize?) -> UIImage? {
-        guard let url else {
-            return nil
-        }
-        
-        return imageFromSource(.init(url: url), size: size)
-    }
-    
-    func loadImageFromURL(_ url: URL, size: CGSize?) async -> Result<UIImage, MediaProviderError> {
-        await loadImageFromSource(.init(url: url), size: size)
-    }
-    
     func loadImageFromSource(_ source: MediaSourceProxy, size: CGSize?) async -> Result<UIImage, MediaProviderError> {
         if let image = imageFromSource(source, size: size) {
             return .success(image)
@@ -102,18 +90,6 @@ struct MediaProvider: MediaProviderProtocol {
         }
         let cacheKey = fileCacheKeyForURL(source.url)
         return fileCache.file(forKey: cacheKey, fileExtension: fileExtension)
-    }
-    
-    func fileFromURL(_ url: URL?, fileExtension: String) -> URL? {
-        guard let url else {
-            return nil
-        }
-        
-        return fileFromSource(MediaSourceProxy(url: url), fileExtension: fileExtension)
-    }
-    
-    func loadFileFromURL(_ url: URL, fileExtension: String) async -> Result<URL, MediaProviderError> {
-        await loadFileFromSource(MediaSourceProxy(url: url), fileExtension: fileExtension)
     }
 
     @discardableResult func loadFileFromSource(_ source: MediaSourceProxy, fileExtension: String) async -> Result<URL, MediaProviderError> {

--- a/ElementX/Sources/Services/Media/MediaProviderProtocol.swift
+++ b/ElementX/Sources/Services/Media/MediaProviderProtocol.swift
@@ -27,8 +27,4 @@ protocol MediaProviderProtocol: ImageProviderProtocol {
     func fileFromSource(_ source: MediaSourceProxy?, fileExtension: String) -> URL?
 
     @discardableResult func loadFileFromSource(_ source: MediaSourceProxy, fileExtension: String) async -> Result<URL, MediaProviderError>
-
-    func fileFromURL(_ url: URL?, fileExtension: String) -> URL?
-
-    @discardableResult func loadFileFromURL(_ url: URL, fileExtension: String) async -> Result<URL, MediaProviderError>
 }

--- a/ElementX/Sources/Services/Media/MockMediaProvider.swift
+++ b/ElementX/Sources/Services/Media/MockMediaProvider.swift
@@ -19,15 +19,7 @@ import UIKit
 
 struct MockMediaProvider: MediaProviderProtocol {
     func imageFromSource(_ source: MediaSourceProxy?, size: CGSize?) -> UIImage? {
-        imageFromURL(source?.url, size: size)
-    }
-    
-    func loadImageFromSource(_ source: MediaSourceProxy, size: CGSize?) async -> Result<UIImage, MediaProviderError> {
-        .failure(.failedRetrievingImage)
-    }
-    
-    func imageFromURL(_ url: URL?, size: CGSize?) -> UIImage? {
-        guard url != nil else {
+        guard source != nil else {
             return nil
         }
         
@@ -42,7 +34,7 @@ struct MockMediaProvider: MediaProviderProtocol {
         return UIImage(systemName: "photo")
     }
     
-    func loadImageFromURL(_ url: URL, size: CGSize?) async -> Result<UIImage, MediaProviderError> {
+    func loadImageFromSource(_ source: MediaSourceProxy, size: CGSize?) async -> Result<UIImage, MediaProviderError> {
         guard let image = UIImage(systemName: "photo") else {
             fatalError()
         }
@@ -55,14 +47,6 @@ struct MockMediaProvider: MediaProviderProtocol {
     }
 
     @discardableResult func loadFileFromSource(_ source: MediaSourceProxy, fileExtension: String) async -> Result<URL, MediaProviderError> {
-        .failure(.failedRetrievingFile)
-    }
-
-    func fileFromURL(_ url: URL?, fileExtension: String) -> URL? {
-        nil
-    }
-
-    @discardableResult func loadFileFromURL(_ url: URL, fileExtension: String) async -> Result<URL, MediaProviderError> {
         .failure(.failedRetrievingFile)
     }
 }

--- a/UnitTests/Sources/MediaProvider/MediaProviderTests.swift
+++ b/UnitTests/Sources/MediaProvider/MediaProviderTests.swift
@@ -56,26 +56,6 @@ final class MediaProviderTests: XCTestCase {
         XCTAssertNil(image)
     }
     
-    func test_whenImageFromURLStringWithURLStringNil_nilReturned() throws {
-        let image = mediaProvider.imageFromURL(nil, size: AvatarSize.room(on: .timeline).scaledSize)
-        XCTAssertNil(image)
-    }
-    
-    func test_whenImageFromURLStringWithURLStringNotNilAndImageCacheContainsImage_imageIsReturned() throws {
-        let avatarSize = AvatarSize.room(on: .timeline)
-        let url = URL.picturesDirectory
-        let key = "\(url.absoluteString){\(avatarSize.scaledValue),\(avatarSize.scaledValue)}"
-        let imageForKey = UIImage()
-        imageCache.retrievedImagesInMemory[key] = imageForKey
-        let image = mediaProvider.imageFromURL(url, size: avatarSize.scaledSize)
-        XCTAssertEqual(image, imageForKey)
-    }
-    
-    func test_whenImageFromURLStringWithURLStringNotNilAndImageNotCached_nilReturned() throws {
-        let image = mediaProvider.imageFromURL(URL.picturesDirectory, size: AvatarSize.room(on: .timeline).scaledSize)
-        XCTAssertNil(image)
-    }
-    
     func test_whenLoadImageFromSourceAndImageCacheContainsImage_successIsReturned() async throws {
         let avatarSize = AvatarSize.room(on: .timeline)
         let url = URL.picturesDirectory
@@ -210,27 +190,6 @@ final class MediaProviderTests: XCTestCase {
         let expectedResult: Result<URL, MediaProviderError> = .failure(.failedRetrievingImage)
         mediaLoader.mediaContentData = try loadTestImage().pngData()
         let result = await mediaProvider.loadFileFromSource(MediaSourceProxy(url: URL(staticString: "test/test1")), fileExtension: "png")
-        XCTAssertEqual(result, expectedResult)
-    }
-    
-    func test_whenFileFromURLStringAndURLIsNil_nilIsReturned() async throws {
-        mediaLoader.mediaContentData = try loadTestImage().pngData()
-        let url = mediaProvider.fileFromURL(nil, fileExtension: "png")
-        XCTAssertNil(url)
-    }
-    
-    func test_whenFileFromURLString_correctURLIsReturned() throws {
-        let expectedURL = URL(filePath: "/some/file/path")
-        fileCache.fileURLToReturn = expectedURL
-        let url = mediaProvider.fileFromURL(URL(staticString: "test/test1"), fileExtension: "png")
-        XCTAssertEqual(url?.absoluteString, expectedURL.absoluteString)
-    }
-    
-    func test_whenLoadFileFromURLString_correctURLIsReturned() async throws {
-        let expectedURL = URL(filePath: "/some/file/path")
-        let expectedResult: Result<URL, MediaProviderError> = .success(expectedURL)
-        fileCache.fileURLToReturn = expectedURL
-        let result = await mediaProvider.loadFileFromURL(URL(staticString: "test/test1"), fileExtension: "png")
         XCTAssertEqual(result, expectedResult)
     }
     

--- a/UnitTests/Sources/MediaProvider/MockMediaLoader.swift
+++ b/UnitTests/Sources/MediaProvider/MockMediaLoader.swift
@@ -24,10 +24,6 @@ class MockMediaLoader: MediaLoaderProtocol {
     var mediaContentData: Data?
     var mediaThumbnailData: Data?
     
-    func mediaSourceForURL(_ url: URL) -> MediaSourceProxy {
-        MediaSourceProxy(url: URL.picturesDirectory)
-    }
-    
     func loadMediaContentForSource(_ source: ElementX.MediaSourceProxy) async throws -> Data {
         if let mediaContentData {
             return mediaContentData

--- a/changelog.d/444.api
+++ b/changelog.d/444.api
@@ -1,0 +1,1 @@
+Remove all APIs that load media from URLs. These were unused and we should continue to load media through MediaSource in the future.


### PR DESCRIPTION
There are all unused as we are now using `MediaSource` everywhere (and should continue to do so).