### PR TITLE
Fix for the sender icon not being rendered in notifications sometimes

### DIFF
--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -119,12 +119,9 @@ extension UNMutableNotificationContent {
         return self
     }
 
-    // swiftlint:disable:next function_parameter_count
     func addSenderIcon(using mediaProvider: MediaProviderProtocol?,
-                       senderId: String,
-                       receiverId: String,
+                       senderID: String,
                        senderName: String,
-                       roomId: String,
                        iconType: NotificationIconType) async throws -> UNMutableNotificationContent {
         var image: INImage?
         if let mediaSource = iconType.mediaSource {
@@ -138,7 +135,7 @@ extension UNMutableNotificationContent {
             }
         }
 
-        let senderHandle = INPersonHandle(value: senderId, type: .unknown)
+        let senderHandle = INPersonHandle(value: senderID, type: .unknown)
         let sender = INPerson(personHandle: senderHandle,
                               nameComponents: nil,
                               displayName: senderName,
@@ -150,7 +147,7 @@ extension UNMutableNotificationContent {
         var speakableGroupName: INSpeakableString?
         var recipients: [INPerson]?
         if case let .group(_, groupName) = iconType {
-            let meHandle = INPersonHandle(value: receiverId, type: .unknown)
+            let meHandle = INPersonHandle(value: receiverID, type: .unknown)
             let me = INPerson(personHandle: meHandle, nameComponents: nil, displayName: nil, image: nil, contactIdentifier: nil, customIdentifier: nil, isMe: true)
             speakableGroupName = INSpeakableString(spokenPhrase: groupName)
             recipients = [sender, me]
@@ -160,7 +157,7 @@ extension UNMutableNotificationContent {
                                          outgoingMessageType: .outgoingMessageText,
                                          content: nil,
                                          speakableGroupName: speakableGroupName,
-                                         conversationIdentifier: roomId,
+                                         conversationIdentifier: roomID,
                                          serviceName: nil,
                                          sender: sender,
                                          attachments: nil)

--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -232,22 +232,19 @@ extension NotificationItemProxyProtocol {
         notification.sound = isNoisy ? UNNotificationSound(named: UNNotificationSoundName(rawValue: "message.caf")) : nil
 
         let senderName = senderDisplayName ?? roomDisplayName
-        var groupName: String?
-        var mediaSource: MediaSourceProxy?
+        let iconType: NotificationIconType
         if !isDirect {
-            groupName = senderName != roomDisplayName ? roomDisplayName : nil
-            mediaSource = roomAvatarMediaSource
+            iconType = .group(mediaSource: roomAvatarMediaSource, groupName: roomDisplayName)
         } else {
-            mediaSource = senderAvatarMediaSource
+            iconType = .sender(mediaSource: senderAvatarMediaSource)
         }
 
         notification = try await notification.addSenderIcon(using: mediaProvider,
                                                             senderId: event.senderID,
                                                             receiverId: receiverID,
                                                             senderName: senderName,
-                                                            groupName: groupName,
-                                                            mediaSource: mediaSource,
-                                                            roomId: roomID)
+                                                            roomId: roomID,
+                                                            iconType: iconType)
         return notification
     }
 

--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -240,10 +240,8 @@ extension NotificationItemProxyProtocol {
         }
 
         notification = try await notification.addSenderIcon(using: mediaProvider,
-                                                            senderId: event.senderID,
-                                                            receiverId: receiverID,
+                                                            senderID: event.senderID,
                                                             senderName: senderName,
-                                                            roomId: roomID,
                                                             iconType: iconType)
         return notification
     }

--- a/Tools/Sources/Utilities.swift
+++ b/Tools/Sources/Utilities.swift
@@ -19,7 +19,6 @@ enum Utilities {
     @discardableResult
     static func zsh(_ command: String, workingDirectoryURL: URL = projectDirectoryURL) throws -> String? {
         let process = Process()
-        process.environment = [:]
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         process.arguments = ["-cu", command]
         process.currentDirectoryURL = workingDirectoryURL

--- a/Tools/Sources/Utilities.swift
+++ b/Tools/Sources/Utilities.swift
@@ -19,6 +19,7 @@ enum Utilities {
     @discardableResult
     static func zsh(_ command: String, workingDirectoryURL: URL = projectDirectoryURL) throws -> String? {
         let process = Process()
+        process.environment = [:]
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         process.arguments = ["-cu", command]
         process.currentDirectoryURL = workingDirectoryURL

--- a/changelog.d/863.bugfix
+++ b/changelog.d/863.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug that did not render the sender icon of a dm sometimes.


### PR DESCRIPTION
This was happening because we were using both the flow for groups and normal senders at the same time, which made the notification confused on which image the render (the one set on the sender, or the one set on the intent).

Now we only set the image on the intent when we are sure we want to render a group.