### PR TITLE
Fix search bar behavior

### DIFF
--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -32,6 +32,9 @@ struct InviteUsersScreen: View {
                 }
             }
             .searchable(text: $context.searchQuery, placement: .navigationBarDrawer(displayMode: .always), prompt: L10n.commonSearchForSomeone)
+            .introspectSearchController { searchViewController in
+                searchViewController.hidesNavigationBarDuringPresentation = false
+            }
             .compoundSearchField()
             .alert(item: $context.alertInfo) { $0.alert }
             .background(ViewFrameReader(frame: $frame))


### PR DESCRIPTION
This PR prevents the search bar to be hidden during the following search:
- Adding users during the creation of a group chat
- Invite more people in a room

**Result**

https://github.com/vector-im/element-x-ios/assets/19324622/e44e4d7d-ede3-46b3-bcc2-b538a2c86793
