### PR TITLE
Removed string references from UI Tests

### DIFF
--- a/UITests/Sources/HomeScreenUITests.swift
+++ b/UITests/Sources/HomeScreenUITests.swift
@@ -19,9 +19,6 @@ import XCTest
 class HomeScreenUITests: XCTestCase {
     func testInitialStateComponents() {
         let app = Application.launch(.home)
-
-        XCTAssert(app.navigationBars[L10n.screenRoomlistMainSpaceTitle].exists)
-
         app.assertScreenshot(.home)
     }
 }

--- a/UITests/Sources/OnboardingUITests.swift
+++ b/UITests/Sources/OnboardingUITests.swift
@@ -22,40 +22,4 @@ class OnboardingUITests: XCTestCase {
         let app = Application.launch(.onboarding)
         app.assertScreenshot(.onboarding)
     }
-    
-    // This test has been disabled for now as there is only a single page.
-    func disabled_testSwipingBetweenPages() {
-        let app = Application.launch(.onboarding)
-        
-        // Given the splash screen in its initial state.
-        let page1TitleText = app.staticTexts[L10n.screenOnboardingWelcomeTitle]
-        let page2TitleText = app.staticTexts[L10n.screenOnboardingWelcomeTitle] // There isn't a second string to match any more.
-        let hiddenPageTitleText = app.staticTexts[A11yIdentifiers.onboardingScreen.hidden].firstMatch
-        
-        XCTAssertTrue(page1TitleText.isHittable, "The title from the first page of the carousel should be onscreen.")
-        XCTAssertFalse(page2TitleText.isHittable, "The title from the second page of the carousel should be offscreen.")
-        XCTAssertFalse(hiddenPageTitleText.isHittable, "The hidden page of the carousel should be offscreen.")
-        
-        // When swiping to the next screen.
-        page1TitleText.swipeLeft(velocity: .fast)
-        
-        // Then the second screen should be shown.
-        XCTAssertFalse(page1TitleText.isHittable, "The title from the first page of the carousel should be offscreen.")
-        XCTAssertTrue(page2TitleText.isHittable, "The title from the second page of the carousel should be onscreen.")
-        
-        // When swiping back to the previous screen.
-        page2TitleText.swipeRight(velocity: .fast)
-        
-        // Then the first screen should be shown again.
-        XCTAssertTrue(page1TitleText.isHittable, "The title from the first page of the carousel should be onscreen.")
-        XCTAssertFalse(page2TitleText.isHittable, "The title from the second page of the carousel should be offscreen.")
-        
-        // When swiping back to the previous screen.
-        page1TitleText.swipeRight(velocity: .fast)
-        
-        // Then the screen shouldn't change and the hidden screen should be ignored.
-        XCTAssertTrue(page1TitleText.isHittable, "The title from the first page of the carousel should be still be onscreen.")
-        XCTAssertFalse(page2TitleText.isHittable, "The title from the second page of the carousel should be offscreen.")
-        XCTAssertFalse(hiddenPageTitleText.isHittable, "It shouldn't be possible to swipe to the hidden page of the carousel.")
-    }
 }

--- a/UITests/Sources/ServerSelectionUITests.swift
+++ b/UITests/Sources/ServerSelectionUITests.swift
@@ -25,8 +25,6 @@ class ServerSelectionUITests: XCTestCase {
         
         // Then it should be configured for matrix.org
         app.assertScreenshot(.serverSelection, step: 0)
-        XCTAssertEqual(app.textFields[A11yIdentifiers.changeServerScreen.server].value as? String, "matrix.org", "The server shown should be matrix.org with the https scheme hidden.")
-        XCTAssertEqual(app.buttons[A11yIdentifiers.changeServerScreen.continue].label, L10n.actionContinue, "The confirm button should say Confirm when in modal presentation.")
     }
 
     func testEmptyAddress() async {
@@ -39,8 +37,6 @@ class ServerSelectionUITests: XCTestCase {
         
         // Then the screen should not allow the user to continue.
         app.assertScreenshot(.serverSelection, step: 1)
-        XCTAssertEqual(app.textFields[A11yIdentifiers.changeServerScreen.server].value as? String, L10n.commonServerUrl, "The text field should show placeholder text in this state.")
-        XCTAssertFalse(app.buttons[A11yIdentifiers.changeServerScreen.continue].isEnabled, "The confirm button should be disabled when the address is empty.")
     }
 
     func testInvalidAddress() {
@@ -62,6 +58,5 @@ class ServerSelectionUITests: XCTestCase {
         // Then the screen should be tweaked slightly to reflect the change of navigation.
         app.assertScreenshot(.serverSelectionNonModal)
         XCTAssertFalse(app.buttons[A11yIdentifiers.changeServerScreen.dismiss].exists, "The dismiss button should be hidden when not in modal presentation.")
-        XCTAssertEqual(app.buttons[A11yIdentifiers.changeServerScreen.continue].label, L10n.actionNext, "The confirm button should say Next when not in modal presentation.")
     }
 }

--- a/UITests/Sources/SessionVerificationUITests.swift
+++ b/UITests/Sources/SessionVerificationUITests.swift
@@ -49,7 +49,6 @@ class SessionVerificationUITests: XCTestCase {
         app.buttons[A11yIdentifiers.sessionVerificationScreen.acceptChallenge].tap()
         app.assertScreenshot(.sessionVerification, step: Step.acceptingEmojis)
         
-        XCTAssert(app.staticTexts[L10n.commonVerificationComplete].waitForExistence(timeout: 5.0))
         app.assertScreenshot(.sessionVerification, step: Step.verificationComplete)
         
         app.buttons[A11yIdentifiers.sessionVerificationScreen.close].tap()

--- a/UITests/SupportingFiles/target.yml
+++ b/UITests/SupportingFiles/target.yml
@@ -61,9 +61,6 @@ targets:
     - path: ../../Tools/Scripts/Templates/SimpleScreenExample/Tests/UI
     - path: ../../ElementX/Sources/UITests/UITestsScreenIdentifier.swift
     - path: ../../ElementX/Sources/UITests/UITestsSignalling.swift
-    - path: ../../ElementX/Sources/Generated/Strings.swift
-    - path: ../../ElementX/Sources/Generated/Strings+Untranslated.swift
-    - path: ../../ElementX/Resources
     - path: ../../ElementX/Sources/Other/AccessibilityIdentifiers.swift
     - path: ../../ElementX/Sources/Other/Extensions/Bundle.swift
     - path: ../../ElementX/Sources/Other/Extensions/XCUIElement.swift


### PR DESCRIPTION
We don't really need these anymore, we can use identifiers or just asserting screenshots.
