### PR TITLE
Cleanup the background task that pauses the SDK when resigning active

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -542,10 +542,13 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
         }
 
         backgroundTask = backgroundTaskService.startBackgroundTask(withName: "SuspendApp: \(UUID().uuidString)") { [weak self] in
-            self?.userSession?.clientProxy.stopSync { [weak self] in
-                guard let self else { return }
-                backgroundTask?.stop()
-                backgroundTask = nil
+            guard let self else {
+                return
+            }
+            userSession?.clientProxy.stopSync {
+                // No need to weakify self, this is a non escaping closure
+                self.backgroundTask?.stop()
+                self.backgroundTask = nil
             }
         }
 

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -541,18 +541,15 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
             return
         }
 
-        backgroundTask = backgroundTaskService.startBackgroundTask(withName: "SuspendApp: \(UUID().uuidString)") { [weak self] in
-            guard let self else { return }
-            
-            stopSync { [weak self] in
-                guard let self else { return }
-                backgroundTask?.stop()
-                backgroundTask = nil
-            }
+        backgroundTask = backgroundTaskService.startBackgroundTask(withName: "SuspendApp: \(UUID().uuidString)")
 
-            isSuspended = true
+        stopSync { [weak self] in
+            guard let self else { return }
+            backgroundTask?.stop()
+            backgroundTask = nil
         }
-        
+        isSuspended = true
+
         // This does seem to work if scheduled from the background task above
         // Schedule it here instead but with an earliest being date of 30 seconds
         scheduleBackgroundAppRefresh()

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -159,7 +159,7 @@ class ClientProxy: ClientProxyProtocol {
     
     func startSync() {
         MXLog.info("Starting sync")
-        guard slidingSyncObserverToken == nil else {
+        guard !isSyncing else {
             return
         }
         

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -170,10 +170,10 @@ class ClientProxy: ClientProxyProtocol {
 
         MXLog.info("Stopping sync")
         slidingSyncObserverToken.cancel()
+        self.slidingSyncObserverToken = nil
 
         Task {
             while !slidingSyncObserverToken.isFinished() { }
-            self.slidingSyncObserverToken = nil
             completionHandler?()
         }
     }

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -81,10 +81,16 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     var allRoomsSummaryProvider: RoomSummaryProviderProtocol? { get }
     
     var invitesSummaryProvider: RoomSummaryProviderProtocol? { get }
+
+    var isSyncing: Bool { get }
     
     func startSync()
-    
-    func stopSync(completionHandler: (() -> Void)?)
+
+    /// Stops the sync usiung non escaping closure.
+    /// It's supposed to be used for the expiration handlers to guarantee its synchronous execution
+    func stopSync(completionHandler: () -> Void)
+
+    func stopSync()
     
     func directRoomForUserID(_ userID: String) async -> Result<String?, ClientProxyError>
     

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -84,7 +84,7 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     
     func startSync()
     
-    func stopSync()
+    func stopSync(completionHandler: (() -> Void)?)
     
     func directRoomForUserID(_ userID: String) async -> Result<String?, ClientProxyError>
     

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -43,7 +43,7 @@ class MockClientProxy: ClientProxyProtocol {
     
     func startSync() { }
     
-    func stopSync() { }
+    func stopSync(completionHandler: (() -> Void)?) { }
     
     func directRoomForUserID(_ userID: String) async -> Result<String?, ClientProxyError> {
         .failure(.failedRetrievingDirectRoom)

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -33,6 +33,8 @@ class MockClientProxy: ClientProxyProtocol {
     var invitesSummaryProvider: RoomSummaryProviderProtocol? = MockRoomSummaryProvider()
 
     var avatarURLPublisher: AnyPublisher<URL?, Never> { Empty().eraseToAnyPublisher() }
+
+    var isSyncing: Bool { false }
     
     internal init(userID: String, roomSummaryProvider: RoomSummaryProviderProtocol? = MockRoomSummaryProvider()) {
         self.userID = userID
@@ -43,7 +45,9 @@ class MockClientProxy: ClientProxyProtocol {
     
     func startSync() { }
     
-    func stopSync(completionHandler: (() -> Void)?) { }
+    func stopSync(completionHandler: () -> Void) { }
+
+    func stopSync() { }
     
     func directRoomForUserID(_ userID: String) async -> Result<String?, ClientProxyError> {
         .failure(.failedRetrievingDirectRoom)

--- a/changelog.d/438.bugfix
+++ b/changelog.d/438.bugfix
@@ -1,0 +1,1 @@
+Stopping bg task when the app is suspended and the slidingSyncObserver is finished.


### PR DESCRIPTION
 From the video you can see that only the third time I background the app (where I waited about 30 seconds) when I foregrounded it, I got back the loading indicator showing the the sync has restarted.
 
 So we are extending the duration of the sync for 30 seconds after suspension, and then stopping it in the expiration handler
 
 We restart the sync only if the app is coming from a suspended state and the sync was stopped.

https://github.com/vector-im/element-x-ios/assets/34335419/1ec1f508-f4f2-43b7-95ac-5c736c4c643f


