### PR TITLE
Add background app refresh support

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -403,7 +403,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
                 case .didReceiveAuthError(let isSoftLogout):
                     stateMachine.processEvent(.signOut(isSoft: isSoftLogout))
                 case .updateRestorationToken:
-                    _ = userSessionStore.refreshRestorationToken(for: userSession)
+                    userSessionStore.refreshRestorationToken(for: userSession)
                 default:
                     break
                 }

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -84,6 +84,9 @@ final class AppSettings {
     /// that don't yet have an officially trusted proxy configured in their well-known.
     let slidingSyncProxyURL: URL? = nil
     
+    /// The task identifier used for background app refresh. Also used in main target's the Info.plist
+    let backgroundAppRefreshTaskIdentifier = "io.element.elementx.background.refresh"
+    
     // MARK: - Authentication
     
     /// The URL that is opened when tapping the Learn more button on the sliding sync alert during authentication.

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -23,6 +23,14 @@ enum ClientProxyCallback {
     case receivedAuthError(isSoftLogout: Bool)
     case receivedNotification(NotificationItemProxyProtocol)
     case updateRestorationToken
+    
+    var isSyncUpdate: Bool {
+        if case .receivedSyncUpdate = self {
+            return true
+        } else {
+            return false
+        }
+    }
 }
 
 enum ClientProxyError: Error {

--- a/ElementX/Sources/Services/UserSession/UserSessionStoreProtocol.swift
+++ b/ElementX/Sources/Services/UserSession/UserSessionStoreProtocol.swift
@@ -41,6 +41,7 @@ protocol UserSessionStoreProtocol {
     func userSession(for client: Client) async -> Result<UserSessionProtocol, UserSessionStoreError>
 
     /// Refresh the restore token of the client for a given session.
+    @discardableResult
     func refreshRestorationToken(for userSession: UserSessionProtocol) -> Result<Void, UserSessionStoreError>
     
     /// Logs out of the specified session.

--- a/ElementX/SupportingFiles/Info.plist
+++ b/ElementX/SupportingFiles/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>io.element.elementx.background.refresh</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -29,6 +33,10 @@
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>INSendMessageIntent</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -64,6 +64,12 @@ targets:
         ]
         NSCameraUsageDescription: The camera is used to take and upload photos and videos.
         NSMicrophoneUsageDescription: The microphone is used to take videos.
+        UIBackgroundModes: [
+          fetch
+        ]
+        BGTaskSchedulerPermittedIdentifiers: [
+          io.element.elementx.background.refresh
+        ]
 
 
     settings:

--- a/changelog.d/pr-892.feature
+++ b/changelog.d/pr-892.feature
@@ -1,0 +1,1 @@
+Add background app refresh support


### PR DESCRIPTION
This PR add support for background app refreshes. 

The app currently stops syncing after a background task that starts when the app resigns active expires. We will now also schedule a background refresh task to run 30 seconds after this happens (just a suggestion for the system). When that happens the sync is restarted. It will attempt to run for a maximum or 10 sync responses or 10 seconds and then shut down again.

How to test this amazing piece of kit:

1) Run on a real device, simulators are not supported
2) Put a breakpoint right after scheduling the task -> `Successfully scheduled background app refresh task`
3) Execute this debugger command `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"io.element.elementx.background.refresh"]`
4) Continue the execution
5) See the background task getting invoked and profit

(https://developer.apple.com/documentation/backgroundtasks/starting_and_terminating_tasks_during_development)