### PR TITLE
Work around the fastlane-diawi-plugin getting deleted

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,7 +68,7 @@ lane :alpha do
     }
   )
 
-  upload_to_diawi()
+  # upload_to_diawi()
 
   upload_to_browserstack()
 end
@@ -190,25 +190,25 @@ lane :release_to_github do
   api_token = ENV["GITHUB_TOKEN"]
   UI.user_error!("Invalid GitHub API token.") unless !api_token.to_s.empty?
 
-  # Get the Diawi link from Diawi action shared value
-  diawi_link = lane_context[SharedValues::UPLOADED_FILE_LINK_TO_DIAWI]
+  # # Get the Diawi link from Diawi action shared value
+  # diawi_link = lane_context[SharedValues::UPLOADED_FILE_LINK_TO_DIAWI]
 
   release_version = get_version_number(target: "ElementX")
 
   changes = export_version_changes(version: release_version)
 
   description = ""
-  if diawi_link.nil?
+  # if diawi_link.nil?
     description = "#{changes}"
-  else
-    # Generate the Diawi QR code file link
-    diawi_app_id = URI(diawi_link).path.split('/').last
-    diawi_qr_code_link = "https://www.diawi.com/qrcode/link/#{diawi_app_id}"
+  # else
+  #   # Generate the Diawi QR code file link
+  #   diawi_app_id = URI(diawi_link).path.split('/').last
+  #   diawi_qr_code_link = "https://www.diawi.com/qrcode/link/#{diawi_app_id}"
 
-    "[iOS AdHoc Release - Diawi Link](#{diawi_link})
-    ![QR code](#{diawi_qr_code_link})
-    #{changes}"
-  end
+  #   "[iOS AdHoc Release - Diawi Link](#{diawi_link})
+  #   ![QR code](#{diawi_qr_code_link})
+  #   #{changes}"
+  # end
 
   github_release = set_github_release(
     repository_name: "vector-im/element-x-ios",
@@ -300,29 +300,29 @@ private_lane :config_xcodegen_alpha do
   bump_build_number()
 end
 
-private_lane :upload_to_diawi do
-  api_token = ENV["DIAWI_API_TOKEN"]
-  UI.user_error!("Invalid Diawi API token.") unless !api_token.to_s.empty?
+# private_lane :upload_to_diawi do
+#   api_token = ENV["DIAWI_API_TOKEN"]
+#   UI.user_error!("Invalid Diawi API token.") unless !api_token.to_s.empty?
 
-  # Upload to Diawi
-  diawi(
-    token: api_token,
-    wall_of_apps: false,
-    file: lane_context[SharedValues::IPA_OUTPUT_PATH]
-  )
+#   # Upload to Diawi
+#   diawi(
+#     token: api_token,
+#     wall_of_apps: false,
+#     file: lane_context[SharedValues::IPA_OUTPUT_PATH]
+#   )
 
-  # Get the Diawi link from Diawi action shared value
-  diawi_link = lane_context[SharedValues::UPLOADED_FILE_LINK_TO_DIAWI]
-  UI.command_output("Diawi link: " + diawi_link.to_s)
+#   # Get the Diawi link from Diawi action shared value
+#   diawi_link = lane_context[SharedValues::UPLOADED_FILE_LINK_TO_DIAWI]
+#   UI.command_output("Diawi link: " + diawi_link.to_s)
 
-  # Generate the Diawi QR code file link
-  diawi_app_id = URI(diawi_link).path.split('/').last
-  diawi_qr_code_link = "https://www.diawi.com/qrcode/link/#{diawi_app_id}"
+#   # Generate the Diawi QR code file link
+#   diawi_app_id = URI(diawi_link).path.split('/').last
+#   diawi_qr_code_link = "https://www.diawi.com/qrcode/link/#{diawi_app_id}"
 
-  # Set "DIAWI_FILE_LINK" to GitHub environment variables for Github actions
-  sh("echo DIAWI_FILE_LINK=#{diawi_link} >> $GITHUB_ENV")
-  sh("echo DIAWI_QR_CODE_LINK=#{diawi_qr_code_link} >> $GITHUB_ENV")
-end
+#   # Set "DIAWI_FILE_LINK" to GitHub environment variables for Github actions
+#   sh("echo DIAWI_FILE_LINK=#{diawi_link} >> $GITHUB_ENV")
+#   sh("echo DIAWI_QR_CODE_LINK=#{diawi_qr_code_link} >> $GITHUB_ENV")
+# end
 
 private_lane :upload_to_browserstack do
   browserstack_username = ENV["BROWSERSTACK_USERNAME"]

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,7 +2,6 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-diawi'
 gem 'fastlane-plugin-xcodegen'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-browserstack'


### PR DESCRIPTION
The Diawi Fastlane plugin has been deleted on friday (the whole repo actuall). There doesn't seem to be an alternative available so let's defer this to a later date.
Alphas will still build but they will not be uploaded to diawi. 