### PR TITLE
Add test plans for all test targets

### DIFF
--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -33,8 +33,9 @@ schemes:
       gatherCoverageData: true
       coverageTargets:
         - ElementX
-      targets:
-        - UnitTests
+      testPlans:
+        - path: ../../UnitTests/SupportingFiles/UnitTests.xctestplan
+          defaultPlan: true
       environmentVariables:
         IS_RUNNING_UNIT_TESTS: "1"
 

--- a/IntegrationTests/SupportingFiles/IntegrationTests.xctestplan
+++ b/IntegrationTests/SupportingFiles/IntegrationTests.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "AEF793E9-1B0B-4383-BFE4-68E19BAEDC7F",
+      "name" : "Default",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:ElementX.xcodeproj",
+        "identifier" : "D3DB351B7FBE0F49649171FC",
+        "name" : "IntegrationTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/IntegrationTests/SupportingFiles/target.yml
+++ b/IntegrationTests/SupportingFiles/target.yml
@@ -24,8 +24,9 @@ schemes:
       gatherCoverageData: true
       coverageTargets:
         - ElementX
-      targets:
-      - IntegrationTests
+      testPlans:
+        - path: IntegrationTests.xctestplan
+          defaultPlan: true
 
 targets:
   IntegrationTests:

--- a/UnitTests/SupportingFiles/UnitTests.xctestplan
+++ b/UnitTests/SupportingFiles/UnitTests.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "D789E5F1-30B8-4A23-B20E-281ACE05CFD6",
+      "name" : "Default",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "defaultTestExecutionTimeAllowance" : 60,
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:ElementX.xcodeproj",
+        "identifier" : "32C23C8D224D46EFE62AFAD0",
+        "name" : "UnitTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/UnitTests/SupportingFiles/target.yml
+++ b/UnitTests/SupportingFiles/target.yml
@@ -22,8 +22,9 @@ schemes:
       gatherCoverageData: true
       coverageTargets:
         - ElementX
-      targets:
-      - UnitTests
+      testPlans:
+        - path: UnitTests.xctestplan
+          defaultPlan: true
 
 targets:
   UnitTests:

--- a/changelog.d/pr-740.change
+++ b/changelog.d/pr-740.change
@@ -1,0 +1,1 @@
+Add test plans for other test targets.


### PR DESCRIPTION
This PR adds test plan for the test targets:
- **UnitTests**: with `"defaultTestExecutionTimeAllowance" : 60`
- **IntegrationTests**: with the default configuration