### PR TITLE
Fixes #641 - Room previews failing to load because of incorrect slidi…

### DIFF
--- a/ElementX/Sources/Other/ScrollViewAdapter.swift
+++ b/ElementX/Sources/Other/ScrollViewAdapter.swift
@@ -24,30 +24,39 @@ class ScrollViewAdapter: NSObject, UIScrollViewDelegate {
             scrollView?.delegate = self
         }
     }
-        
-    var isScrolling = CurrentValueSubject<Bool, Never>(false)
-        
-    private func update(_ scrollView: UIScrollView) {
-        isScrolling.send(scrollView.isDragging || scrollView.isDecelerating)
+    
+    let didScroll = PassthroughSubject<Void, Never>()
+    let isScrolling = CurrentValueSubject<Bool, Never>(false)
+    
+    // MARK: - UIScrollViewDelegate
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        didScroll.send(())
     }
     
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        update(scrollView)
+        updateDidScroll(scrollView)
     }
     
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        update(scrollView)
+        updateDidScroll(scrollView)
     }
     
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
-        update(scrollView)
+        updateDidScroll(scrollView)
     }
         
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        update(scrollView)
+        updateDidScroll(scrollView)
     }
     
     func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
-        update(scrollView)
+        updateDidScroll(scrollView)
+    }
+    
+    // MARK: - Private
+    
+    private func updateDidScroll(_ scrollView: UIScrollView) {
+        isScrolling.send(scrollView.isDragging || scrollView.isDecelerating)
     }
 }

--- a/changelog.d/641.bugfix
+++ b/changelog.d/641.bugfix
@@ -1,0 +1,1 @@
+Fixed room previews failing to load because of incorrect sliding sync view ranges


### PR DESCRIPTION
…ng sync view ranges

Using the search functionality in conjuncture with the existing appearance call based visible range computations proved to be unreliable and resulted in not only incorrect ranges but clunky code.

This PR rewrites all of that and makes the range computation now rely on the underlying scroll view, its content size and offset.

It relies heavily on the deduplication and throttling happening view model side and while the computations might not be perfect they're good enough considering the paddings we're using