### PR TITLE
Remove CurrentValueSubject as protocol requirement

### DIFF
--- a/ElementX/Sources/Other/CurrentValuePublisher.swift
+++ b/ElementX/Sources/Other/CurrentValuePublisher.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Combine
+
+struct CurrentValuePublisher<Output, Failure: Error>: Publisher {
+    private let subject: CurrentValueSubject<Output, Failure>
+    
+    init(_ subject: CurrentValueSubject<Output, Failure>) {
+        self.subject = subject
+    }
+    
+    init(_ value: Output) {
+        self.init(CurrentValueSubject(value))
+    }
+    
+    func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input {
+        subject.receive(subscriber: subscriber)
+    }
+    
+    var value: Output {
+        subject.value
+    }
+}
+
+extension CurrentValueSubject {
+    func asCurrentValuePublisher() -> CurrentValuePublisher<Output, Failure> {
+        .init(self)
+    }
+}

--- a/ElementX/Sources/Other/CurrentValuePublisher.swift
+++ b/ElementX/Sources/Other/CurrentValuePublisher.swift
@@ -16,6 +16,8 @@
 
 import Combine
 
+/// A wrapper of CurrentValueSubject.
+/// The purpose of this type is to remove the possibility to send new values on the underlying subject.
 struct CurrentValuePublisher<Output, Failure: Error>: Publisher {
     private let subject: CurrentValueSubject<Output, Failure>
     

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
@@ -23,9 +23,9 @@ enum MockRoomSummaryProviderState {
 }
 
 class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
-    let roomListPublisher: CurrentValueSubject<[RoomSummary], Never>
-    let statePublisher: CurrentValueSubject<RoomSummaryProviderState, Never>
-    let countPublisher: CurrentValueSubject<UInt, Never>
+    let roomListPublisher: CurrentValuePublisher<[RoomSummary], Never>
+    let statePublisher: CurrentValuePublisher<RoomSummaryProviderState, Never>
+    let countPublisher: CurrentValuePublisher<UInt, Never>
     
     convenience init() {
         self.init(state: .loading)

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
@@ -53,13 +53,13 @@ enum RoomSummary: CustomStringConvertible {
 
 protocol RoomSummaryProviderProtocol {
     /// Publishes the currently available room summaries
-    var roomListPublisher: CurrentValueSubject<[RoomSummary], Never> { get }
+    var roomListPublisher: CurrentValuePublisher<[RoomSummary], Never> { get }
     
     /// Publishes the current state the summary provider is finding itself in
-    var statePublisher: CurrentValueSubject<RoomSummaryProviderState, Never> { get }
+    var statePublisher: CurrentValuePublisher<RoomSummaryProviderState, Never> { get }
     
     /// Publishes the total number of rooms
-    var countPublisher: CurrentValueSubject<UInt, Never> { get }
+    var countPublisher: CurrentValuePublisher<UInt, Never> { get }
         
     func updateVisibleRange(_ range: Range<Int>, timelineLimit: UInt)
 }

--- a/ElementX/Sources/Services/Timeline/MockRoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/MockRoomTimelineProvider.swift
@@ -17,7 +17,7 @@
 import Combine
 
 struct MockRoomTimelineProvider: RoomTimelineProviderProtocol {
-    var itemsPublisher = CurrentValueSubject<[TimelineItemProxy], Never>([])
+    var itemsPublisher = CurrentValuePublisher<[TimelineItemProxy], Never>([])
     
     private var itemProxies = [TimelineItemProxy]()
 }

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
@@ -31,11 +31,15 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
     private var cancellables = Set<AnyCancellable>()
     private let serialDispatchQueue: DispatchQueue
     
-    let itemsPublisher = CurrentValueSubject<[TimelineItemProxy], Never>([])
+    private let itemsSubject = CurrentValueSubject<[TimelineItemProxy], Never>([])
+    
+    var itemsPublisher: CurrentValuePublisher<[TimelineItemProxy], Never> {
+        itemsSubject.asCurrentValuePublisher()
+    }
     
     private var itemProxies: [TimelineItemProxy] {
         didSet {
-            itemsPublisher.send(itemProxies)
+            itemsSubject.send(itemProxies)
         }
     }
     

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProviderProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProviderProtocol.swift
@@ -18,5 +18,5 @@ import Combine
 import Foundation
 
 protocol RoomTimelineProviderProtocol {
-    var itemsPublisher: CurrentValueSubject<[TimelineItemProxy], Never> { get }
+    var itemsPublisher: CurrentValuePublisher<[TimelineItemProxy], Never> { get }
 }


### PR DESCRIPTION
This pr introduces the `CurrentValuePublisher`.  
It's purpose is to hide the `send` method for clients that need just to subscribe and/or the current value of a `CurrentValueSubject`.