### PR TITLE
Adopt the bump event types sliding sync proxy API. Allow only `m.room…

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -319,6 +319,7 @@ class ClientProxy: ClientProxyProtocol {
             let slidingSync = try slidingSyncBuilder
                 .addList(v: visibleRoomsSlidingSyncView)
                 .withCommonExtensions()
+                .bumpEventTypes(bumpEventTypes: ["m.room.message", "m.room.encrypted"])
                 .storageKey(name: "ElementX")
                 .build()
             

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -314,12 +314,14 @@ class ClientProxy: ClientProxyProtocol {
                 return
             }
             
+            let roomListRecencyOrderingAllowedEventTypes = ["m.room.message", "m.room.encrypted", "m.sticker"]
+            
             // Add the visibleRoomsSlidingSyncView here so that it can take advantage of the SS builder cold cache
             // We will still register the allRoomsSlidingSyncView later, and than will have no cache
             let slidingSync = try slidingSyncBuilder
                 .addList(v: visibleRoomsSlidingSyncView)
                 .withCommonExtensions()
-                .bumpEventTypes(bumpEventTypes: ["m.room.message", "m.room.encrypted"])
+                .bumpEventTypes(bumpEventTypes: roomListRecencyOrderingAllowedEventTypes)
                 .storageKey(name: "ElementX")
                 .build()
             


### PR DESCRIPTION
….message and `m.room.encrypted` to reorder the room list