### PR TITLE
Pass attachment bodies when loading media

### DIFF
--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,7 +20,7 @@
     {
       "identity" : "compound-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vector-im/compound-ios.git",
+      "location" : "https://github.com/vector-im/compound-ios",
       "state" : {
         "revision" : "b4f34edce9003ba1fde31500312f317b728f4ee3"
       }
@@ -111,8 +111,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "3a1355ab4c6933e9f55d8a7addcefb13c6a5c26d",
-        "version" : "1.0.58-alpha"
+        "revision" : "15c314fcb20e3b009b573a50edc4736a73e63c96",
+        "version" : "1.0.59-alpha"
       }
     },
     {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -595,7 +595,7 @@ extension ClientProxy: MediaLoaderProtocol {
         try await mediaLoader.loadMediaThumbnailForSource(source, width: width, height: height)
     }
     
-    func loadMediaFileForSource(_ source: MediaSourceProxy) async throws -> MediaFileHandleProxy {
-        try await mediaLoader.loadMediaFileForSource(source)
+    func loadMediaFileForSource(_ source: MediaSourceProxy, body: String?) async throws -> MediaFileHandleProxy {
+        try await mediaLoader.loadMediaFileForSource(source, body: body)
     }
 }

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -91,7 +91,7 @@ class MockClientProxy: ClientProxyProtocol {
         throw ClientProxyError.failedLoadingMedia
     }
     
-    func loadMediaFileForSource(_ source: MediaSourceProxy) async throws -> MediaFileHandleProxy {
+    func loadMediaFileForSource(_ source: MediaSourceProxy, body: String?) async throws -> MediaFileHandleProxy {
         throw ClientProxyError.failedLoadingMedia
     }
     

--- a/ElementX/Sources/Services/Media/Provider/MediaLoader.swift
+++ b/ElementX/Sources/Services/Media/Provider/MediaLoader.swift
@@ -46,9 +46,9 @@ actor MediaLoader: MediaLoaderProtocol {
         }
     }
     
-    func loadMediaFileForSource(_ source: MediaSourceProxy) async throws -> MediaFileHandleProxy {
+    func loadMediaFileForSource(_ source: MediaSourceProxy, body: String?) async throws -> MediaFileHandleProxy {
         let result = try await Task.dispatch(on: clientQueue) {
-            try self.client.getMediaFile(mediaSource: source.underlyingSource, mimeType: source.mimeType ?? "application/octet-stream")
+            try self.client.getMediaFile(mediaSource: source.underlyingSource, body: body, mimeType: source.mimeType ?? "application/octet-stream")
         }
         
         return MediaFileHandleProxy(handle: result)

--- a/ElementX/Sources/Services/Media/Provider/MediaLoaderProtocol.swift
+++ b/ElementX/Sources/Services/Media/Provider/MediaLoaderProtocol.swift
@@ -21,5 +21,11 @@ protocol MediaLoaderProtocol {
 
     func loadMediaThumbnailForSource(_ source: MediaSourceProxy, width: UInt, height: UInt) async throws -> Data
     
-    func loadMediaFileForSource(_ source: MediaSourceProxy) async throws -> MediaFileHandleProxy
+    func loadMediaFileForSource(_ source: MediaSourceProxy, body: String?) async throws -> MediaFileHandleProxy
+}
+
+extension MediaLoaderProtocol {
+    func loadMediaFileForSource(_ source: MediaSourceProxy) async throws -> MediaFileHandleProxy {
+        try await loadMediaFileForSource(source, body: nil)
+    }
 }

--- a/ElementX/Sources/Services/Media/Provider/MediaProvider.swift
+++ b/ElementX/Sources/Services/Media/Provider/MediaProvider.swift
@@ -91,12 +91,12 @@ struct MediaProvider: MediaProviderProtocol {
     
     // MARK: Files
     
-    func loadFileFromSource(_ source: MediaSourceProxy) async -> Result<MediaFileHandleProxy, MediaProviderError> {
+    func loadFileFromSource(_ source: MediaSourceProxy, body: String?) async -> Result<MediaFileHandleProxy, MediaProviderError> {
         let loadFileBgTask = await backgroundTaskService?.startBackgroundTask(withName: "LoadFile: \(source.url.hashValue)")
         defer { loadFileBgTask?.stop() }
         
         do {
-            let file = try await mediaLoader.loadMediaFileForSource(source)
+            let file = try await mediaLoader.loadMediaFileForSource(source, body: body)
             return .success(file)
         } catch {
             MXLog.error("Failed retrieving file with error: \(error)")

--- a/ElementX/Sources/Services/Media/Provider/MediaProviderProtocol.swift
+++ b/ElementX/Sources/Services/Media/Provider/MediaProviderProtocol.swift
@@ -24,5 +24,11 @@ enum MediaProviderError: Error {
 }
 
 protocol MediaProviderProtocol: ImageProviderProtocol {
-    func loadFileFromSource(_ source: MediaSourceProxy) async -> Result<MediaFileHandleProxy, MediaProviderError>
+    func loadFileFromSource(_ source: MediaSourceProxy, body: String?) async -> Result<MediaFileHandleProxy, MediaProviderError>
+}
+
+extension MediaProviderProtocol {
+    func loadFileFromSource(_ source: MediaSourceProxy) async -> Result<MediaFileHandleProxy, MediaProviderError> {
+        await loadFileFromSource(source, body: nil)
+    }
 }

--- a/ElementX/Sources/Services/Media/Provider/MockMediaProvider.swift
+++ b/ElementX/Sources/Services/Media/Provider/MockMediaProvider.swift
@@ -47,7 +47,7 @@ struct MockMediaProvider: MediaProviderProtocol {
         return .success(data)
     }
     
-    func loadFileFromSource(_ source: MediaSourceProxy) async -> Result<MediaFileHandleProxy, MediaProviderError> {
+    func loadFileFromSource(_ source: MediaSourceProxy, body: String?) async -> Result<MediaFileHandleProxy, MediaProviderError> {
         .failure(.failedRetrievingFile)
     }
 }

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
@@ -106,29 +106,29 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
         }
         
         var source: MediaSourceProxy?
-        var title: String
+        var body: String
         switch timelineItem {
         case let item as ImageRoomTimelineItem:
             source = item.source
-            title = item.body
+            body = item.body
         case let item as VideoRoomTimelineItem:
             source = item.source
-            title = item.body
+            body = item.body
         case let item as FileRoomTimelineItem:
             source = item.source
-            title = item.body
+            body = item.body
         case let item as AudioRoomTimelineItem:
             // For now we are just displaying audio messages with the File preview until we create a timeline player for them.
             source = item.source
-            title = item.body
+            body = item.body
         default:
             return .none
         }
         
         guard let source else { return .none }
-        switch await mediaProvider.loadFileFromSource(source) {
+        switch await mediaProvider.loadFileFromSource(source, body: body) {
         case .success(let file):
-            return .displayMediaFile(file: file, title: title)
+            return .displayMediaFile(file: file, title: body)
         case .failure:
             return .none
         }

--- a/UnitTests/Sources/MediaProvider/MediaLoaderTests.swift
+++ b/UnitTests/Sources/MediaProvider/MediaLoaderTests.swift
@@ -95,7 +95,7 @@ private class MockMediaLoadingClient: ClientProtocol {
     
     func uploadMedia(mimeType: String, data content: [UInt8]) throws -> String { fatalError() }
     
-    func getMediaFile(mediaSource: MatrixRustSDK.MediaSource, mimeType: String) throws -> MatrixRustSDK.MediaFileHandle { fatalError() }
+    func getMediaFile(mediaSource: MatrixRustSDK.MediaSource, body: String?, mimeType: String) throws -> MatrixRustSDK.MediaFileHandle { fatalError() }
     
     func getProfile(userId: String) throws -> MatrixRustSDK.UserProfile { fatalError() }
     

--- a/UnitTests/Sources/MediaProvider/MockMediaLoader.swift
+++ b/UnitTests/Sources/MediaProvider/MockMediaLoader.swift
@@ -41,7 +41,7 @@ class MockMediaLoader: MediaLoaderProtocol {
         }
     }
     
-    func loadMediaFileForSource(_ source: MediaSourceProxy) async throws -> MediaFileHandleProxy {
+    func loadMediaFileForSource(_ source: MediaSourceProxy, body: String?) async throws -> MediaFileHandleProxy {
         if let mediaFileURL {
             return .unmanaged(url: mediaFileURL)
         } else {

--- a/project.yml
+++ b/project.yml
@@ -42,7 +42,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.58-alpha
+    exactVersion: 1.0.59-alpha
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
We now use the attachment body string to generate the correct temporary filename so that it's available to system dialogs later.