### PR TITLE
Disable unhandled_throwing_task rule.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ disabled_rules:
   - unused_setter_value
   - redundant_discardable_let
   - identifier_name
+  - unhandled_throwing_task
 
 opt_in_rules:  
   - force_unwrapping


### PR DESCRIPTION
Disable the new [`unhandled_throwing_task`](https://realm.github.io/SwiftLint/unhandled_throwing_task.html) rule in SwiftLint. This is going to get annoying if we have to `do { } catch { }` around every `Task.sleep`.