### PR TITLE
Hide the avatar when the Dynamic Text is large

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
@@ -20,6 +20,8 @@ struct HomeScreenRoomCell: View {
     let room: HomeScreenRoom
     let context: HomeScreenViewModel.Context
     
+    @Environment(\.dynamicTypeSize) var size
+    
     var body: some View {
         Button {
             if let roomId = room.roomId {
@@ -49,12 +51,14 @@ struct HomeScreenRoomCell: View {
     
     @ViewBuilder
     var avatar: some View {
-        LoadableAvatarImage(url: room.avatarURL,
-                            name: room.name,
-                            contentID: room.roomId,
-                            avatarSize: .room(on: .home),
-                            imageProvider: context.imageProvider)
-            .accessibilityHidden(true)
+        if size < .accessibility4 {
+            LoadableAvatarImage(url: room.avatarURL,
+                                name: room.name,
+                                contentID: room.roomId,
+                                avatarSize: .room(on: .home),
+                                imageProvider: context.imageProvider)
+                .accessibilityHidden(true)
+        }
     }
     
     @ViewBuilder

--- a/changelog.d/pr-690.bugfix
+++ b/changelog.d/pr-690.bugfix
@@ -1,0 +1,1 @@
+Hide the avatars when the users has larger font on by Sem Pruijs


### PR DESCRIPTION
Currently, when the user has larger font on (settings > accessibility > display & text size  > larger text) and they try to read the content in the Home Screen, the profile pictures are so big that they cannot read the groep name anymore.

I think the group name and the preview message is more important than someones profile picture. (And  whatsapp agrees with me)



![old, a screenshot of the home view where the profile pictures are too big](https://user-images.githubusercontent.com/19208988/223716895-28c19a54-afd6-4c61-ad5d-e1aaa1ccbd0d.png)


This pr fixes that by hiding the avatar when the user has a larger text size.

![normal, a screenshot with the regular text size](https://user-images.githubusercontent.com/19208988/223716893-4a120ea3-cfab-4d1f-9a2b-56d0dba2119c.png)
![fixed, a screenshot of the home view with larger text, where the profile pictures are hidden ](https://user-images.githubusercontent.com/19208988/223716887-d7534539-7c61-437a-8e10-5ca3ad109d52.png)

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

**UI changes have been tested with:**
- [x] iPhone and iPad simulators in portrait and landscape orientations.
- [x] Dark mode enabled and disabled.
- [x] Various sizes of dynamic type.
- [x] Voiceover enabled.
