### PR TITLE
Bump SDK version and fix breaking changes.

### DIFF
--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "6e9c8b7f0f68fd8e617e9d6c1ad902736899557a",
-        "version" : "1.0.46-alpha"
+        "revision" : "cc68dbd95a35a481a7398e7cc324e26917fd4022",
+        "version" : "1.0.47-alpha"
       }
     },
     {

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -72,8 +72,8 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             .sink { [weak self] roomSummaryProviderState, totalCount, rooms in
                 guard let self else { return }
                 
-                let isLoadingData = roomSummaryProviderState != .live && (totalCount == 0 || rooms.count != totalCount)
-                let hasNoRooms = roomSummaryProviderState == .live && totalCount == 0
+                let isLoadingData = roomSummaryProviderState != .fullyLoaded && (totalCount == 0 || rooms.count != totalCount)
+                let hasNoRooms = roomSummaryProviderState == .fullyLoaded && totalCount == 0
                 
                 var roomListMode = self.state.roomListMode
                 if isLoadingData {
@@ -269,7 +269,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
     }
     
     private func updateVisibleRange(_ range: Range<Int>, timelineLimit: UInt) {
-        guard visibleRoomsSummaryProvider?.statePublisher.value == .live,
+        guard visibleRoomsSummaryProvider?.statePublisher.value == .fullyLoaded,
               !range.isEmpty else { return }
         
         guard let visibleRoomsSummaryProvider else {

--- a/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
+++ b/ElementX/Sources/Services/Client/SlidingSyncViewProxy.swift
@@ -23,7 +23,7 @@ private class SlidingSyncViewObserver: SlidingSyncListRoomListObserver, SlidingS
     let roomListDiffPublisher = PassthroughSubject<SlidingSyncListRoomsListDiff, Never>()
     
     /// Publishes the current state of sliding sync, such as whether its catching up or live.
-    let stateUpdatePublisher = CurrentValueSubject<SlidingSyncState, Never>(.cold)
+    let stateUpdatePublisher = CurrentValueSubject<SlidingSyncState, Never>(.fullyLoaded)
     
     /// Publishes the number of available rooms
     let countUpdatePublisher = CurrentValueSubject<UInt, Never>(0)

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
@@ -35,11 +35,11 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
         switch state {
         case .loading:
             roomListPublisher = .init([])
-            statePublisher = .init(.cold)
+            statePublisher = .init(.notLoaded)
             countPublisher = .init(0)
         case .loaded:
             roomListPublisher = .init(Self.rooms)
-            statePublisher = .init(.live)
+            statePublisher = .init(.fullyLoaded)
             countPublisher = .init(UInt(Self.rooms.count))
         }
     }

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -26,7 +26,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
     private var cancellables = Set<AnyCancellable>()
     
     let roomListPublisher = CurrentValueSubject<[RoomSummary], Never>([])
-    let statePublisher = CurrentValueSubject<RoomSummaryProviderState, Never>(.cold)
+    let statePublisher = CurrentValueSubject<RoomSummaryProviderState, Never>(.notLoaded)
     let countPublisher = CurrentValueSubject<UInt, Never>(0)
     
     private var rooms: [RoomSummary] = [] {
@@ -220,14 +220,14 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
 extension RoomSummaryProviderState {
     init(slidingSyncState: SlidingSyncState) {
         switch slidingSyncState {
-        case .cold:
-            self = .cold
-        case .preload:
-            self = .preload
-        case .catchingUp:
-            self = .catchingUp
-        case .live:
-            self = .live
+        case .notLoaded:
+            self = .notLoaded
+        case .preloaded:
+            self = .preloaded
+        case .partiallyLoaded:
+            self = .partiallyLoaded
+        case .fullyLoaded:
+            self = .fullyLoaded
         }
     }
 }

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
@@ -19,10 +19,10 @@ import Foundation
 import MatrixRustSDK
 
 enum RoomSummaryProviderState {
-    case cold
-    case preload
-    case catchingUp
-    case live
+    case notLoaded
+    case preloaded
+    case partiallyLoaded
+    case fullyLoaded
 }
 
 enum RoomSummary: CustomStringConvertible {

--- a/changelog.d/709.change
+++ b/changelog.d/709.change
@@ -1,0 +1,1 @@
+Bump SDK version and fix breaking changes.

--- a/project.yml
+++ b/project.yml
@@ -42,7 +42,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.46-alpha
+    exactVersion: 1.0.47-alpha
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
Updates to v1.0.47 and handles renaming of sliding sync states.