### PR TITLE
Hide scroll down button VoiceOver

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -79,6 +79,7 @@ struct RoomScreen: View {
                 .padding()
         }
         .opacity(context.scrollToBottomButtonVisible ? 1.0 : 0.0)
+        .accessibilityHidden(!context.scrollToBottomButtonVisible)
         .animation(.elementDefault, value: context.scrollToBottomButtonVisible)
     }
     

--- a/changelog.d/pr670.bugfix
+++ b/changelog.d/pr670.bugfix
@@ -1,0 +1,1 @@
+Hides the scroll down button for VoiceOver users if it is hidden for visual users by Sem Pruijs


### PR DESCRIPTION

The scroll down button was still intractable when it was hidden for visual users. This pr fixes that by hiding the button if it is hidden for visual users.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [x] Voiceover enabled.
