### PR TITLE
Fix accent colour not being applied to Alerts etc.

### DIFF
--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -22,6 +22,10 @@ struct Application: App {
     private let applicationCoordinator: AppCoordinatorProtocol
 
     init() {
+        // Set the tint colour app-wide. Using UIView ensures that alerts, confirmation dialogs
+        // and Xcode previews all take on the tint colour, similar to defining it in an asset catalog.
+        UIView.appearance().tintColor = .element.accent
+        
         if Tests.isRunningUITests {
             applicationCoordinator = UITestsAppCoordinator()
         } else {
@@ -35,7 +39,6 @@ struct Application: App {
                 EmptyView()
             } else {
                 applicationCoordinator.toPresentable()
-                    .accentColor(.element.accent)
                     .task {
                         applicationCoordinator.start()
                     }

--- a/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
+++ b/ElementX/Sources/Application/Navigation/NavigationCoordinators.swift
@@ -371,11 +371,9 @@ private struct NavigationSplitCoordinatorView: View {
         // through the NavigationSplitCoordinator as well.
         .sheet(item: $navigationSplitCoordinator.sheetModule) { module in
             module.coordinator?.toPresentable()
-                .tint(.element.accent)
         }
         .fullScreenCover(item: $navigationSplitCoordinator.fullScreenCoverModule) { module in
             module.coordinator?.toPresentable()
-                .tint(.element.accent)
         }
     }
     
@@ -666,11 +664,9 @@ private struct NavigationStackCoordinatorView: View {
         }
         .sheet(item: $navigationStackCoordinator.sheetModule) { module in
             module.coordinator?.toPresentable()
-                .tint(.element.accent)
         }
         .fullScreenCover(item: $navigationStackCoordinator.fullScreenCoverModule) { module in
             module.coordinator?.toPresentable()
-                .tint(.element.accent)
         }
     }
 }

--- a/ElementX/Sources/Screens/AnalyticsPrompt/View/AnalyticsPrompt.swift
+++ b/ElementX/Sources/Screens/AnalyticsPrompt/View/AnalyticsPrompt.swift
@@ -69,6 +69,7 @@ struct AnalyticsPrompt: View {
                 .font(.element.body)
                 .multilineTextAlignment(.center)
                 .foregroundColor(.element.secondaryContent)
+                .tint(.element.links)
             
             Divider()
                 .background(Color.element.quinaryContent)
@@ -115,6 +116,5 @@ struct AnalyticsPrompt_Previews: PreviewProvider {
     static let viewModel = AnalyticsPromptViewModel(termsURL: ServiceLocator.shared.settings.analyticsConfiguration.termsURL)
     static var previews: some View {
         AnalyticsPrompt(context: viewModel.context)
-            .tint(.element.accent)
     }
 }

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/View/LoginScreen.swift
@@ -165,7 +165,6 @@ struct Login_Previews: PreviewProvider {
         NavigationStack {
             LoginScreen(context: viewModel.context)
                 .navigationBarTitleDisplayMode(.inline)
-                .tint(.element.accent)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button { } label: {
@@ -174,6 +173,5 @@ struct Login_Previews: PreviewProvider {
                     }
                 }
         }
-        .tint(.element.accent)
     }
 }

--- a/ElementX/Sources/Screens/Authentication/ServerSelection/View/ServerSelectionScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelection/View/ServerSelectionScreen.swift
@@ -106,7 +106,6 @@ struct ServerSelection_Previews: PreviewProvider {
         ForEach(MockServerSelectionScreenState.allCases, id: \.self) { state in
             NavigationStack {
                 ServerSelectionScreen(context: state.viewModel.context)
-                    .tint(.element.accent)
             }
         }
     }

--- a/ElementX/Sources/Screens/Authentication/SoftLogout/View/SoftLogoutScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/SoftLogout/View/SoftLogoutScreen.swift
@@ -182,7 +182,6 @@ struct SoftLogout_Previews: PreviewProvider {
         NavigationStack {
             SoftLogoutScreen(context: viewModel.context)
                 .navigationBarTitleDisplayMode(.inline)
-                .tint(.element.accent)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button { } label: {
@@ -191,6 +190,5 @@ struct SoftLogout_Previews: PreviewProvider {
                     }
                 }
         }
-        .tint(.element.accent)
     }
 }

--- a/ElementX/Sources/Screens/DeveloperOptionsScreen/View/DeveloperOptionsScreenScreen.swift
+++ b/ElementX/Sources/Screens/DeveloperOptionsScreen/View/DeveloperOptionsScreenScreen.swift
@@ -26,6 +26,8 @@ struct DeveloperOptionsScreenScreen: View {
                 Toggle(isOn: $context.shouldCollapseRoomStateEvents) {
                     Text("Collapse room state events")
                 }
+                .tint(.element.brand)
+                .labelStyle(FormRowLabelStyle())
                 .onChange(of: context.shouldCollapseRoomStateEvents) { _ in
                     context.send(viewAction: .changedShouldCollapseRoomStateEvents)
                 }
@@ -77,6 +79,5 @@ struct DeveloperOptionsScreen_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = DeveloperOptionsScreenViewModel()
         DeveloperOptionsScreenScreen(context: viewModel.context)
-            .tint(.element.accent)
     }
 }

--- a/ElementX/Sources/Screens/EmojiPickerScreen/View/EmojiPickerScreen.swift
+++ b/ElementX/Sources/Screens/EmojiPickerScreen/View/EmojiPickerScreen.swift
@@ -67,6 +67,5 @@ struct EmojiPickerScreen_Previews: PreviewProvider {
         NavigationStack {
             EmojiPickerScreen(context: EmojiPickerScreenViewModel(emojiProvider: EmojiProvider()).context)
         }
-        .tint(.element.accent)
     }
 }

--- a/ElementX/Sources/Screens/FilePreview/View/FilePreviewScreen.swift
+++ b/ElementX/Sources/Screens/FilePreview/View/FilePreviewScreen.swift
@@ -98,6 +98,5 @@ struct FilePreview_Previews: PreviewProvider {
             let upgradeViewModel = FilePreviewViewModel(fileURL: URL(staticString: "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"))
             FilePreviewScreen(context: upgradeViewModel.context)
         }
-        .tint(.element.accent)
     }
 }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -240,9 +240,7 @@ struct HomeScreen: View {
 struct HomeScreen_Previews: PreviewProvider {
     static var previews: some View {
         body(.loading)
-            .tint(.element.accent)
         body(.loaded)
-            .tint(.element.accent)
     }
     
     static func body(_ state: MockRoomSummaryProviderState) -> some View {

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
@@ -161,10 +161,6 @@ private extension View {
 
 struct HomeScreenRoomCell_Previews: PreviewProvider {
     static var previews: some View {
-        body.tint(.element.accent)
-    }
-
-    static var body: some View {
         let summaryProvider = MockRoomSummaryProvider(state: .loaded)
 
         let userSession = MockUserSession(clientProxy: MockClientProxy(userID: "John Doe", roomSummaryProvider: summaryProvider),

--- a/ElementX/Sources/Screens/OnboardingScreen/View/OnboardingScreen.swift
+++ b/ElementX/Sources/Screens/OnboardingScreen/View/OnboardingScreen.swift
@@ -205,6 +205,5 @@ struct OnboardingScreen_Previews: PreviewProvider {
     
     static var previews: some View {
         OnboardingScreen(context: viewModel.context)
-            .tint(.element.accent)
     }
 }

--- a/ElementX/Sources/Screens/RoomDetails/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetails/View/RoomDetailsScreen.swift
@@ -171,6 +171,5 @@ struct RoomDetails_Previews: PreviewProvider {
     
     static var previews: some View {
         RoomDetailsScreen(context: viewModel.context)
-            .tint(.element.accent)
     }
 }

--- a/ElementX/Sources/Screens/RoomMembers/View/RoomMemberDetailsMemberCell.swift
+++ b/ElementX/Sources/Screens/RoomMembers/View/RoomMemberDetailsMemberCell.swift
@@ -48,13 +48,6 @@ struct RoomMemberDetailsMemberCell: View {
 
 struct RoomMemberDetailsMemberCell_Previews: PreviewProvider {
     static var previews: some View {
-        body.preferredColorScheme(.light)
-            .tint(.element.accent)
-        body.preferredColorScheme(.dark)
-            .tint(.element.accent)
-    }
-
-    static var body: some View {
         let members: [RoomMemberProxy] = [
             .mockAlice,
             .mockBob,

--- a/ElementX/Sources/Screens/RoomMembers/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMembers/View/RoomMemberDetailsScreen.swift
@@ -59,6 +59,5 @@ struct RoomMemberDetails_Previews: PreviewProvider {
                                                        members: members)
             RoomMemberDetailsScreen(context: viewModel.context)
         }
-        .tint(.element.accent)
     }
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
@@ -217,7 +217,6 @@ struct MessageComposer_Previews: PreviewProvider {
                             replyCancellationAction: { },
                             editCancellationAction: { })
         }
-        .tint(.element.accent)
         .padding(.horizontal)
     }
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemDebugView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemDebugView.swift
@@ -51,7 +51,6 @@ struct TimelineItemDebugView: View {
                 }
             }
         }
-        .tint(.element.accent)
     }
 }
 

--- a/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
+++ b/ElementX/Sources/Screens/SessionVerification/View/SessionVerificationScreen.swift
@@ -226,15 +226,12 @@ struct SessionVerificationScreen: View {
 
 struct SessionVerification_Previews: PreviewProvider {
     static var previews: some View {
-        Group {
-            sessionVerificationScreen(state: .initial)
-            sessionVerificationScreen(state: .requestingVerification)
-            sessionVerificationScreen(state: .cancelled)
-            
-            sessionVerificationScreen(state: .showingChallenge(emojis: SessionVerificationControllerProxyMock.emojis))
-            sessionVerificationScreen(state: .verified)
-        }
-        .tint(Color.element.accent)
+        sessionVerificationScreen(state: .initial)
+        sessionVerificationScreen(state: .requestingVerification)
+        sessionVerificationScreen(state: .cancelled)
+        
+        sessionVerificationScreen(state: .showingChallenge(emojis: SessionVerificationControllerProxyMock.emojis))
+        sessionVerificationScreen(state: .verified)
     }
     
     static func sessionVerificationScreen(state: SessionVerificationStateMachine.State) -> some View {

--- a/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/View/SettingsScreen.swift
@@ -192,7 +192,6 @@ struct SettingsScreen_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
             SettingsScreen(context: viewModel.context)
-                .tint(.element.accent)
         }
     }
 }

--- a/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
+++ b/Tools/Scripts/Templates/SimpleScreenExample/ElementX/View/TemplateScreen.swift
@@ -93,14 +93,12 @@ struct TemplateScreen: View {
 // MARK: - Previews
 
 struct Template_Previews: PreviewProvider {
+    static let regularViewModel = TemplateViewModel(promptType: .regular)
+    static let upgradeViewModel = TemplateViewModel(promptType: .upgrade)
     static var previews: some View {
-        Group {
-            let regularViewModel = TemplateViewModel(promptType: .regular)
-            TemplateScreen(context: regularViewModel.context)
-            
-            let upgradeViewModel = TemplateViewModel(promptType: .upgrade)
-            TemplateScreen(context: upgradeViewModel.context)
-        }
-        .tint(.element.accent)
+        TemplateScreen(context: regularViewModel.context)
+            .previewDisplayName("Regular")
+        TemplateScreen(context: upgradeViewModel.context)
+            .previewDisplayName("Upgrade")
     }
 }

--- a/changelog.d/43.bugfix
+++ b/changelog.d/43.bugfix
@@ -1,0 +1,1 @@
+Fix accent colour not being applied to Alerts etc.


### PR DESCRIPTION
The use of SwiftUI's `.tint` modifier was really manual and couldn't be applied to Alerts. This PR sets the tint on `UIView` which means it is carried all over the UI (including to Xcode previews) and behaves as thought the accent colour was defined within the asset catalog.

| Alert | Modals (unchanged but showing it is automatic) |
| - | - |
| ![Simulator Screen Shot - iPhone 14 - 2023-03-14 at 12 28 23](https://user-images.githubusercontent.com/6060466/225001034-f8380f9e-c3da-43d2-8d1d-f9d15298a0d4.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-14 at 12 30 04](https://user-images.githubusercontent.com/6060466/225001384-9cbf0666-f7be-4dc3-b0cf-d28317cf40d3.png) |
