### PR TITLE
Optimize leaving a room from home screen

### DIFF
--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -111,8 +111,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "1c1cd29d5720ecd0f6043b5d8f5a40d30dd5ec41",
-        "version" : "1.0.61-alpha"
+        "revision" : "3ea7abc7ceb51577724b499209f5b6b3fe2cfcde",
+        "version" : "1.0.62-alpha"
       }
     },
     {

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -414,6 +414,21 @@ class RoomProxyMock: RoomProxyProtocol {
         set(value) { underlyingMembersPublisher = value }
     }
     var underlyingMembersPublisher: AnyPublisher<[RoomMemberProxyProtocol], Never>!
+    var invitedMembersCount: UInt64 {
+        get { return underlyingInvitedMembersCount }
+        set(value) { underlyingInvitedMembersCount = value }
+    }
+    var underlyingInvitedMembersCount: UInt64!
+    var joinedMembersCount: UInt64 {
+        get { return underlyingJoinedMembersCount }
+        set(value) { underlyingJoinedMembersCount = value }
+    }
+    var underlyingJoinedMembersCount: UInt64!
+    var activeMembersCount: UInt64 {
+        get { return underlyingActiveMembersCount }
+        set(value) { underlyingActiveMembersCount = value }
+    }
+    var underlyingActiveMembersCount: UInt64!
 
     //MARK: - loadAvatarURLForUserId
 

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -325,20 +325,11 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 return
             }
             
-            guard !room.isPublic else {
+            if room.isPublic {
                 state.bindings.leaveRoomAlertItem = LeaveRoomAlertItem(roomId: roomId, state: .public)
-                return
+            } else {
+                state.bindings.leaveRoomAlertItem = room.joinedMembersCount > 1 ? LeaveRoomAlertItem(roomId: roomId, state: .private) : LeaveRoomAlertItem(roomId: roomId, state: .empty)
             }
-            
-            await room.updateMembers()
-            let joinedMembers = await room.membersPublisher.values.first()?.filter { $0.membership == .join }
-            
-            guard let joinedMembers else {
-                state.bindings.alertInfo = AlertInfo(id: UUID(), title: L10n.errorUnknown)
-                return
-            }
-            
-            state.bindings.leaveRoomAlertItem = joinedMembers.count > 1 ? LeaveRoomAlertItem(roomId: roomId, state: .private) : LeaveRoomAlertItem(roomId: roomId, state: .empty)
         }
     }
     

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -441,6 +441,18 @@ class RoomProxy: RoomProxyProtocol {
         }
     }
     
+    var invitedMembersCount: UInt64 {
+        room.invitedMembersCount()
+    }
+    
+    var joinedMembersCount: UInt64 {
+        room.joinedMembersCount()
+    }
+    
+    var activeMembersCount: UInt64 {
+        room.activeMembersCount()
+    }
+    
     // MARK: - Private
     
     /// Force the timeline to load member details so it can populate sender profiles whenever we add a timeline listener

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -104,6 +104,12 @@ protocol RoomProxyProtocol {
     func acceptInvitation() async -> Result<Void, RoomProxyError>
     
     func fetchDetails(for eventID: String)
+    
+    var invitedMembersCount: UInt64 { get }
+    
+    var joinedMembersCount: UInt64 { get }
+    
+    var activeMembersCount: UInt64 { get }
 }
 
 extension RoomProxyProtocol {

--- a/project.yml
+++ b/project.yml
@@ -42,7 +42,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.61-alpha
+    exactVersion: 1.0.62-alpha
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
This PR optimize the "room leave" process from the home screen by calling using the `joinedMembersCount` instead of fetching the members for the room. It also updated the rust sdk to the version **1.0.62-alpha**