### PR TITLE
Fix for missing image for groups in notifications

### DIFF
--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -105,7 +105,7 @@ extension UNMutableNotificationContent {
                                          serviceName: nil,
                                          sender: sender,
                                          attachments: nil)
-        intent.setImage(image, forParameterNamed: \.conversationIdentifier)
+        intent.setImage(image, forParameterNamed: \.speakableGroupName)
 
         // Use the intent to initialize the interaction.
         let interaction = INInteraction(intent: intent, response: nil)


### PR DESCRIPTION
The solution was found here:
https://stackoverflow.com/questions/69293012/using-a-group-icon-with-ios-15-communication-notifications
![simulator_screenshot_BCF2167D-699F-4D74-A80F-6B29B153789F](https://user-images.githubusercontent.com/34335419/235175093-6ad3712b-435d-4e52-a2e8-d67d983a11a7.png)
