### PR TITLE
Fix: forget the user’s consents for analytics on logout

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -295,7 +295,8 @@ class AppCoordinator: AppCoordinatorProtocol {
             tearDownUserSession()
             
             // reset analytics
-            ServiceLocator.shared.analytics.reset()
+            ServiceLocator.shared.analytics.optOut()
+            AppSettings.forgetAnalyticsConsents()
             
             stateMachine.processEvent(.completedSigningOut(isSoft: isSoft))
         }

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -296,7 +296,7 @@ class AppCoordinator: AppCoordinatorProtocol {
             
             // reset analytics
             ServiceLocator.shared.analytics.optOut()
-            AppSettings.forgetAnalyticsConsents()
+            ServiceLocator.shared.analytics.resetConsentState()
             
             stateMachine.processEvent(.completedSigningOut(isSoft: isSoft))
         }

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -134,6 +134,12 @@ final class AppSettings: ObservableObject {
     /// `true` when the user has opted in to send analytics.
     @UserPreference(key: UserDefaultsKeys.enableAnalytics, defaultValue: false, storageType: .userDefaults(store))
     var enableAnalytics
+    
+    /// Reset user consents for analytics
+    static func forgetAnalyticsConsents() {
+        MXLog.warning("Resetting user consents for analytics.")
+        store.removeObject(forKey: UserDefaultsKeys.enableAnalytics.rawValue)
+    }
         
     // MARK: - Room Screen
     

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -23,7 +23,7 @@ final class AppSettings: ObservableObject {
         case lastVersionLaunched
         case seenInvites
         case timelineStyle
-        case enableAnalytics
+        case analyticsConsentState
         case enableInAppNotifications
         case pusherProfileTag
         case shouldCollapseRoomStateEvents
@@ -109,7 +109,7 @@ final class AppSettings: ObservableObject {
     let bugReportUISIId = "element-auto-uisi"
     
     // MARK: - Analytics
-        
+    
     #if DEBUG
     /// The configuration to use for analytics during development. Set `isEnabled` to false to disable analytics in debug builds.
     /// **Note:** Analytics are disabled by default for forks. If you are maintaining a fork, set custom configurations.
@@ -125,22 +125,11 @@ final class AppSettings: ObservableObject {
                                                         apiKey: "phc_Jzsm6DTm6V2705zeU5dcNvQDlonOR68XvX2sh1sEOHO",
                                                         termsURL: URL(staticString: "https://element.io/cookie-policy"))
     #endif
-    
-    /// Whether the user has already been shown the PostHog analytics prompt.
-    var hasSeenAnalyticsPrompt: Bool {
-        Self.store.object(forKey: UserDefaultsKeys.enableAnalytics.rawValue) != nil
-    }
-    
-    /// `true` when the user has opted in to send analytics.
-    @UserPreference(key: UserDefaultsKeys.enableAnalytics, defaultValue: false, storageType: .userDefaults(store))
-    var enableAnalytics
-    
-    /// Reset user consents for analytics
-    static func forgetAnalyticsConsents() {
-        MXLog.warning("Resetting user consents for analytics.")
-        store.removeObject(forKey: UserDefaultsKeys.enableAnalytics.rawValue)
-    }
         
+    /// Whether the user has opted in to send analytics.
+    @UserPreference(key: UserDefaultsKeys.analyticsConsentState, defaultValue: AnalyticsConsentState.unknown, storageType: .userDefaults(store))
+    var analyticsConsentState
+    
     // MARK: - Room Screen
     
     @UserPreference(key: UserDefaultsKeys.timelineStyle, defaultValue: TimelineStyle.bubbles, storageType: .userDefaults(store))
@@ -151,7 +140,7 @@ final class AppSettings: ObservableObject {
     
     // MARK: - Notifications
 
-    @UserPreference(key: UserDefaultsKeys.timelineStyle, defaultValue: true, storageType: .userDefaults(store))
+    @UserPreference(key: UserDefaultsKeys.enableInAppNotifications, defaultValue: true, storageType: .userDefaults(store))
     var enableInAppNotifications
 
     /// Tag describing which set of device specific rules a pusher executes.

--- a/ElementX/Sources/Screens/AnalyticsSettings/AnalyticsSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/AnalyticsSettings/AnalyticsSettingsScreenViewModel.swift
@@ -28,7 +28,7 @@ class AnalyticsSettingsScreenViewModel: AnalyticsSettingsScreenViewModelType, An
         super.init(initialViewState: state)
         
         ServiceLocator.shared.settings.$analyticsConsentState
-            .map { $0 == .optIn }
+            .map { $0 == .optedIn }
             .weakAssign(to: \.state.bindings.enableAnalytics, on: self)
             .store(in: &cancellables)
     }

--- a/ElementX/Sources/Screens/AnalyticsSettings/AnalyticsSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/AnalyticsSettings/AnalyticsSettingsScreenViewModel.swift
@@ -22,12 +22,13 @@ typealias AnalyticsSettingsScreenViewModelType = StateStoreViewModel<AnalyticsSe
 class AnalyticsSettingsScreenViewModel: AnalyticsSettingsScreenViewModelType, AnalyticsSettingsScreenViewModelProtocol {
     init() {
         let strings = AnalyticsSettingsScreenStrings(termsURL: ServiceLocator.shared.settings.analyticsConfiguration.termsURL)
-        let bindings = AnalyticsSettingsScreenViewStateBindings(enableAnalytics: ServiceLocator.shared.settings.enableAnalytics)
+        let bindings = AnalyticsSettingsScreenViewStateBindings(enableAnalytics: ServiceLocator.shared.analytics.isEnabled)
         let state = AnalyticsSettingsScreenViewState(strings: strings, bindings: bindings)
         
         super.init(initialViewState: state)
         
-        ServiceLocator.shared.settings.$enableAnalytics
+        ServiceLocator.shared.settings.$analyticsConsentState
+            .map { $0 == .optIn }
             .weakAssign(to: \.state.bindings.enableAnalytics, on: self)
             .store(in: &cancellables)
     }
@@ -35,7 +36,7 @@ class AnalyticsSettingsScreenViewModel: AnalyticsSettingsScreenViewModelType, An
     override func process(viewAction: AnalyticsSettingsScreenViewAction) {
         switch viewAction {
         case .toggleAnalytics:
-            if ServiceLocator.shared.settings.enableAnalytics {
+            if ServiceLocator.shared.analytics.isEnabled {
                 ServiceLocator.shared.analytics.optOut()
             } else {
                 ServiceLocator.shared.analytics.optIn()

--- a/ElementX/Sources/Services/Analytics/Analytics.swift
+++ b/ElementX/Sources/Services/Analytics/Analytics.swift
@@ -44,18 +44,22 @@ class Analytics {
     /// Whether to show the user the analytics opt in prompt.
     var shouldShowAnalyticsPrompt: Bool {
         // Only show the prompt once, and when analytics are enabled in BuildSettings.
-        !ServiceLocator.shared.settings.hasSeenAnalyticsPrompt && ServiceLocator.shared.settings.analyticsConfiguration.isEnabled
+        ServiceLocator.shared.settings.analyticsConsentState == .unknown && ServiceLocator.shared.settings.analyticsConfiguration.isEnabled
+    }
+    
+    var isEnabled: Bool {
+        ServiceLocator.shared.settings.analyticsConsentState == .optIn
     }
     
     /// Opts in to analytics tracking with the supplied user session.
     func optIn() {
-        ServiceLocator.shared.settings.enableAnalytics = true
+        ServiceLocator.shared.settings.analyticsConsentState = .optIn
         startIfEnabled()
     }
     
     /// Stops analytics tracking and calls `reset` to clear any IDs and event queues.
     func optOut() {
-        ServiceLocator.shared.settings.enableAnalytics = false
+        ServiceLocator.shared.settings.analyticsConsentState = .optOut
         
         // The order is important here. PostHog ignores the reset if stopped.
         reset()
@@ -66,7 +70,7 @@ class Analytics {
     
     /// Starts the analytics client if the user has opted in, otherwise does nothing.
     func startIfEnabled() {
-        guard ServiceLocator.shared.settings.enableAnalytics, !isRunning else { return }
+        guard isEnabled, !isRunning else { return }
         
         client.start()
         ServiceLocator.shared.bugReportService.start()
@@ -85,6 +89,12 @@ class Analytics {
         client.reset()
         ServiceLocator.shared.bugReportService.reset()
         MXLog.info("Reset.")
+    }
+    
+    /// Reset the consent state for analytics
+    func resetConsentState() {
+        MXLog.warning("Resetting consent state for analytics.")
+        ServiceLocator.shared.settings.analyticsConsentState = .unknown
     }
     
     /// Flushes the event queue in the analytics client, uploading all pending events.

--- a/ElementX/Sources/Services/Analytics/Analytics.swift
+++ b/ElementX/Sources/Services/Analytics/Analytics.swift
@@ -48,18 +48,18 @@ class Analytics {
     }
     
     var isEnabled: Bool {
-        ServiceLocator.shared.settings.analyticsConsentState == .optIn
+        ServiceLocator.shared.settings.analyticsConsentState == .optedIn
     }
     
     /// Opts in to analytics tracking with the supplied user session.
     func optIn() {
-        ServiceLocator.shared.settings.analyticsConsentState = .optIn
+        ServiceLocator.shared.settings.analyticsConsentState = .optedIn
         startIfEnabled()
     }
     
     /// Stops analytics tracking and calls `reset` to clear any IDs and event queues.
     func optOut() {
-        ServiceLocator.shared.settings.analyticsConsentState = .optOut
+        ServiceLocator.shared.settings.analyticsConsentState = .optedOut
         
         // The order is important here. PostHog ignores the reset if stopped.
         reset()

--- a/ElementX/Sources/Services/Analytics/AnalyticsConsentState.swift
+++ b/ElementX/Sources/Services/Analytics/AnalyticsConsentState.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 enum AnalyticsConsentState: String, Codable {
-    case optOut
-    case optIn
+    case optedOut
+    case optedIn
     case unknown
 }

--- a/ElementX/Sources/Services/Analytics/AnalyticsConsentState.swift
+++ b/ElementX/Sources/Services/Analytics/AnalyticsConsentState.swift
@@ -1,0 +1,23 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+enum AnalyticsConsentState: String, Codable {
+    case optOut
+    case optIn
+    case unknown
+}

--- a/UnitTests/Sources/AnalyticsSettingsScreenViewModelTests.swift
+++ b/UnitTests/Sources/AnalyticsSettingsScreenViewModelTests.swift
@@ -42,13 +42,13 @@ class AnalyticsSettingsScreenViewModelTests: XCTestCase {
     }
 
     func testOptIn() {
-        applicationSettings.analyticsConsentState = .optOut
+        applicationSettings.analyticsConsentState = .optedOut
         context.send(viewAction: .toggleAnalytics)
         XCTAssertTrue(context.enableAnalytics)
     }
     
     func testOptOut() {
-        applicationSettings.analyticsConsentState = .optIn
+        applicationSettings.analyticsConsentState = .optedIn
         context.send(viewAction: .toggleAnalytics)
         XCTAssertFalse(context.enableAnalytics)
     }

--- a/UnitTests/Sources/AnalyticsSettingsScreenViewModelTests.swift
+++ b/UnitTests/Sources/AnalyticsSettingsScreenViewModelTests.swift
@@ -42,12 +42,13 @@ class AnalyticsSettingsScreenViewModelTests: XCTestCase {
     }
 
     func testOptIn() {
+        applicationSettings.analyticsConsentState = .optOut
         context.send(viewAction: .toggleAnalytics)
         XCTAssertTrue(context.enableAnalytics)
     }
     
     func testOptOut() {
-        applicationSettings.enableAnalytics = true
+        applicationSettings.analyticsConsentState = .optIn
         context.send(viewAction: .toggleAnalytics)
         XCTAssertFalse(context.enableAnalytics)
     }

--- a/UnitTests/Sources/AnalyticsTests.swift
+++ b/UnitTests/Sources/AnalyticsTests.swift
@@ -182,4 +182,16 @@ class AnalyticsTests: XCTestCase {
         // Then the properties should be cleared
         XCTAssertNil(client.pendingUserProperties, "The user properties should be cleared.")
     }
+    
+    func testForgetAnalyticsConsents() {
+        // Given an existing install of the app where the user previously accpeted the tracking
+        applicationSettings.enableAnalytics = true
+        XCTAssertFalse(ServiceLocator.shared.analytics.shouldShowAnalyticsPrompt)
+
+        // When forgetting analytics consents
+        AppSettings.forgetAnalyticsConsents()
+        
+        // Then the analytics prompt should be presented again
+        XCTAssertTrue(ServiceLocator.shared.analytics.shouldShowAnalyticsPrompt)
+    }
 }

--- a/UnitTests/Sources/AnalyticsTests.swift
+++ b/UnitTests/Sources/AnalyticsTests.swift
@@ -47,7 +47,7 @@ class AnalyticsTests: XCTestCase {
     
     func testAnalyticsPromptUserDeclinedPostHog() {
         // Given an existing install of the app where the user previously declined PostHog
-        applicationSettings.analyticsConsentState = .optOut
+        applicationSettings.analyticsConsentState = .optedOut
         
         // When the user is prompted for analytics
         let showPrompt = ServiceLocator.shared.analytics.shouldShowAnalyticsPrompt
@@ -58,7 +58,7 @@ class AnalyticsTests: XCTestCase {
     
     func testAnalyticsPromptUserAcceptedPostHog() {
         // Given an existing install of the app where the user previously accepted PostHog
-        applicationSettings.analyticsConsentState = .optIn
+        applicationSettings.analyticsConsentState = .optedIn
         
         // When the user is prompted for analytics
         let showPrompt = ServiceLocator.shared.analytics.shouldShowAnalyticsPrompt
@@ -81,7 +81,7 @@ class AnalyticsTests: XCTestCase {
         // When analytics is opt-out
         ServiceLocator.shared.analytics.optOut()
         // Then analytics should be disabled
-        XCTAssertEqual(applicationSettings.analyticsConsentState, .optOut)
+        XCTAssertEqual(applicationSettings.analyticsConsentState, .optedOut)
         XCTAssertFalse(ServiceLocator.shared.analytics.isEnabled)
         XCTAssertFalse(ServiceLocator.shared.analytics.isRunning)
         XCTAssertFalse(analyticsClient.isRunning)
@@ -96,7 +96,7 @@ class AnalyticsTests: XCTestCase {
         // When analytics is opt-in
         ServiceLocator.shared.analytics.optIn()
         // The analytics should be enabled
-        XCTAssertEqual(applicationSettings.analyticsConsentState, .optIn)
+        XCTAssertEqual(applicationSettings.analyticsConsentState, .optedIn)
         XCTAssertTrue(ServiceLocator.shared.analytics.isEnabled)
         // Analytics client and the bug report service should have been started
         XCTAssertTrue(analyticsClient.startCalled)
@@ -105,7 +105,7 @@ class AnalyticsTests: XCTestCase {
 
     func testAnalyticsStartIfNotEnabled() {
         // Given an existing install of the app where the user previously declined the tracking
-        applicationSettings.analyticsConsentState = .optOut
+        applicationSettings.analyticsConsentState = .optedOut
         // Analytics should not start
         XCTAssertFalse(ServiceLocator.shared.analytics.isEnabled)
         ServiceLocator.shared.analytics.startIfEnabled()
@@ -115,7 +115,7 @@ class AnalyticsTests: XCTestCase {
     
     func testAnalyticsStartIfEnabled() {
         // Given an existing install of the app where the user previously accpeted the tracking
-        applicationSettings.analyticsConsentState = .optIn
+        applicationSettings.analyticsConsentState = .optedIn
         // Analytics should start
         XCTAssertTrue(ServiceLocator.shared.analytics.isEnabled)
         ServiceLocator.shared.analytics.startIfEnabled()
@@ -188,7 +188,7 @@ class AnalyticsTests: XCTestCase {
     
     func testResetConsentState() {
         // Given an existing install of the app where the user previously accpeted the tracking
-        applicationSettings.analyticsConsentState = .optIn
+        applicationSettings.analyticsConsentState = .optedIn
         XCTAssertFalse(ServiceLocator.shared.analytics.shouldShowAnalyticsPrompt)
 
         // When forgetting analytics consents

--- a/changelog.d/pr-816.change
+++ b/changelog.d/pr-816.change
@@ -1,0 +1,1 @@
+Analytics: reset user's consents on logout.


### PR DESCRIPTION
This PR reset the user's consents for analytics on logout (as requested in #106)