### PR TITLE
Fix message composer textfield accessibility label

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
@@ -41,6 +41,7 @@ struct MessageComposerTextField: View {
                           isMultiline: $isMultiline,
                           maxHeight: maxHeight,
                           onEnterKeyHandler: onEnterKeyHandler)
+            .accessibilityLabel(placeholder)
             .background(placeholderView, alignment: .topLeading)
     }
     
@@ -49,6 +50,7 @@ struct MessageComposerTextField: View {
         if showingPlaceholder {
             Text(placeholder)
                 .foregroundColor(placeholderColor)
+                .accessibilityHidden(true)
         }
     }
 }

--- a/changelog.d/pr-688.bugfix
+++ b/changelog.d/pr-688.bugfix
@@ -1,0 +1,1 @@
+Hide the message composer textfield placeholder for VoiceOver users by Sem Pruijs


### PR DESCRIPTION
For VoiceOver users, there were 2 elements that where selectable. 
The first was the background message text placeholder, and the second the textfield.
You could only let the keyboard appear by activating the placeholder text and nothing happend when you clicked on the textfield.

This pr fixes that by hiding the placeholder text for VoiceOver users and giving an accessibility label to the textfield. 

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [x] Voiceover enabled.
