### PR TITLE
Improve media uploading content type selection. Fix pasting in screenshots not working

### DIFF
--- a/ElementX/Sources/Other/Extensions/NSItemProvider.swift
+++ b/ElementX/Sources/Other/Extensions/NSItemProvider.swift
@@ -15,12 +15,30 @@
 //
 
 import Foundation
+import UniformTypeIdentifiers
 
 extension NSItemProvider {
     var isSupportedForPasteOrDrop: Bool {
-        !registeredContentTypes
-            .compactMap(\.preferredMIMEType)
-            .filter { $0.hasPrefix("image/") || $0.hasPrefix("video/") || $0.hasPrefix("application/") }
-            .isEmpty
+        preferredContentType != nil
+    }
+    
+    var preferredContentType: UTType? {
+        let supportedContentTypes = registeredContentTypes
+            .filter { isMimeTypeSupported($0.preferredMIMEType) }
+        
+        // Have .jpeg take priority over .heic
+        if supportedContentTypes.contains(.jpeg) {
+            return .jpeg
+        }
+        
+        return supportedContentTypes.first
+    }
+    
+    private func isMimeTypeSupported(_ mimeType: String?) -> Bool {
+        guard let mimeType else {
+            return false
+        }
+        
+        return mimeType.hasPrefix("image/") || mimeType.hasPrefix("video/") || mimeType.hasPrefix("application/")
     }
 }

--- a/ElementX/Sources/Screens/MediaPickerScreen/PhotoLibraryPicker.swift
+++ b/ElementX/Sources/Screens/MediaPickerScreen/PhotoLibraryPicker.swift
@@ -62,7 +62,7 @@ struct PhotoLibraryPicker: UIViewControllerRepresentable {
         
         func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
             guard let provider = results.first?.itemProvider,
-                  let contentType = provider.registeredContentTypes.filter({ $0.conforms(to: .image) || $0.conforms(to: .movie) || $0.conforms(to: .video) }).first else {
+                  let contentType = provider.preferredContentType else {
                 photoLibraryPicker.callback(.cancel)
                 return
             }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -335,8 +335,8 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     // Pasting and dropping
     
     private func handlePasteOrDrop(_ provider: NSItemProvider) {
-        guard let type = provider.registeredContentTypes.first,
-              let preferredExtension = type.preferredFilenameExtension else {
+        guard let contentType = provider.preferredContentType,
+              let preferredExtension = contentType.preferredFilenameExtension else {
             MXLog.error("Invalid NSItemProvider: \(provider)")
             displayError(.toast(L10n.screenRoomErrorFailedProcessingMedia))
             return
@@ -345,7 +345,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         let providerSuggestedName = provider.suggestedName
         let providerDescription = provider.description
         
-        _ = provider.loadDataRepresentation(for: type) { data, error in
+        _ = provider.loadDataRepresentation(for: contentType) { data, error in
             Task { @MainActor in
                 let loadingIndicatorIdentifier = UUID().uuidString
                 ServiceLocator.shared.userIndicatorController.submitIndicator(UserIndicator(id: loadingIndicatorIdentifier, type: .modal, title: L10n.commonLoading, persistent: true))


### PR DESCRIPTION
Sometimes selected media reports multiple registered content types e.g. a live photo will report

```
▿ 3 elements
  ▿ 0 : <UTType 0x282692150> com.apple.live-photo-bundle (not dynamic, declared)
    - _type : <UTType 0x282692150> com.apple.live-photo-bundle (not dynamic, declared)
  ▿ 1 : <_UTCoreType 0x1e8395670> public.jpeg (not dynamic, declared)
    - _type : <_UTCoreType 0x1e8395670> public.jpeg (not dynamic, declared)
  ▿ 2 : <_UTCoreType 0x1e83957d0> public.heic (not dynamic, declared)
    - _type : <_UTCoreType 0x1e83957d0> public.heic (not dynamic, declared)
```

and in those cases we need to make sure we don't just select the first one but filter down to the types we actually support. More than that, in this case we also receive 2 possible image types and we should try to use jpeg if available.

Fixes https://github.com/vector-im/element-x-ios/issues/858