### PR TITLE
Disable background app refreshes until we understand the deadlocks an…

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -565,9 +565,10 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
 
         isSuspended = true
 
+        #warning("Intentionally disabled until we understand certain deadlocks")
         // This does seem to work if scheduled from the background task above
         // Schedule it here instead but with an earliest being date of 30 seconds
-        scheduleBackgroundAppRefresh()
+        // scheduleBackgroundAppRefresh()
     }
 
     @objc


### PR DESCRIPTION
…d crashes we've been seeing

We're currently seeing crashes happening in the background. We believe they might be coming from sliding sync deadlocking but we don't know for sure if they're a background app refresh problem or something else.

We've decided to disable background app refresh entirely for now and check for further crashes that might give us more insight into the problem