### PR TITLE
Room subscription limits

### DIFF
--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -111,8 +111,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "c4185fb641cd5eb312c64b2b70ec2241ade3e309",
-        "version" : "1.0.53-alpha"
+        "revision" : "8ce08eb804c449f4e7472e66edd7e80b4e8e9ded",
+        "version" : "1.0.54-alpha"
       }
     },
     {

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -141,7 +141,7 @@ class RoomProxy: RoomProxyProtocol {
         let settings = RoomSubscription(requiredState: [RequiredState(key: "m.room.topic", value: ""),
                                                         RequiredState(key: "m.room.canonical_alias", value: ""),
                                                         RequiredState(key: "m.room.join_rules", value: "")],
-                                        timelineLimit: nil)
+                                        timelineLimit: UInt32(SlidingSyncConstants.timelinePrecachingTimelineLimit))
         if let result = try? slidingSyncRoom.subscribeAndAddTimelineListener(listener: listener, settings: settings) {
             timelineObservationToken = result.taskHandle
             Task {


### PR DESCRIPTION
Given the following scenario:
* a room moves outside of the visible rooms list
* it continues to receive messages
* the room is then opened through the search (which doesn't change the SS range)

then that room will be missing messages that were sent after it exited the visible list.

The fix for that is to actually use a timeline limit when subscribing to it, same limit we use for the normal room list when not scrolling.