### PR TITLE
The simmer modifier stopped animating on Xcode 14.3 iOS 16.4. Not ent…

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Animation/ShimmerModifier.swift
+++ b/ElementX/Sources/Other/SwiftUI/Animation/ShimmerModifier.swift
@@ -42,7 +42,7 @@ struct ShimmerModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .mask { gradient }
-            .onAppear {
+            .task {
                 withAnimation(.linear(duration: 1.75).delay(0.5).repeatForever(autoreverses: false)) {
                     animationTrigger.toggle()
                 }


### PR DESCRIPTION
…irely sure why but switching `onAppear` to `task` fixes it