### PR TITLE
Fix use of zsh in our tools.

### DIFF
--- a/Tools/Sources/Utilities.swift
+++ b/Tools/Sources/Utilities.swift
@@ -20,7 +20,7 @@ enum Utilities {
     static func zsh(_ command: String, workingDirectoryURL: URL = projectDirectoryURL) throws -> String? {
         let process = Process()
         process.executableURL = URL(filePath: "/bin/zsh")
-        process.arguments = ["-c", command]
+        process.arguments = ["-cu", command]
         process.currentDirectoryURL = workingDirectoryURL
 
         let outputPipe = Pipe()


### PR DESCRIPTION
Just a tiny fix to unblock us for now, this PR makes sure `zsh` doesn't inherit its environment from `swift run`. We can look at launching the process directly instead of through a shell at a later date.