### PR TITLE
Fixes cache cleaning behavior after sdk change

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -458,20 +458,21 @@ class AppCoordinator: AppCoordinatorProtocol {
     private func clearCache() {
         showLoadingIndicator()
         
-        defer {
-            hideLoadingIndicator()
-        }
-        
         navigationRootCoordinator.setRootCoordinator(SplashScreenCoordinator())
         
         userSession.clientProxy.stopSync()
         userSessionFlowCoordinator?.stop()
         
-        userSessionStore.clearCacheFor(userSession: userSession)
-        
+        let userID = userSession.userID
         tearDownUserSession()
-        
-        stateMachine.processEvent(.startWithExistingSession)
+    
+        // Allow for everything to deallocate properly
+        Task {
+            try await Task.sleep(for: .seconds(2))
+            userSessionStore.clearCache(for: userID)
+            stateMachine.processEvent(.startWithExistingSession)
+            hideLoadingIndicator()
+        }
     }
 }
 

--- a/ElementX/Sources/Services/UserSession/UserSessionStoreProtocol.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStoreProtocol.swift
@@ -47,5 +47,5 @@ protocol UserSessionStoreProtocol {
     func logout(userSession: UserSessionProtocol)
     
     /// Clears our all the matrix sdk state data for the specified session
-    func clearCacheFor(userSession: UserSessionProtocol)
+    func clearCache(for userID: String)
 }


### PR DESCRIPTION
The new Sqlite state store is no longer in the matrix-sdk-state subfolder. Also, the client wasn't properly dealocated at the time this was run so I've added some artifical delays
