### PR TITLE
Fix project warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,4 @@
 disabled_rules:
-  - blanket_disable_command
   - trailing_whitespace
   - unused_setter_value
   - redundant_discardable_let

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,5 @@
 disabled_rules:
+  - blanket_disable_command
   - trailing_whitespace
   - unused_setter_value
   - redundant_discardable_let

--- a/ElementX/Sources/Generated/Strings+Untranslated.swift
+++ b/ElementX/Sources/Generated/Strings+Untranslated.swift
@@ -83,3 +83,4 @@ extension UntranslatedL10n {
 
 private final class BundleToken {}
 
+// swiftlint:enable all

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -721,3 +721,4 @@ extension L10n {
 
 private final class BundleToken {}
 
+// swiftlint:enable all

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable all

--- a/ElementX/Sources/Other/SwiftUI/Views/LoadableImage.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/LoadableImage.swift
@@ -72,7 +72,7 @@ struct LoadableImage<TransformerView: View, PlaceholderView: View>: View {
             guard image == nil, let mediaSource else { return }
             
             if case let .success(image) = await imageProvider?.loadImageFromSource(mediaSource, size: size) {
-                self.cachedImage = image
+                cachedImage = image
             }
         }
         

--- a/ElementX/Sources/Screens/EmojiPickerScreen/EmojiPickerScreenViewModel.swift
+++ b/ElementX/Sources/Screens/EmojiPickerScreen/EmojiPickerScreenViewModel.swift
@@ -50,8 +50,9 @@ class EmojiPickerScreenViewModel: EmojiPickerScreenViewModelType, EmojiPickerScr
 
     private func loadEmojis() {
         Task(priority: .userInitiated) { [weak self] in
-            let categories = await emojiProvider.getCategories(searchString: nil)
-            self?.state.categories = convert(emojiCategories: categories)
+            guard let self else { return }
+            let categories = await self.emojiProvider.getCategories(searchString: nil)
+            self.state.categories = convert(emojiCategories: categories)
         }
     }
     

--- a/Tools/SwiftGen/Templates/Strings/structured-swift5-element-untranslated.stencil
+++ b/Tools/SwiftGen/Templates/Strings/structured-swift5-element-untranslated.stencil
@@ -90,3 +90,4 @@ private final class BundleToken {}
 {% else %}
 // No string found
 {% endif %}
+// swiftlint:enable all

--- a/Tools/SwiftGen/Templates/Strings/structured-swift5-element.stencil
+++ b/Tools/SwiftGen/Templates/Strings/structured-swift5-element.stencil
@@ -105,3 +105,4 @@ private final class BundleToken {}
 {% else %}
 // No string found
 {% endif %}
+// swiftlint:enable all

--- a/UnitTests/Sources/DateTests.swift
+++ b/UnitTests/Sources/DateTests.swift
@@ -18,6 +18,7 @@
 import XCTest
 
 // swiftlint:disable force_unwrapping
+
 class DateTests: XCTestCase {
     let calendar = Calendar.current
     let startOfToday = Calendar.current.startOfDay(for: .now)
@@ -41,3 +42,5 @@ class DateTests: XCTestCase {
         XCTAssertEqual(theMillennium.formattedMinimal(), theMillennium.formatted(.dateTime.year().day().month()))
     }
 }
+
+// swiftlint:enable force_unwrapping

--- a/UnitTests/Sources/MessageTimelineItemTests.swift
+++ b/UnitTests/Sources/MessageTimelineItemTests.swift
@@ -18,7 +18,6 @@
 import MatrixRustSDK
 import XCTest
 
-// swiftlint:disable force_unwrapping
 class MessageTimelineItemTests: XCTestCase {
     // MARK: Image
     
@@ -95,6 +94,8 @@ class MessageTimelineItemTests: XCTestCase {
                                                source: mediaSourceFromUrl(url: "mxc://doesnt/matter"),
                                                info: makeAudioInfo(mimetype: nil))
         let messageItem = MockEventTimelineItem.message(from: imageContent)
+        
+        // swiftlint:disable:next force_unwrapping
         XCTAssertTrue(messageItem.contentType!.conforms(to: .mpeg4Audio))
     }
     
@@ -128,7 +129,6 @@ class MessageTimelineItemTests: XCTestCase {
 
 // MARK: - Mocks
 
-// swiftlint:disable force_cast
 private struct MockEventTimelineItem: EventTimelineItemProtocol {
     static func message<Content: MessageContentProtocol>(from content: Content) -> MessageTimelineItem<Content> {
         let item = MockEventTimelineItem(underlyingContent: content)
@@ -137,6 +137,7 @@ private struct MockEventTimelineItem: EventTimelineItemProtocol {
     
     let underlyingContent: MessageContentProtocol
     
+    // swiftlint:disable:next force_cast
     func content() -> MatrixRustSDK.TimelineItemContent { underlyingContent as! TimelineItemContent }
     
     func eventId() -> String? { UUID().uuidString }


### PR DESCRIPTION
- Swift 5.8 warnings
- Run SwiftFormat 0.51.5
- Fix SwiftLint blanket_disable_command warnings.
Assets.swift will be fixed by https://github.com/SwiftGen/SwiftGen/pull/1054