### PR TITLE
Notification deep linking fix

### DIFF
--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -94,7 +94,7 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         
         switch appRoute {
         case .room, .roomDetails, .roomList:
-            roomFlowCoordinator.handleAppRoute(appRoute, animated: true)
+            roomFlowCoordinator.handleAppRoute(appRoute, animated: animated)
         }
     }
 

--- a/UnitTests/Sources/ExpiringTaskRunnerTests.swift
+++ b/UnitTests/Sources/ExpiringTaskRunnerTests.swift
@@ -42,7 +42,7 @@ class ExpiringTaskRunnerTests: XCTestCase {
         }
         
         do {
-            let result = try await runner.run(timeout: .seconds(1))
+            _ = try await runner.run(timeout: .seconds(1))
         } catch {
             XCTAssertEqual(error as? ExpiringTaskTestError, ExpiringTaskTestError.failed)
         }
@@ -55,7 +55,7 @@ class ExpiringTaskRunnerTests: XCTestCase {
         }
 
         do {
-            let result = try await runner.run(timeout: .milliseconds(100))
+            _ = try await runner.run(timeout: .milliseconds(100))
         } catch {
             XCTAssertEqual(error as? ExpiringTaskRunnerError, ExpiringTaskRunnerError.timeout)
         }


### PR DESCRIPTION
In order to deep link into rooms following push notifications we need to wait for the room list to load said rooms. 
Previously it used to work because the cold cache was enabled. The cold cache isn't guaranteed to contain all the rooms so it's not a good solution to begin with. 
This PR makes the client proxy first query the cold cache (if available) and, if the room is not found, wait for the all rooms list to load before trying again.