### PR TITLE
Adopt latest rust side sliding sync fixes. 

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -4609,7 +4609,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "0.0.1-paginate-only-with-token";
+				version = "1.0.65-alpha";
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -102,8 +102,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "f7e5c77a9f443e93edb179d5cc1b0b1cb2f5e0b1",
-        "version" : "0.0.1-paginate-only-with-token"
+        "revision" : "937bd40d601b59d676c18e466fd111925e498799",
+        "version" : "1.0.65-alpha"
       }
     },
     {
@@ -172,7 +172,7 @@
     {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
         "revision" : "cef5b3f6f11781dd4591bdd1dd0a3d22bd609334",
         "version" : "1.11.0"

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -62,6 +62,7 @@ class ClientProxy: ClientProxyProtocol {
     
     private var slidingSyncObserverToken: TaskHandle?
     private var slidingSync: SlidingSyncProtocol?
+    private var slidingSyncTasks = [TaskHandle?]()
     
     var visibleRoomsListBuilder: SlidingSyncListBuilder?
     var visibleRoomsListProxy: SlidingSyncListProxy?
@@ -532,14 +533,14 @@ class ClientProxy: ClientProxyProtocol {
 
         if let allRoomsListBuilder {
             MXLog.info("Registering all rooms view")
-            _ = slidingSync?.addList(listBuilder: allRoomsListBuilder)
+            slidingSyncTasks.append(slidingSync?.addList(listBuilder: allRoomsListBuilder))
         } else {
             MXLog.error("All rooms sliding sync view unavailable")
         }
 
         if let invitesListBuilder {
             MXLog.info("Registering invites view")
-            _ = slidingSync?.addList(listBuilder: invitesListBuilder)
+            slidingSyncTasks.append(slidingSync?.addList(listBuilder: invitesListBuilder))
         } else {
             MXLog.error("Invites sliding sync view unavailable")
         }
@@ -547,7 +548,7 @@ class ClientProxy: ClientProxyProtocol {
         if ServiceLocator.shared.settings.enableLocalPushNotifications {
             if let notificationsListBuilder {
                 MXLog.info("Registering notifications view")
-                _ = slidingSync?.addList(listBuilder: notificationsListBuilder)
+                slidingSyncTasks.append(slidingSync?.addList(listBuilder: notificationsListBuilder))
             } else {
                 MXLog.error("Notifications sliding sync view unavailable")
             }

--- a/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
@@ -57,7 +57,7 @@ struct EventTimelineItemProxy {
         guard let localSendState = item.localSendState() else { return nil }
         
         switch localSendState {
-        case .notSendYet:
+        case .notSentYet:
             return .sending
         case .sendingFailed:
             return .sendingFailed

--- a/project.yml
+++ b/project.yml
@@ -42,7 +42,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 0.0.1-paginate-only-with-token
+    exactVersion: 1.0.65-alpha
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
Relates to https://github.com/matrix-org/matrix-rust-sdk/pull/1936

This fixes sliding sync not killing the long polling connection as soon as the parameters are changed e.g. adding lists or room subscriptions
