### PR TITLE
Use renamed (and linked) analytics strings.

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -159,7 +159,6 @@
 "room_timeline_beginning_of_room" = "This is the beginning of %1$@.";
 "room_timeline_beginning_of_room_no_name" = "This is the beginning of this conversation.";
 "room_timeline_read_marker_title" = "New";
-"screen_analytics_help_us_improve" = "Help us identify issues and improve %1$@ by sharing anonymous usage data.";
 "screen_analytics_prompt_data_usage" = "We <b>don't</b> record or profile any account data";
 "screen_analytics_prompt_help_us_improve" = "Help us identify issues and improve %1$@ by sharing anonymous usage data.";
 "screen_analytics_prompt_read_terms" = "You can read all our terms %1$@.";
@@ -167,9 +166,7 @@
 "screen_analytics_prompt_settings" = "You can turn this off anytime in settings";
 "screen_analytics_prompt_third_party_sharing" = "We <b>don't</b> share information with third parties";
 "screen_analytics_prompt_title" = "Help improve %1$@";
-"screen_analytics_read_terms" = "You can read all our terms %1$@.";
-"screen_analytics_read_terms_content_link" = "here";
-"screen_analytics_share_data" = "Share analytics data";
+"screen_analytics_settings_share_data" = "Share analytics data";
 "screen_bug_report_attach_screenshot" = "Attach screenshot";
 "screen_bug_report_contact_me" = "You may contact me if you have any follow up questions";
 "screen_bug_report_edit_screenshot" = "Edit screenshot";
@@ -312,6 +309,9 @@
 "dialog_title_error" = "Error";
 "dialog_title_success" = "Success";
 "notification_room_action_quick_reply" = "Quick reply";
+"screen_analytics_settings_help_us_improve" = "Help us identify issues and improve %1$@ by sharing anonymous usage data.";
+"screen_analytics_settings_read_terms" = "You can read all our terms %1$@.";
+"screen_analytics_settings_read_terms_content_link" = "here";
 "screen_change_server_submit" = "Continue";
 "screen_change_server_title" = "Select your server";
 "screen_dm_details_block_alert_action" = "Block";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -392,10 +392,6 @@ public enum L10n {
   public static func roomTimelineStateChanges(_ p1: Int) -> String {
     return L10n.tr("Localizable", "room_timeline_state_changes", p1)
   }
-  /// Help us identify issues and improve %1$@ by sharing anonymous usage data.
-  public static func screenAnalyticsHelpUsImprove(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "screen_analytics_help_us_improve", String(describing: p1))
-  }
   /// We <b>don't</b> record or profile any account data
   public static var screenAnalyticsPromptDataUsage: String { return L10n.tr("Localizable", "screen_analytics_prompt_data_usage") }
   /// Help us identify issues and improve %1$@ by sharing anonymous usage data.
@@ -416,14 +412,18 @@ public enum L10n {
   public static func screenAnalyticsPromptTitle(_ p1: Any) -> String {
     return L10n.tr("Localizable", "screen_analytics_prompt_title", String(describing: p1))
   }
+  /// Help us identify issues and improve %1$@ by sharing anonymous usage data.
+  public static func screenAnalyticsSettingsHelpUsImprove(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "screen_analytics_settings_help_us_improve", String(describing: p1))
+  }
   /// You can read all our terms %1$@.
-  public static func screenAnalyticsReadTerms(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "screen_analytics_read_terms", String(describing: p1))
+  public static func screenAnalyticsSettingsReadTerms(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "screen_analytics_settings_read_terms", String(describing: p1))
   }
   /// here
-  public static var screenAnalyticsReadTermsContentLink: String { return L10n.tr("Localizable", "screen_analytics_read_terms_content_link") }
+  public static var screenAnalyticsSettingsReadTermsContentLink: String { return L10n.tr("Localizable", "screen_analytics_settings_read_terms_content_link") }
   /// Share analytics data
-  public static var screenAnalyticsShareData: String { return L10n.tr("Localizable", "screen_analytics_share_data") }
+  public static var screenAnalyticsSettingsShareData: String { return L10n.tr("Localizable", "screen_analytics_settings_share_data") }
   /// Attach screenshot
   public static var screenBugReportAttachScreenshot: String { return L10n.tr("Localizable", "screen_bug_report_attach_screenshot") }
   /// You may contact me if you have any follow up questions

--- a/ElementX/Sources/Screens/AnalyticsSettings/AnalyticsSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/AnalyticsSettings/AnalyticsSettingsScreenModels.swift
@@ -34,12 +34,12 @@ struct AnalyticsSettingsScreenStrings {
     let sectionFooter: AttributedString
     
     init(termsURL: URL) {
-        let content = AttributedString(L10n.screenAnalyticsHelpUsImprove(InfoPlistReader.main.bundleDisplayName))
+        let content = AttributedString(L10n.screenAnalyticsSettingsHelpUsImprove(InfoPlistReader.main.bundleDisplayName))
         // Create the 'read terms' with a placeholder.
         let linkPlaceholder = "{link}"
-        var readTerms = AttributedString(L10n.screenAnalyticsReadTerms(linkPlaceholder))
+        var readTerms = AttributedString(L10n.screenAnalyticsSettingsReadTerms(linkPlaceholder))
         readTerms.replace(linkPlaceholder,
-                          with: L10n.screenAnalyticsReadTermsContentLink,
+                          with: L10n.screenAnalyticsSettingsReadTermsContentLink,
                           asLinkTo: termsURL)
         sectionFooter = content + "\n\n" + readTerms
     }

--- a/ElementX/Sources/Screens/AnalyticsSettings/View/AnalyticsSettingsScreen.swift
+++ b/ElementX/Sources/Screens/AnalyticsSettings/View/AnalyticsSettingsScreen.swift
@@ -31,7 +31,7 @@ struct AnalyticsSettingsScreen: View {
     var analyticsSection: some View {
         Section {
             Toggle(isOn: $context.enableAnalytics) {
-                Label(L10n.screenAnalyticsShareData, systemImage: "chart.bar")
+                Label(L10n.screenAnalyticsSettingsShareData, systemImage: "chart.bar")
             }
             .toggleStyle(.compoundForm)
             .onChange(of: context.enableAnalytics) { _ in


### PR DESCRIPTION
Renames a few keys on the Analytics Settings screen (which are linked in Localazy to the Analytics Prompt).