### PR TITLE
Rich reply rendering

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/Replies/TimelineReplyView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Replies/TimelineReplyView.swift
@@ -88,7 +88,10 @@ struct TimelineReplyView: View {
         @ViewBuilder
         private var icon: some View {
             if let mediaSource {
-                LoadableImage(mediaSource: mediaSource, size: .init(width: imageContainerSize, height: imageContainerSize), imageProvider: context.imageProvider) {
+                LoadableImage(mediaSource: mediaSource,
+                              size: .init(width: imageContainerSize,
+                                          height: imageContainerSize),
+                              imageProvider: context.imageProvider) {
                     Image(systemName: "photo")
                         .padding(4.0)
                 }

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineBubbleLayout.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineBubbleLayout.swift
@@ -71,11 +71,3 @@ struct TimelineBubbleLayout: Layout {
         }
     }
 }
-
-extension View {
-    func timelineQuoteBubbleFormatting() -> some View {
-        foregroundColor(.compound.textPlaceholder)
-            .fixedSize(horizontal: false, vertical: true)
-            .padding(4.0)
-    }
-}

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineBubbleLayout.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineBubbleLayout.swift
@@ -76,6 +76,6 @@ extension View {
     func timelineQuoteBubbleFormatting() -> some View {
         foregroundColor(.compound.textPlaceholder)
             .fixedSize(horizontal: false, vertical: true)
-            .padding(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
+            .padding(4.0)
     }
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -131,7 +131,9 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                 // The rendered reply bubble with a greedy width. The custom layout prevents
                 // the infinite width from increasing the overall width of the view.
                 TimelineReplyView(timelineItemReplyDetails: replyDetails)
-                    .timelineQuoteBubbleFormatting()
+                    .foregroundColor(.compound.textPlaceholder)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(4.0)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.element.background)
                     .cornerRadius(8)
@@ -139,7 +141,8 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                 
                 // Add a fixed width reply bubble that is used for layout calculations but won't be rendered.
                 TimelineReplyView(timelineItemReplyDetails: replyDetails)
-                    .timelineQuoteBubbleFormatting()
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(4.0)
                     .layoutPriority(TimelineBubbleLayout.Priority.hiddenQuote)
                     .hidden()
             }

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
@@ -50,7 +50,7 @@ struct TimelineItemPlainStylerView<Content: View>: View {
                let replyDetails = messageTimelineItem.replyDetails {
                 HStack(spacing: 4.0) {
                     Rectangle()
-                        .foregroundColor(.element.accent)
+                        .foregroundColor(.global.melon)
                         .frame(width: 4.0)
                     TimelineReplyView(timelineItemReplyDetails: replyDetails)
                 }

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
@@ -43,10 +43,17 @@ struct FormattedBodyText: View {
                     // The rendered blockquote with a greedy width. The custom layout prevents the
                     // infinite width from increasing the overall width of the view.
                     Text(component.attributedString.mergingAttributes(blockquoteAttributes))
-                        .timelineQuoteBubbleFormatting()
+                        .foregroundColor(.compound.textPlaceholder)
+                        .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(Color.element.background)
-                        .cornerRadius(8)
+                        .padding(.leading, 12.0)
+                        .overlay(alignment: .leading) {
+                            // User an overlay here so that the rectangle's infinite height doesn't take priority
+                            Rectangle()
+                                .frame(width: 2.0)
+                                .padding(.leading, 6.0)
+                                .foregroundColor(.compound.textPlaceholder)
+                        }
                         .layoutPriority(TimelineBubbleLayout.Priority.visibleQuote)
                 } else {
                     Text(component.attributedString)
@@ -62,7 +69,8 @@ struct FormattedBodyText: View {
             ForEach(attributedComponents, id: \.self) { component in
                 if component.isBlockquote {
                     Text(component.attributedString.mergingAttributes(blockquoteAttributes))
-                        .timelineQuoteBubbleFormatting()
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.leading, 12.0)
                         .layoutPriority(TimelineBubbleLayout.Priority.hiddenQuote)
                         .hidden()
                 }


### PR DESCRIPTION
This PR introduces custom reply views for all message types: 
* text, notification and emotes as plain text
* audio, files with sf symbol icons (the same used in the timeline items)
* images using the image thumbnail
* videos using the video thumbnail
* a loading state using a "redacted" version

It also changes the look of blockquotes.
 
![Screenshot 2023-05-16 at 17 18 43](https://github.com/vector-im/element-x-ios/assets/637564/3285c363-43d1-47e6-905e-42826ec0184a)

![Screenshot 2023-05-16 at 17 18 40](https://github.com/vector-im/element-x-ios/assets/637564/71b6eab3-58f8-4cba-aa3b-b781e6b7aed6)

![Screenshot 2023-05-16 at 17 18 58](https://github.com/vector-im/element-x-ios/assets/637564/56fe5438-0163-4da3-bc00-67d57aaeff7c)

![Screenshot 2023-05-16 at 17 19 02](https://github.com/vector-im/element-x-ios/assets/637564/f0a1b89f-7724-4207-a68b-b371c66e0170)

![Screenshot 2023-05-16 at 17 20 36](https://github.com/vector-im/element-x-ios/assets/637564/dbc3c157-557c-4c37-a3f4-76180674d4db)

![Screenshot 2023-05-16 at 17 21 27](https://github.com/vector-im/element-x-ios/assets/637564/4cfc43af-e735-4e0d-abd9-977c5df6aa38)
