### PR TITLE
m.room.join_rules added as a required state

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -379,7 +379,8 @@ class ClientProxy: ClientProxyProtocol {
     }
     
     private lazy var slidingSyncRequiredState = [RequiredState(key: "m.room.avatar", value: ""),
-                                                 RequiredState(key: "m.room.encryption", value: "")]
+                                                 RequiredState(key: "m.room.encryption", value: ""),
+                                                 RequiredState(key: "m.room.join_rules", value: "")]
     
     private lazy var slidingSyncFilters = SlidingSyncRequestListFilters(isDm: nil,
                                                                         spaces: [],

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -379,8 +379,7 @@ class ClientProxy: ClientProxyProtocol {
     }
     
     private lazy var slidingSyncRequiredState = [RequiredState(key: "m.room.avatar", value: ""),
-                                                 RequiredState(key: "m.room.encryption", value: ""),
-                                                 RequiredState(key: "m.room.join_rules", value: "")]
+                                                 RequiredState(key: "m.room.encryption", value: "")]
     
     private lazy var slidingSyncFilters = SlidingSyncRequestListFilters(isDm: nil,
                                                                         spaces: [],

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -139,7 +139,8 @@ class RoomProxy: RoomProxyProtocol {
         
     func addTimelineListener(listener: TimelineListener) -> Result<[TimelineItem], RoomProxyError> {
         let settings = RoomSubscription(requiredState: [RequiredState(key: "m.room.topic", value: ""),
-                                                        RequiredState(key: "m.room.canonical_alias", value: "")],
+                                                        RequiredState(key: "m.room.canonical_alias", value: ""),
+                                                        RequiredState(key: "m.room.join_rules", value: "")],
                                         timelineLimit: nil)
         if let result = try? slidingSyncRoom.subscribeAndAddTimelineListener(listener: listener, settings: settings) {
             timelineObservationToken = result.taskHandle


### PR DESCRIPTION
This allow the `isPublic` value to be correct when used
