### PR TITLE
Avoid race and duplication conditions between local and remote notifications

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -69,8 +69,6 @@ class AppCoordinator: AppCoordinatorProtocol {
 
         userSessionStore = UserSessionStore(backgroundTaskService: backgroundTaskService)
 
-        ServiceLocator.shared.settings.servedNotificationIdentifiers = []
-
         notificationManager = NotificationManager()
         notificationManager.delegate = self
         notificationManager.start()

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -69,6 +69,8 @@ class AppCoordinator: AppCoordinatorProtocol {
 
         userSessionStore = UserSessionStore(backgroundTaskService: backgroundTaskService)
 
+        ServiceLocator.shared.settings.servedNotificationIdentifiers = []
+
         notificationManager = NotificationManager()
         notificationManager.delegate = self
         notificationManager.start()
@@ -84,7 +86,7 @@ class AppCoordinator: AppCoordinatorProtocol {
             wipeUserData(includingSettings: true)
         }
         ServiceLocator.shared.settings.lastVersionLaunched = currentVersion.description
-                
+
         setupStateMachine()
 
         observeApplicationState()

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -69,6 +69,8 @@ final class AppSettings {
     /// deleted between runs so should clear data in the shared container and keychain.
     @UserPreference(key: UserDefaultsKeys.lastVersionLaunched, storageType: .userDefaults(store))
     var lastVersionLaunched: String?
+
+    let lastLaunchDate = Date()
     
     /// The Set of room identifiers of invites that the user already saw in the invites list.
     /// This Set is being used to implement badges for unread invites.
@@ -155,8 +157,6 @@ final class AppSettings {
     
     let permalinkBaseURL = URL(staticString: "https://matrix.to")
 
-    let lastAppLaunchDate = Date()
-    
     // MARK: - Feature Flags
     
     // MARK: Start Chat

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -150,6 +150,8 @@ final class AppSettings: ObservableObject {
     // MARK: - Other
     
     let permalinkBaseURL = URL(staticString: "https://matrix.to")
+
+    let lastAppLaunchDate = Date()
     
     // MARK: - Feature Flags
     

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -148,7 +148,7 @@ final class AppSettings {
     var pusherProfileTag: String?
 
     /// A set of all the notification identifiers that have been served so far, it's reset every time the app is launched
-    @UserPreference(key: SharedUserDefaultsKeys.servedNotificationIdentifiers, defaultValue: [], storageType: .userDefaults(store))
+    @UserPreference(key: SharedUserDefaultsKeys.servedNotificationIdentifiers, initialValue: [], storageType: .userDefaults(store))
     var servedNotificationIdentifiers: Set<String>
         
     // MARK: - Other

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -18,7 +18,7 @@ import Foundation
 import SwiftUI
 
 /// Store Element specific app settings.
-final class AppSettings: ObservableObject {
+final class AppSettings {
     private enum UserDefaultsKeys: String {
         case lastVersionLaunched
         case seenInvites
@@ -146,6 +146,10 @@ final class AppSettings: ObservableObject {
     /// Tag describing which set of device specific rules a pusher executes.
     @UserPreference(key: UserDefaultsKeys.pusherProfileTag, storageType: .userDefaults(store))
     var pusherProfileTag: String?
+
+    /// A set of all the notification identifiers that have been served so far, it's reset every time the app is launched
+    @UserPreference(key: SharedUserDefaultsKeys.servedNotificationIdentifiers, defaultValue: [], storageType: .userDefaults(store))
+    var servedNotificationIdentifiers: Set<String>
         
     // MARK: - Other
     

--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -23,7 +23,7 @@ extension UNNotificationContent {
         userInfo[NotificationConstants.UserInfoKey.receiverIdentifier] as? String
     }
 
-    @objc var notificationIdentifier: String? {
+    @objc var notificationID: String? {
         userInfo[NotificationConstants.UserInfoKey.notificationIdentifier] as? String
     }
 
@@ -64,7 +64,7 @@ extension UNMutableNotificationContent {
         }
     }
 
-    override var notificationIdentifier: String? {
+    override var notificationID: String? {
         get {
             userInfo[NotificationConstants.UserInfoKey.notificationIdentifier] as? String
         }

--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -22,6 +22,18 @@ extension UNNotificationContent {
     @objc var receiverID: String? {
         userInfo[NotificationConstants.UserInfoKey.receiverIdentifier] as? String
     }
+
+    @objc var notificationIdentifier: String? {
+        userInfo[NotificationConstants.UserInfoKey.notificationIdentifier] as? String
+    }
+
+    @objc var roomID: String? {
+        userInfo[NotificationConstants.UserInfoKey.roomIdentifier] as? String
+    }
+
+    @objc var eventID: String? {
+        userInfo[NotificationConstants.UserInfoKey.eventIdentifier] as? String
+    }
 }
 
 extension UNMutableNotificationContent {
@@ -33,7 +45,34 @@ extension UNMutableNotificationContent {
             userInfo[NotificationConstants.UserInfoKey.receiverIdentifier] = newValue
         }
     }
-    
+
+    override var roomID: String? {
+        get {
+            userInfo[NotificationConstants.UserInfoKey.roomIdentifier] as? String
+        }
+        set {
+            userInfo[NotificationConstants.UserInfoKey.roomIdentifier] = newValue
+        }
+    }
+
+    override var eventID: String? {
+        get {
+            userInfo[NotificationConstants.UserInfoKey.eventIdentifier] as? String
+        }
+        set {
+            userInfo[NotificationConstants.UserInfoKey.eventIdentifier] = newValue
+        }
+    }
+
+    override var notificationIdentifier: String? {
+        get {
+            userInfo[NotificationConstants.UserInfoKey.notificationIdentifier] as? String
+        }
+        set {
+            userInfo[NotificationConstants.UserInfoKey.notificationIdentifier] = newValue
+        }
+    }
+
     func addMediaAttachment(using mediaProvider: MediaProviderProtocol?,
                             mediaSource: MediaSourceProxy) async -> UNMutableNotificationContent {
         guard let mediaProvider else {

--- a/ElementX/Sources/Other/SharedUserDefaultsKeys.swift
+++ b/ElementX/Sources/Other/SharedUserDefaultsKeys.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+enum SharedUserDefaultsKeys: String {
+    case servedNotificationIdentifiers
+}

--- a/ElementX/Sources/Other/UserPreference.swift
+++ b/ElementX/Sources/Other/UserPreference.swift
@@ -76,6 +76,12 @@ extension UserPreference {
         self.init(key: key.rawValue, defaultValue: defaultValue, storageType: storageType)
     }
 
+    /// Convenience initializer that also immediatelly stores the provided initialValue.
+    ///
+    /// - Parameters:
+    ///   - key: the raw representable key used to store the value, needs conform also to String
+    ///   - initialValue: the initial value that will be stored, the initialValue is also used as defaultValue
+    ///   - storageType: the storage type where the wrappedValue will be stored.
     convenience init<R: RawRepresentable>(key: R, initialValue: T, storageType: StorageType) where R.RawValue == String {
         self.init(key: key, defaultValue: initialValue, storageType: storageType)
         wrappedValue = initialValue

--- a/ElementX/Sources/Other/UserPreference.swift
+++ b/ElementX/Sources/Other/UserPreference.swift
@@ -75,6 +75,11 @@ extension UserPreference {
     convenience init<R: RawRepresentable>(key: R, defaultValue: T, storageType: StorageType) where R.RawValue == String {
         self.init(key: key.rawValue, defaultValue: defaultValue, storageType: storageType)
     }
+
+    convenience init<R: RawRepresentable>(key: R, initialValue: T, storageType: StorageType) where R.RawValue == String {
+        self.init(key: key, defaultValue: initialValue, storageType: storageType)
+        wrappedValue = initialValue
+    }
     
     convenience init(key: String, storageType: StorageType) where T: ExpressibleByNilLiteral {
         self.init(key: key, defaultValue: nil, storageType: storageType)

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -45,7 +45,8 @@ private class WeakClientProxyWrapper: ClientDelegate, NotificationDelegate, Slid
     // MARK: - NotificationDelegate
 
     func didReceiveNotification(notification: MatrixRustSDK.NotificationItem) {
-        clientProxy?.didReceiveNotification(notification: NotificationItemProxy(notificationItem: notification))
+        guard let userID = clientProxy?.userID else { return }
+        clientProxy?.didReceiveNotification(notification: NotificationItemProxy(notificationItem: notification, receiverID: userID))
     }
 }
 
@@ -103,9 +104,9 @@ class ClientProxy: ClientProxyProtocol {
         let delegate = WeakClientProxyWrapper(clientProxy: self)
         client.setDelegate(delegate: delegate)
         // Uncomment to test local notifications
-//        await Task.dispatch(on: clientQueue) {
-//            client.setNotificationDelegate(notificationDelegate: delegate)
-//        }
+        await Task.dispatch(on: clientQueue) {
+            client.setNotificationDelegate(notificationDelegate: delegate)
+        }
         
         configureSlidingSync()
 
@@ -461,14 +462,14 @@ class ClientProxy: ClientProxyProtocol {
     
     private lazy var slidingSyncRequiredState = [
         RequiredState(key: "m.room.avatar", value: ""),
-        RequiredState(key: "m.room.encryption", value: "")
+        RequiredState(key: "m.room.encryption", value: ""),
         // These are required for notifications
         // The idea is to create another SS
         // to listen to them separately
         // only here for testing purposes when enabling local notifications
-//        RequiredState(key: "m.room.member", value: "$ME"),
-//        RequiredState(key: "m.room.power_levels", value: ""),
-//        RequiredState(key: "m.room.name", value: "")
+        RequiredState(key: "m.room.member", value: "$ME"),
+        RequiredState(key: "m.room.power_levels", value: ""),
+        RequiredState(key: "m.room.name", value: "")
     ]
     
     private lazy var slidingSyncInvitesRequiredState = [RequiredState(key: "m.room.avatar", value: ""),

--- a/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
+++ b/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
@@ -101,7 +101,8 @@ class NotificationManager: NSObject, NotificationManagerProtocol {
     }
 
     private func showLocalNotification(_ notification: NotificationItemProxyProtocol) async {
-        guard let userSession else { return }
+        guard let userSession,
+              notification.event.timestamp > ServiceLocator.shared.settings.lastAppLaunchDate else { return }
         do {
             guard let content = try await notification.process(receiverId: userSession.userID, roomId: notification.roomID, mediaProvider: userSession.mediaProvider) else {
                 return

--- a/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
+++ b/ElementX/Sources/Services/Notification/Manager/NotificationManager.swift
@@ -104,10 +104,12 @@ class NotificationManager: NSObject, NotificationManagerProtocol {
         guard let userSession,
               notification.event.timestamp > ServiceLocator.shared.settings.lastAppLaunchDate else { return }
         do {
-            guard let content = try await notification.process(receiverId: userSession.userID, roomId: notification.roomID, mediaProvider: userSession.mediaProvider) else {
+            guard let content = try await notification.process(mediaProvider: userSession.mediaProvider),
+                  let identifier = notification.identifier else {
                 return
             }
-            let request = UNNotificationRequest(identifier: ProcessInfo.processInfo.globallyUniqueString, content: content, trigger: nil)
+            let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
+            ServiceLocator.shared.settings.servedNotificationIdentifiers.insert(identifier)
             try await notificationCenter.add(request)
         } catch {
             MXLog.error("[NotificationManager] show local notification item failed: \(error)")

--- a/ElementX/Sources/Services/Notification/NotificationConstants.swift
+++ b/ElementX/Sources/Services/Notification/NotificationConstants.swift
@@ -23,6 +23,7 @@ enum NotificationConstants {
         static let unreadCount = "unread_count"
         static let pusherNotificationClientIdentifier = "pusher_notification_client_identifier"
         static let receiverIdentifier = "receiver_id"
+        static let notificationIdentifier = "notification_identifier"
     }
 
     enum Category {

--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -43,7 +43,7 @@ protocol NotificationItemProxyProtocol {
 }
 
 extension NotificationItemProxyProtocol {
-    var identifier: String? {
+    var id: String? {
         let identifiers = receiverID + roomID + event.eventID
         guard let data = identifiers.data(using: .utf8) else {
             return nil
@@ -210,7 +210,7 @@ extension NotificationItemProxyProtocol {
         notification.receiverID = receiverID
         notification.roomID = roomID
         notification.eventID = event.eventID
-        notification.notificationIdentifier = identifier
+        notification.notificationID = id
         notification.title = InfoPlistReader(bundle: .app).bundleDisplayName
         notification.body = L10n.notification
         notification.threadIdentifier = roomID
@@ -224,7 +224,7 @@ extension NotificationItemProxyProtocol {
         notification.receiverID = receiverID
         notification.roomID = roomID
         notification.eventID = event.eventID
-        notification.notificationIdentifier = identifier
+        notification.notificationID = id
         notification.title = senderDisplayName ?? roomDisplayName
         if notification.title != roomDisplayName {
             notification.subtitle = roomDisplayName

--- a/ElementX/Sources/Services/Notification/Proxy/NotificationServiceProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationServiceProxy.swift
@@ -18,14 +18,16 @@ import Foundation
 import MatrixRustSDK
 
 class NotificationServiceProxy: NotificationServiceProxyProtocol {
+    private let userID: String
 //    private let service: NotificationServiceProtocol
 
     init(basePath: String,
-         userId: String) {
+         userID: String) {
+        self.userID = userID
 //        service = NotificationService(basePath: basePath, userId: userId)
     }
 
     func notificationItem(roomId: String, eventId: String) async throws -> NotificationItemProxyProtocol? {
-        MockNotificationItemProxy(eventID: eventId, roomID: roomId)
+        MockNotificationItemProxy(eventID: eventId, roomID: roomId, receiverID: userID)
     }
 }

--- a/ElementX/Sources/Services/Timeline/TimelineEventProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineEventProxy.swift
@@ -23,6 +23,8 @@ protocol TimelineEventProxyProtocol {
     var eventID: String { get }
 
     var senderID: String { get }
+
+    var timestamp: Date { get }
 }
 
 final class TimelineEventProxy: TimelineEventProxyProtocol {
@@ -43,10 +45,15 @@ final class TimelineEventProxy: TimelineEventProxyProtocol {
     var type: TimelineEventType? {
         try? timelineEvent.eventType()
     }
+
+    var timestamp: Date {
+        Date(timeIntervalSince1970: TimeInterval(timelineEvent.timestamp() / 1000))
+    }
 }
 
 struct MockTimelineEventProxy: TimelineEventProxyProtocol {
     let eventID: String
     let senderID = ""
     let type: TimelineEventType? = nil
+    let timestamp = Date()
 }

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -138,6 +138,7 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
         guard let identifier = modifiedContent.notificationIdentifier,
               !settings.servedNotificationIdentifiers.contains(identifier) else {
             MXLog.info("\(tag) notify: notification already served")
+            discard()
             return
         }
 

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -135,7 +135,7 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
             return
         }
 
-        guard let identifier = modifiedContent.notificationIdentifier,
+        guard let identifier = modifiedContent.notificationID,
               !settings.servedNotificationIdentifiers.contains(identifier) else {
             MXLog.info("\(tag) notify: notification already served")
             discard()

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -19,6 +19,7 @@ import MatrixRustSDK
 import UserNotifications
 
 class NotificationServiceExtension: UNNotificationServiceExtension {
+    private let settings = NSESettings()
     private lazy var keychainController = KeychainController(service: .sessions,
                                                              accessGroup: InfoPlistReader.main.keychainAccessGroupIdentifier)
     var handler: ((UNNotificationContent) -> Void)?
@@ -29,8 +30,8 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
         guard !DataProtectionManager.isDeviceLockedAfterReboot(containerURL: URL.appGroupContainerDirectory),
               let roomId = request.roomId,
               let eventId = request.eventId,
-              let notificationID = request.pusherNotificationClientIdentifier,
-              let credentials = keychainController.restorationTokens().first(where: { $0.restorationToken.pusherNotificationClientIdentifier == notificationID }) else {
+              let clientID = request.pusherNotificationClientIdentifier,
+              let credentials = keychainController.restorationTokens().first(where: { $0.restorationToken.pusherNotificationClientIdentifier == clientID }) else {
             // We cannot process this notification, it might be due to one of these:
             // - Device rebooted and locked
             // - Not a Matrix notification
@@ -69,7 +70,7 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
         MXLog.info("\(tag) run with roomId: \(roomId), eventId: \(eventId)")
 
         let service = NotificationServiceProxy(basePath: URL.sessionsBaseDirectory.path,
-                                               userId: credentials.userID)
+                                               userID: credentials.userID)
 
         guard let itemProxy = try await service.notificationItem(roomId: roomId,
                                                                  eventId: eventId) else {
@@ -81,9 +82,7 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
 
         // First process without a media proxy.
         // After this some properties of the notification should be set, like title, subtitle, sound etc.
-        guard let firstContent = try await itemProxy.process(receiverId: credentials.userID,
-                                                             roomId: roomId,
-                                                             mediaProvider: nil) else {
+        guard let firstContent = try await itemProxy.process(mediaProvider: nil) else {
             MXLog.error("\(tag) not even first content")
 
             // Notification should be discarded
@@ -103,9 +102,7 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
         MXLog.info("\(tag) process with media")
 
         // There is some media to load, process it again
-        if let latestContent = try await itemProxy.process(receiverId: credentials.userID,
-                                                           roomId: roomId,
-                                                           mediaProvider: createMediaProvider(with: credentials)) {
+        if let latestContent = try await itemProxy.process(mediaProvider: createMediaProvider(with: credentials)) {
             // Processing finished, hopefully with some media
             modifiedContent = latestContent
             return notify()
@@ -137,6 +134,14 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
             MXLog.info("\(tag) notify: no modified content")
             return
         }
+
+        guard let identifier = modifiedContent.notificationIdentifier,
+              !settings.servedNotificationIdentifiers.contains(identifier) else {
+            MXLog.info("\(tag) notify: notification already served")
+            return
+        }
+
+        settings.servedNotificationIdentifiers.insert(identifier)
         handler?(modifiedContent)
         handler = nil
         self.modifiedContent = nil

--- a/NSE/Sources/Other/NSESettings.swift
+++ b/NSE/Sources/Other/NSESettings.swift
@@ -1,0 +1,28 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+final class NSESettings {
+    private static var suiteName: String = InfoPlistReader.main.appGroupIdentifier
+
+    /// UserDefaults to be used on reads and writes.
+    private static var store: UserDefaults! = UserDefaults(suiteName: suiteName)
+
+    /// A set of all the notification identifiers that have been served so far, it's reset every time the app is launched
+    @UserPreference(key: SharedUserDefaultsKeys.servedNotificationIdentifiers, defaultValue: [], storageType: .userDefaults(store))
+    var servedNotificationIdentifiers: Set<String>
+}

--- a/NSE/SupportingFiles/target.yml
+++ b/NSE/SupportingFiles/target.yml
@@ -90,3 +90,5 @@ targets:
     - path: ../../ElementX/Sources/Other/AvatarSize.swift
     - path: ../../ElementX/Sources/Other/InfoPlistReader.swift
     - path: ../../ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+    - path: ../../ElementX/Sources/Other/UserPreference.swift
+    - path: ../../ElementX/Sources/Other/SharedUserDefaultsKeys.swift

--- a/changelog.d/813.feature
+++ b/changelog.d/813.feature
@@ -1,0 +1,1 @@
+Local notifications support, these can also be decrypted and shown as rich push notifications.


### PR DESCRIPTION
Implemented a system to avoid race condition and duplication between local notifications and other local notifications, and most importantly between local notifications and remote notifications:

- LocalW/Local: Using a timestamp value exposed on the event wrapped in the notification item, this is compared with the date of the last app launch, if the timestamp is above this value then we can show the notification otherwise we discard it
- LocalW/Remote: Saving a notification identifier value in a shared store between NSE and the main app, this notification identifier is just a sha256 of the client's user id, the room id and the event id. When a remote notification/local notification is about to be served we check first if the identifier is already present, if it is we discard the notification, if not we save the identifier and then we display the notification.

The PR also features some various code improvements to reduce the size of the process functions.

The only thing left to do is decide if we want to enable local notifications immediately right now, or we want to wait for remote notifications to also decrypt their content.

As of right now I tested the code, and local notifications are always faster, so they always take precedence over NSE remote notifications, so when the app is not in a killed state, we are able to serve rich push notifications that show content and media! However not sure if given bad network connections or old devices remotes could take precedence hindering a bit the experience, for now it has never happened once to me testing it on my physical device.