### PR TITLE
Generating SDK Mocks through the usage of `swift run tools generate-sdk-mocks`

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		0C47AE2CA7929CB3B0E2D793 /* ServerSelectionScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0685156EB62D7E243F097CFC /* ServerSelectionScreenViewModelProtocol.swift */; };
 		0C58A846F61949B1D545D661 /* NoticeRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 421E716C521F96D24ECE69B3 /* NoticeRoomTimelineItem.swift */; };
 		0DC815CA24E1BD7F408F37D3 /* CollapsibleTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C4EA55DA62F9D0F984A2AE /* CollapsibleTimelineItem.swift */; };
-		0E6B97E4F4DAC3E5B64B215F /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66653C5417592A727B549533 /* UserProfile.swift */; };
 		0E8C480700870BB34A2A360F /* DeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4003BC24B24C9E63D3304177 /* DeviceKit */; };
 		0EA6537A07E2DC882AEA5962 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 187853A7E643995EE49FAD43 /* Localizable.stringsdict */; };
 		0EE5EBA18BA1FE10254BB489 /* UIFont+AttributedStringBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = E8CA187FE656EE5A3F6C7DE5 /* UIFont+AttributedStringBuilder.m */; };
@@ -193,6 +192,7 @@
 		501304F26B52DF7024011B6C /* EmojiMartJSONLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF9E3E6A23180EC05F06460 /* EmojiMartJSONLoaderTests.swift */; };
 		50C90117FE25390BFBD40173 /* RustTracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542D4F49FABA056DEEEB3400 /* RustTracing.swift */; };
 		518C93DC6516D3D018DE065F /* UNNotificationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E751D7EDB6043238111D90 /* UNNotificationRequest.swift */; };
+		520EEDAFBC778AB0B41F2F53 /* ClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE6170EFE6A161B0A68AB61 /* ClientMock.swift */; };
 		5375902175B2FEA2949D7D74 /* LoginScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDDDDD9FE1A699D23A5E096 /* LoginScreen.swift */; };
 		53DEF39F0C4DE02E3FC56D91 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 800631D7250B7F93195035F1 /* KeychainAccess */; };
 		53F1196F9C69512306A2693F /* TextRoomTimelineItemContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C19F54A0C4FC9AB7ABD583 /* TextRoomTimelineItemContent.swift */; };
@@ -538,6 +538,7 @@
 		D33AC79A50DFC26D2498DD28 /* FileRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5098DA7799946A61E34A2373 /* FileRoomTimelineItem.swift */; };
 		D3FD96913D2B1AAA3149DAC7 /* CreateRoomViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D42EE0102D2857933625DD /* CreateRoomViewModelTests.swift */; };
 		D415764645491F10344FC6AC /* Publisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F18AECC9D38C2B6D85F99C /* Publisher.swift */; };
+		D43F0503EF2CBC55272538FE /* SDKGeneratedMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F079B5DBD0D85FEA687AAE /* SDKGeneratedMocks.swift */; };
 		D4ACF3276F5D0DA28D4028C9 /* AnalyticsPromptScreenViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8196D64EB9CF2AF1F43E4ED1 /* AnalyticsPromptScreenViewModelProtocol.swift */; };
 		D53B80EF02C1062E68659EDD /* ReportContentViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086C19086DD16E9B38E25954 /* ReportContentViewModelTests.swift */; };
 		D55AF9B5B55FEED04771A461 /* RoomFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A008E57D52B07B78DFAD1BB /* RoomFlowCoordinator.swift */; };
@@ -563,6 +564,7 @@
 		E14E469CD97550D0FC58F3CA /* CancellableTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE52983FAFB4E0998C00EE8A /* CancellableTask.swift */; };
 		E1DF24D085572A55C9758A2D /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E89E530A8E92EC44301CA1 /* Bundle.swift */; };
 		E1F446C6B78A3A0FEA15079C /* UnsupportedRoomTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC3C656E960E15B5905E05 /* UnsupportedRoomTimelineView.swift */; };
+		E21FE4C5B614F311C0955859 /* UserProfileProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C454AE59914B551A6D02C0 /* UserProfileProxy.swift */; };
 		E27C4D1A1F8BB77CA790B403 /* InviteUsersScreenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A861DA5932B128FE1DCB5CE2 /* InviteUsersScreenCoordinator.swift */; };
 		E290C78E7F09F47FD2662986 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40C19719687984FD9478FBE /* Task.swift */; };
 		E2DB696117BAEABAD5718023 /* MediaSourceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49B9785E3AD7D1C15A29F2F /* MediaSourceProxy.swift */; };
@@ -878,6 +880,7 @@
 		5098DA7799946A61E34A2373 /* FileRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileRoomTimelineItem.swift; sourceTree = "<group>"; };
 		50E31AB0E77BB70E2BC77463 /* MatrixUserShareLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixUserShareLink.swift; sourceTree = "<group>"; };
 		51C2BCE0BC1FC69C1B36E688 /* BugReportScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportScreenModels.swift; sourceTree = "<group>"; };
+		51C454AE59914B551A6D02C0 /* UserProfileProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileProxy.swift; sourceTree = "<group>"; };
 		5221DFDF809142A2D6AC82B9 /* RoomScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreen.swift; sourceTree = "<group>"; };
 		52BD6ED18E2EB61E28C340AD /* AttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedString.swift; sourceTree = "<group>"; };
 		52D7074991B3267B26D89B22 /* MockRoomTimelineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRoomTimelineController.swift; sourceTree = "<group>"; };
@@ -915,7 +918,7 @@
 		653610CB5F9776EAAAB98155 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fr; path = fr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		65AAD845E53B0C8B5E0812C2 /* UserDiscoveryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDiscoveryService.swift; sourceTree = "<group>"; };
 		65C2B80DD0BF6F10BB5FA922 /* MockAuthenticationServiceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthenticationServiceProxy.swift; sourceTree = "<group>"; };
-		66653C5417592A727B549533 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
+		6654859746B0BE9611459391 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = cs; path = cs.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		669F35C505ACE1110589F875 /* MediaUploadingPreprocessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUploadingPreprocessor.swift; sourceTree = "<group>"; };
 		66F2402D738694F98729A441 /* RoomTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineProvider.swift; sourceTree = "<group>"; };
 		6861FE915C7B5466E6962BBA /* StartChatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartChatScreen.swift; sourceTree = "<group>"; };
@@ -998,6 +1001,7 @@
 		8C8616254EE40CA8BA5E9BC2 /* VideoRoomTimelineItemContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRoomTimelineItemContent.swift; sourceTree = "<group>"; };
 		8D55702474F279D910D2D162 /* RoomStateEventStringBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStateEventStringBuilder.swift; sourceTree = "<group>"; };
 		8D6094DEAAEB388E1AE118C6 /* MockRoomTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRoomTimelineProvider.swift; sourceTree = "<group>"; };
+		8D8169443E5AC5FF71BFB3DB /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8DC2C9E0E15C79BBDA80F0A2 /* TimelineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStyle.swift; sourceTree = "<group>"; };
 		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; path = UITests.xctestplan; sourceTree = "<group>"; };
 		8E1BBA73B611EDEEA6E20E05 /* InvitesScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitesScreenModels.swift; sourceTree = "<group>"; };
@@ -1076,6 +1080,7 @@
 		ACB6C5E4950B6C9842F35A38 /* RoomTimelineViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineViewProvider.swift; sourceTree = "<group>"; };
 		ADB35E2DB4EFE8E6F3959629 /* InviteUsersScreenUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteUsersScreenUITests.swift; sourceTree = "<group>"; };
 		ADD9E0FFA29EAACFF3AB9732 /* SessionVerificationScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationScreenViewModel.swift; sourceTree = "<group>"; };
+		ADE6170EFE6A161B0A68AB61 /* ClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientMock.swift; sourceTree = "<group>"; };
 		AE203026B9AD3DB412439866 /* MediaUploadingPreprocessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUploadingPreprocessorTests.swift; sourceTree = "<group>"; };
 		AE52983FAFB4E0998C00EE8A /* CancellableTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancellableTask.swift; sourceTree = "<group>"; };
 		AE5DDBEBBA17973ED4638823 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = de.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -1126,6 +1131,7 @@
 		C1198B925F4A88DA74083662 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		C2886615BEBAE33A0AA4D5F8 /* RoomScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreenModels.swift; sourceTree = "<group>"; };
 		C2E9B841EE4878283ECDB554 /* InviteUsersScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteUsersScreen.swift; sourceTree = "<group>"; };
+		C2F079B5DBD0D85FEA687AAE /* SDKGeneratedMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKGeneratedMocks.swift; sourceTree = "<group>"; };
 		C352359663A0E52BA20761EE /* LoadableImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableImage.swift; sourceTree = "<group>"; };
 		C38AE3617D7619EF30CDD229 /* EmojiMartStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiMartStore.swift; sourceTree = "<group>"; };
 		C4C89820BB2B88D4EA28131C /* BugReportScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -1611,6 +1617,7 @@
 				248649EBA5BC33DB93698734 /* SessionVerificationControllerProxyMock.swift */,
 				AAD01F7FC2BBAC7351948595 /* UserProfile+Mock.swift */,
 				B23135B06B044CB811139D2F /* Generated */,
+				E5E545F92D01588360A9BAC5 /* SDK */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2715,6 +2722,7 @@
 			isa = PBXGroup;
 			children = (
 				57916A1578D8043BB0795441 /* GeneratedMocks.swift */,
+				C2F079B5DBD0D85FEA687AAE /* SDKGeneratedMocks.swift */,
 			);
 			path = Generated;
 			sourceTree = "<group>";
@@ -2959,7 +2967,7 @@
 				D071F86CD47582B9196C9D16 /* UserDiscoverySection.swift */,
 				65AAD845E53B0C8B5E0812C2 /* UserDiscoveryService.swift */,
 				7F615A00DB223FF3280204D2 /* UserDiscoveryServiceProtocol.swift */,
-				66653C5417592A727B549533 /* UserProfile.swift */,
+				51C454AE59914B551A6D02C0 /* UserProfileProxy.swift */,
 			);
 			path = Users;
 			sourceTree = "<group>";
@@ -2993,6 +3001,14 @@
 				EC4545C7E37E8294D3FE6800 /* StartChatScreen */,
 			);
 			path = Screens;
+			sourceTree = "<group>";
+		};
+		E5E545F92D01588360A9BAC5 /* SDK */ = {
+			isa = PBXGroup;
+			children = (
+				ADE6170EFE6A161B0A68AB61 /* ClientMock.swift */,
+			);
+			path = SDK;
 			sourceTree = "<group>";
 		};
 		E600AACDF87CDBCE32683236 /* Resources */ = {
@@ -3334,6 +3350,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				Base,
+				cs,
 				de,
 				en,
 				es,
@@ -3718,6 +3735,7 @@
 				BB6BF528BC7F5B87E08C4F18 /* CameraPicker.swift in Sources */,
 				E14E469CD97550D0FC58F3CA /* CancellableTask.swift in Sources */,
 				6A0E7551E0D1793245F34CDD /* ClientError.swift in Sources */,
+				520EEDAFBC778AB0B41F2F53 /* ClientMock.swift in Sources */,
 				1950A80CD198BED283DFC2CE /* ClientProxy.swift in Sources */,
 				24BDDD09A90B8BFE3793F3AA /* ClientProxyProtocol.swift in Sources */,
 				9FAF6DA7E8E85C9699757764 /* CollapsibleRoomTimelineView.swift in Sources */,
@@ -3956,6 +3974,7 @@
 				CF82143AA4A4F7BD11D22946 /* RoomTimelineViewProvider.swift in Sources */,
 				B2F8E01ABA1BA30265B4ECBE /* RoundedCornerShape.swift in Sources */,
 				50C90117FE25390BFBD40173 /* RustTracing.swift in Sources */,
+				D43F0503EF2CBC55272538FE /* SDKGeneratedMocks.swift in Sources */,
 				0437765FF480249486893CC7 /* ScreenTrackerViewModifier.swift in Sources */,
 				0BFA67AFD757EE2BA569836A /* ScrollViewAdapter.swift in Sources */,
 				14E99D27628B1A6F0CB46FEA /* SeparatorRoomTimelineItem.swift in Sources */,
@@ -4063,8 +4082,8 @@
 				E3291AD16D7A5CB14781819C /* UserNotificationCenterProtocol.swift in Sources */,
 				40B79D20A873620F7F128A2C /* UserPreference.swift in Sources */,
 				80DEA2A4B20F9E279EAE6B2B /* UserProfile+Mock.swift in Sources */,
-				0E6B97E4F4DAC3E5B64B215F /* UserProfile.swift in Sources */,
 				F94000E3D91B11C527DA8807 /* UserProfileCell.swift in Sources */,
+				E21FE4C5B614F311C0955859 /* UserProfileProxy.swift in Sources */,
 				9CCC77C31CB399661A034739 /* UserProperties+Element.swift in Sources */,
 				8AB8ED1051216546CB35FA0E /* UserSession.swift in Sources */,
 				4A618590DEB72C4F186BFED4 /* UserSessionFlowCoordinator.swift in Sources */,
@@ -4160,6 +4179,7 @@
 		187853A7E643995EE49FAD43 /* Localizable.stringsdict */ = {
 			isa = PBXVariantGroup;
 			children = (
+				6654859746B0BE9611459391 /* cs */,
 				AE5DDBEBBA17973ED4638823 /* de */,
 				13802897C7AFA360EA74C0B0 /* en */,
 				AACE9B8E1A4AE79A7E2914F6 /* es */,
@@ -4173,6 +4193,7 @@
 		7109E709A7738E6BCC4553E6 /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
+				8D8169443E5AC5FF71BFB3DB /* cs */,
 				35AFCF4C05DEED04E3DB1A16 /* de */,
 				CACA846B3E3E9A521D98B178 /* en */,
 				CBBCC6E74774E79B599625D0 /* es */,

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -172,7 +172,7 @@
     {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
         "revision" : "cef5b3f6f11781dd4591bdd1dd0a3d22bd609334",
         "version" : "1.11.0"

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -1094,10 +1094,10 @@ class UserDiscoveryServiceMock: UserDiscoveryServiceProtocol {
     }
     var searchProfilesWithReceivedSearchQuery: String?
     var searchProfilesWithReceivedInvocations: [String] = []
-    var searchProfilesWithReturnValue: Result<[UserProfile], UserDiscoveryErrorType>!
-    var searchProfilesWithClosure: ((String) async -> Result<[UserProfile], UserDiscoveryErrorType>)?
+    var searchProfilesWithReturnValue: Result<[UserProfileProxy], UserDiscoveryErrorType>!
+    var searchProfilesWithClosure: ((String) async -> Result<[UserProfileProxy], UserDiscoveryErrorType>)?
 
-    func searchProfiles(with searchQuery: String) async -> Result<[UserProfile], UserDiscoveryErrorType> {
+    func searchProfiles(with searchQuery: String) async -> Result<[UserProfileProxy], UserDiscoveryErrorType> {
         searchProfilesWithCallsCount += 1
         searchProfilesWithReceivedSearchQuery = searchQuery
         searchProfilesWithReceivedInvocations.append(searchQuery)
@@ -1113,10 +1113,10 @@ class UserDiscoveryServiceMock: UserDiscoveryServiceProtocol {
     var fetchSuggestionsCalled: Bool {
         return fetchSuggestionsCallsCount > 0
     }
-    var fetchSuggestionsReturnValue: Result<[UserProfile], UserDiscoveryErrorType>!
-    var fetchSuggestionsClosure: (() async -> Result<[UserProfile], UserDiscoveryErrorType>)?
+    var fetchSuggestionsReturnValue: Result<[UserProfileProxy], UserDiscoveryErrorType>!
+    var fetchSuggestionsClosure: (() async -> Result<[UserProfileProxy], UserDiscoveryErrorType>)?
 
-    func fetchSuggestions() async -> Result<[UserProfile], UserDiscoveryErrorType> {
+    func fetchSuggestions() async -> Result<[UserProfileProxy], UserDiscoveryErrorType> {
         fetchSuggestionsCallsCount += 1
         if let fetchSuggestionsClosure = fetchSuggestionsClosure {
             return await fetchSuggestionsClosure()

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -1,0 +1,646 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// swiftlint:disable all
+import Foundation
+import MatrixRustSDK
+class SDKClientMock: SDKClientProtocol {
+
+    //MARK: - `accountData`
+
+    public var accountDataEventTypeThrowableError: Error?
+    public var accountDataEventTypeCallsCount = 0
+    public var accountDataEventTypeCalled: Bool {
+        return accountDataEventTypeCallsCount > 0
+    }
+    public var accountDataEventTypeReceivedEventType: String?
+    public var accountDataEventTypeReceivedInvocations: [String] = []
+    public var accountDataEventTypeReturnValue: String?
+    public var accountDataEventTypeClosure: ((String) throws -> String?)?
+
+    public func `accountData`(`eventType`: String) throws -> String? {
+        if let error = accountDataEventTypeThrowableError {
+            throw error
+        }
+        accountDataEventTypeCallsCount += 1
+        accountDataEventTypeReceivedEventType = eventType
+        accountDataEventTypeReceivedInvocations.append(`eventType`)
+        if let accountDataEventTypeClosure = accountDataEventTypeClosure {
+            return try accountDataEventTypeClosure(`eventType`)
+        } else {
+            return accountDataEventTypeReturnValue
+        }
+    }
+    //MARK: - `avatarUrl`
+
+    public var avatarUrlThrowableError: Error?
+    public var avatarUrlCallsCount = 0
+    public var avatarUrlCalled: Bool {
+        return avatarUrlCallsCount > 0
+    }
+    public var avatarUrlReturnValue: String?
+    public var avatarUrlClosure: (() throws -> String?)?
+
+    public func `avatarUrl`() throws -> String? {
+        if let error = avatarUrlThrowableError {
+            throw error
+        }
+        avatarUrlCallsCount += 1
+        if let avatarUrlClosure = avatarUrlClosure {
+            return try avatarUrlClosure()
+        } else {
+            return avatarUrlReturnValue
+        }
+    }
+    //MARK: - `cachedAvatarUrl`
+
+    public var cachedAvatarUrlThrowableError: Error?
+    public var cachedAvatarUrlCallsCount = 0
+    public var cachedAvatarUrlCalled: Bool {
+        return cachedAvatarUrlCallsCount > 0
+    }
+    public var cachedAvatarUrlReturnValue: String?
+    public var cachedAvatarUrlClosure: (() throws -> String?)?
+
+    public func `cachedAvatarUrl`() throws -> String? {
+        if let error = cachedAvatarUrlThrowableError {
+            throw error
+        }
+        cachedAvatarUrlCallsCount += 1
+        if let cachedAvatarUrlClosure = cachedAvatarUrlClosure {
+            return try cachedAvatarUrlClosure()
+        } else {
+            return cachedAvatarUrlReturnValue
+        }
+    }
+    //MARK: - `createRoom`
+
+    public var createRoomRequestThrowableError: Error?
+    public var createRoomRequestCallsCount = 0
+    public var createRoomRequestCalled: Bool {
+        return createRoomRequestCallsCount > 0
+    }
+    public var createRoomRequestReceivedRequest: CreateRoomParameters?
+    public var createRoomRequestReceivedInvocations: [CreateRoomParameters] = []
+    public var createRoomRequestReturnValue: String!
+    public var createRoomRequestClosure: ((CreateRoomParameters) throws -> String)?
+
+    public func `createRoom`(`request`: CreateRoomParameters) throws -> String {
+        if let error = createRoomRequestThrowableError {
+            throw error
+        }
+        createRoomRequestCallsCount += 1
+        createRoomRequestReceivedRequest = request
+        createRoomRequestReceivedInvocations.append(`request`)
+        if let createRoomRequestClosure = createRoomRequestClosure {
+            return try createRoomRequestClosure(`request`)
+        } else {
+            return createRoomRequestReturnValue
+        }
+    }
+    //MARK: - `deviceId`
+
+    public var deviceIdThrowableError: Error?
+    public var deviceIdCallsCount = 0
+    public var deviceIdCalled: Bool {
+        return deviceIdCallsCount > 0
+    }
+    public var deviceIdReturnValue: String!
+    public var deviceIdClosure: (() throws -> String)?
+
+    public func `deviceId`() throws -> String {
+        if let error = deviceIdThrowableError {
+            throw error
+        }
+        deviceIdCallsCount += 1
+        if let deviceIdClosure = deviceIdClosure {
+            return try deviceIdClosure()
+        } else {
+            return deviceIdReturnValue
+        }
+    }
+    //MARK: - `displayName`
+
+    public var displayNameThrowableError: Error?
+    public var displayNameCallsCount = 0
+    public var displayNameCalled: Bool {
+        return displayNameCallsCount > 0
+    }
+    public var displayNameReturnValue: String!
+    public var displayNameClosure: (() throws -> String)?
+
+    public func `displayName`() throws -> String {
+        if let error = displayNameThrowableError {
+            throw error
+        }
+        displayNameCallsCount += 1
+        if let displayNameClosure = displayNameClosure {
+            return try displayNameClosure()
+        } else {
+            return displayNameReturnValue
+        }
+    }
+    //MARK: - `getDmRoom`
+
+    public var getDmRoomUserIdThrowableError: Error?
+    public var getDmRoomUserIdCallsCount = 0
+    public var getDmRoomUserIdCalled: Bool {
+        return getDmRoomUserIdCallsCount > 0
+    }
+    public var getDmRoomUserIdReceivedUserId: String?
+    public var getDmRoomUserIdReceivedInvocations: [String] = []
+    public var getDmRoomUserIdReturnValue: Room?
+    public var getDmRoomUserIdClosure: ((String) throws -> Room?)?
+
+    public func `getDmRoom`(`userId`: String) throws -> Room? {
+        if let error = getDmRoomUserIdThrowableError {
+            throw error
+        }
+        getDmRoomUserIdCallsCount += 1
+        getDmRoomUserIdReceivedUserId = userId
+        getDmRoomUserIdReceivedInvocations.append(`userId`)
+        if let getDmRoomUserIdClosure = getDmRoomUserIdClosure {
+            return try getDmRoomUserIdClosure(`userId`)
+        } else {
+            return getDmRoomUserIdReturnValue
+        }
+    }
+    //MARK: - `getMediaContent`
+
+    public var getMediaContentMediaSourceThrowableError: Error?
+    public var getMediaContentMediaSourceCallsCount = 0
+    public var getMediaContentMediaSourceCalled: Bool {
+        return getMediaContentMediaSourceCallsCount > 0
+    }
+    public var getMediaContentMediaSourceReceivedMediaSource: MediaSource?
+    public var getMediaContentMediaSourceReceivedInvocations: [MediaSource] = []
+    public var getMediaContentMediaSourceReturnValue: [UInt8]!
+    public var getMediaContentMediaSourceClosure: ((MediaSource) throws -> [UInt8])?
+
+    public func `getMediaContent`(`mediaSource`: MediaSource) throws -> [UInt8] {
+        if let error = getMediaContentMediaSourceThrowableError {
+            throw error
+        }
+        getMediaContentMediaSourceCallsCount += 1
+        getMediaContentMediaSourceReceivedMediaSource = mediaSource
+        getMediaContentMediaSourceReceivedInvocations.append(`mediaSource`)
+        if let getMediaContentMediaSourceClosure = getMediaContentMediaSourceClosure {
+            return try getMediaContentMediaSourceClosure(`mediaSource`)
+        } else {
+            return getMediaContentMediaSourceReturnValue
+        }
+    }
+    //MARK: - `getMediaFile`
+
+    public var getMediaFileMediaSourceBodyMimeTypeThrowableError: Error?
+    public var getMediaFileMediaSourceBodyMimeTypeCallsCount = 0
+    public var getMediaFileMediaSourceBodyMimeTypeCalled: Bool {
+        return getMediaFileMediaSourceBodyMimeTypeCallsCount > 0
+    }
+    public var getMediaFileMediaSourceBodyMimeTypeReceivedArguments: (`mediaSource`: MediaSource, `body`: String?, `mimeType`: String)?
+    public var getMediaFileMediaSourceBodyMimeTypeReceivedInvocations: [(`mediaSource`: MediaSource, `body`: String?, `mimeType`: String)] = []
+    public var getMediaFileMediaSourceBodyMimeTypeReturnValue: MediaFileHandle!
+    public var getMediaFileMediaSourceBodyMimeTypeClosure: ((MediaSource, String?, String) throws -> MediaFileHandle)?
+
+    public func `getMediaFile`(`mediaSource`: MediaSource, `body`: String?, `mimeType`: String) throws -> MediaFileHandle {
+        if let error = getMediaFileMediaSourceBodyMimeTypeThrowableError {
+            throw error
+        }
+        getMediaFileMediaSourceBodyMimeTypeCallsCount += 1
+        getMediaFileMediaSourceBodyMimeTypeReceivedArguments = (`mediaSource`: `mediaSource`, `body`: `body`, `mimeType`: `mimeType`)
+        getMediaFileMediaSourceBodyMimeTypeReceivedInvocations.append((`mediaSource`: `mediaSource`, `body`: `body`, `mimeType`: `mimeType`))
+        if let getMediaFileMediaSourceBodyMimeTypeClosure = getMediaFileMediaSourceBodyMimeTypeClosure {
+            return try getMediaFileMediaSourceBodyMimeTypeClosure(`mediaSource`, `body`, `mimeType`)
+        } else {
+            return getMediaFileMediaSourceBodyMimeTypeReturnValue
+        }
+    }
+    //MARK: - `getMediaThumbnail`
+
+    public var getMediaThumbnailMediaSourceWidthHeightThrowableError: Error?
+    public var getMediaThumbnailMediaSourceWidthHeightCallsCount = 0
+    public var getMediaThumbnailMediaSourceWidthHeightCalled: Bool {
+        return getMediaThumbnailMediaSourceWidthHeightCallsCount > 0
+    }
+    public var getMediaThumbnailMediaSourceWidthHeightReceivedArguments: (`mediaSource`: MediaSource, `width`: UInt64, `height`: UInt64)?
+    public var getMediaThumbnailMediaSourceWidthHeightReceivedInvocations: [(`mediaSource`: MediaSource, `width`: UInt64, `height`: UInt64)] = []
+    public var getMediaThumbnailMediaSourceWidthHeightReturnValue: [UInt8]!
+    public var getMediaThumbnailMediaSourceWidthHeightClosure: ((MediaSource, UInt64, UInt64) throws -> [UInt8])?
+
+    public func `getMediaThumbnail`(`mediaSource`: MediaSource, `width`: UInt64, `height`: UInt64) throws -> [UInt8] {
+        if let error = getMediaThumbnailMediaSourceWidthHeightThrowableError {
+            throw error
+        }
+        getMediaThumbnailMediaSourceWidthHeightCallsCount += 1
+        getMediaThumbnailMediaSourceWidthHeightReceivedArguments = (`mediaSource`: `mediaSource`, `width`: `width`, `height`: `height`)
+        getMediaThumbnailMediaSourceWidthHeightReceivedInvocations.append((`mediaSource`: `mediaSource`, `width`: `width`, `height`: `height`))
+        if let getMediaThumbnailMediaSourceWidthHeightClosure = getMediaThumbnailMediaSourceWidthHeightClosure {
+            return try getMediaThumbnailMediaSourceWidthHeightClosure(`mediaSource`, `width`, `height`)
+        } else {
+            return getMediaThumbnailMediaSourceWidthHeightReturnValue
+        }
+    }
+    //MARK: - `getNotificationItem`
+
+    public var getNotificationItemRoomIdEventIdThrowableError: Error?
+    public var getNotificationItemRoomIdEventIdCallsCount = 0
+    public var getNotificationItemRoomIdEventIdCalled: Bool {
+        return getNotificationItemRoomIdEventIdCallsCount > 0
+    }
+    public var getNotificationItemRoomIdEventIdReceivedArguments: (`roomId`: String, `eventId`: String)?
+    public var getNotificationItemRoomIdEventIdReceivedInvocations: [(`roomId`: String, `eventId`: String)] = []
+    public var getNotificationItemRoomIdEventIdReturnValue: NotificationItem!
+    public var getNotificationItemRoomIdEventIdClosure: ((String, String) throws -> NotificationItem)?
+
+    public func `getNotificationItem`(`roomId`: String, `eventId`: String) throws -> NotificationItem {
+        if let error = getNotificationItemRoomIdEventIdThrowableError {
+            throw error
+        }
+        getNotificationItemRoomIdEventIdCallsCount += 1
+        getNotificationItemRoomIdEventIdReceivedArguments = (`roomId`: `roomId`, `eventId`: `eventId`)
+        getNotificationItemRoomIdEventIdReceivedInvocations.append((`roomId`: `roomId`, `eventId`: `eventId`))
+        if let getNotificationItemRoomIdEventIdClosure = getNotificationItemRoomIdEventIdClosure {
+            return try getNotificationItemRoomIdEventIdClosure(`roomId`, `eventId`)
+        } else {
+            return getNotificationItemRoomIdEventIdReturnValue
+        }
+    }
+    //MARK: - `getProfile`
+
+    public var getProfileUserIdThrowableError: Error?
+    public var getProfileUserIdCallsCount = 0
+    public var getProfileUserIdCalled: Bool {
+        return getProfileUserIdCallsCount > 0
+    }
+    public var getProfileUserIdReceivedUserId: String?
+    public var getProfileUserIdReceivedInvocations: [String] = []
+    public var getProfileUserIdReturnValue: UserProfile!
+    public var getProfileUserIdClosure: ((String) throws -> UserProfile)?
+
+    public func `getProfile`(`userId`: String) throws -> UserProfile {
+        if let error = getProfileUserIdThrowableError {
+            throw error
+        }
+        getProfileUserIdCallsCount += 1
+        getProfileUserIdReceivedUserId = userId
+        getProfileUserIdReceivedInvocations.append(`userId`)
+        if let getProfileUserIdClosure = getProfileUserIdClosure {
+            return try getProfileUserIdClosure(`userId`)
+        } else {
+            return getProfileUserIdReturnValue
+        }
+    }
+    //MARK: - `getSessionVerificationController`
+
+    public var getSessionVerificationControllerThrowableError: Error?
+    public var getSessionVerificationControllerCallsCount = 0
+    public var getSessionVerificationControllerCalled: Bool {
+        return getSessionVerificationControllerCallsCount > 0
+    }
+    public var getSessionVerificationControllerReturnValue: SessionVerificationController!
+    public var getSessionVerificationControllerClosure: (() throws -> SessionVerificationController)?
+
+    public func `getSessionVerificationController`() throws -> SessionVerificationController {
+        if let error = getSessionVerificationControllerThrowableError {
+            throw error
+        }
+        getSessionVerificationControllerCallsCount += 1
+        if let getSessionVerificationControllerClosure = getSessionVerificationControllerClosure {
+            return try getSessionVerificationControllerClosure()
+        } else {
+            return getSessionVerificationControllerReturnValue
+        }
+    }
+    //MARK: - `homeserver`
+
+    public var homeserverCallsCount = 0
+    public var homeserverCalled: Bool {
+        return homeserverCallsCount > 0
+    }
+    public var homeserverReturnValue: String!
+    public var homeserverClosure: (() -> String)?
+
+    public func `homeserver`() -> String {
+        homeserverCallsCount += 1
+        if let homeserverClosure = homeserverClosure {
+            return homeserverClosure()
+        } else {
+            return homeserverReturnValue
+        }
+    }
+    //MARK: - `ignoreUser`
+
+    public var ignoreUserUserIdThrowableError: Error?
+    public var ignoreUserUserIdCallsCount = 0
+    public var ignoreUserUserIdCalled: Bool {
+        return ignoreUserUserIdCallsCount > 0
+    }
+    public var ignoreUserUserIdReceivedUserId: String?
+    public var ignoreUserUserIdReceivedInvocations: [String] = []
+    public var ignoreUserUserIdClosure: ((String) throws -> Void)?
+
+    public func `ignoreUser`(`userId`: String) throws {
+        if let error = ignoreUserUserIdThrowableError {
+            throw error
+        }
+        ignoreUserUserIdCallsCount += 1
+        ignoreUserUserIdReceivedUserId = userId
+        ignoreUserUserIdReceivedInvocations.append(`userId`)
+        try ignoreUserUserIdClosure?(`userId`)
+    }
+    //MARK: - `login`
+
+    public var loginUsernamePasswordInitialDeviceNameDeviceIdThrowableError: Error?
+    public var loginUsernamePasswordInitialDeviceNameDeviceIdCallsCount = 0
+    public var loginUsernamePasswordInitialDeviceNameDeviceIdCalled: Bool {
+        return loginUsernamePasswordInitialDeviceNameDeviceIdCallsCount > 0
+    }
+    public var loginUsernamePasswordInitialDeviceNameDeviceIdReceivedArguments: (`username`: String, `password`: String, `initialDeviceName`: String?, `deviceId`: String?)?
+    public var loginUsernamePasswordInitialDeviceNameDeviceIdReceivedInvocations: [(`username`: String, `password`: String, `initialDeviceName`: String?, `deviceId`: String?)] = []
+    public var loginUsernamePasswordInitialDeviceNameDeviceIdClosure: ((String, String, String?, String?) throws -> Void)?
+
+    public func `login`(`username`: String, `password`: String, `initialDeviceName`: String?, `deviceId`: String?) throws {
+        if let error = loginUsernamePasswordInitialDeviceNameDeviceIdThrowableError {
+            throw error
+        }
+        loginUsernamePasswordInitialDeviceNameDeviceIdCallsCount += 1
+        loginUsernamePasswordInitialDeviceNameDeviceIdReceivedArguments = (`username`: `username`, `password`: `password`, `initialDeviceName`: `initialDeviceName`, `deviceId`: `deviceId`)
+        loginUsernamePasswordInitialDeviceNameDeviceIdReceivedInvocations.append((`username`: `username`, `password`: `password`, `initialDeviceName`: `initialDeviceName`, `deviceId`: `deviceId`))
+        try loginUsernamePasswordInitialDeviceNameDeviceIdClosure?(`username`, `password`, `initialDeviceName`, `deviceId`)
+    }
+    //MARK: - `logout`
+
+    public var logoutThrowableError: Error?
+    public var logoutCallsCount = 0
+    public var logoutCalled: Bool {
+        return logoutCallsCount > 0
+    }
+    public var logoutClosure: (() throws -> Void)?
+
+    public func `logout`() throws {
+        if let error = logoutThrowableError {
+            throw error
+        }
+        logoutCallsCount += 1
+        try logoutClosure?()
+    }
+    //MARK: - `restoreSession`
+
+    public var restoreSessionSessionThrowableError: Error?
+    public var restoreSessionSessionCallsCount = 0
+    public var restoreSessionSessionCalled: Bool {
+        return restoreSessionSessionCallsCount > 0
+    }
+    public var restoreSessionSessionReceivedSession: Session?
+    public var restoreSessionSessionReceivedInvocations: [Session] = []
+    public var restoreSessionSessionClosure: ((Session) throws -> Void)?
+
+    public func `restoreSession`(`session`: Session) throws {
+        if let error = restoreSessionSessionThrowableError {
+            throw error
+        }
+        restoreSessionSessionCallsCount += 1
+        restoreSessionSessionReceivedSession = session
+        restoreSessionSessionReceivedInvocations.append(`session`)
+        try restoreSessionSessionClosure?(`session`)
+    }
+    //MARK: - `rooms`
+
+    public var roomsCallsCount = 0
+    public var roomsCalled: Bool {
+        return roomsCallsCount > 0
+    }
+    public var roomsReturnValue: [Room]!
+    public var roomsClosure: (() -> [Room])?
+
+    public func `rooms`() -> [Room] {
+        roomsCallsCount += 1
+        if let roomsClosure = roomsClosure {
+            return roomsClosure()
+        } else {
+            return roomsReturnValue
+        }
+    }
+    //MARK: - `searchUsers`
+
+    public var searchUsersSearchTermLimitThrowableError: Error?
+    public var searchUsersSearchTermLimitCallsCount = 0
+    public var searchUsersSearchTermLimitCalled: Bool {
+        return searchUsersSearchTermLimitCallsCount > 0
+    }
+    public var searchUsersSearchTermLimitReceivedArguments: (`searchTerm`: String, `limit`: UInt64)?
+    public var searchUsersSearchTermLimitReceivedInvocations: [(`searchTerm`: String, `limit`: UInt64)] = []
+    public var searchUsersSearchTermLimitReturnValue: SearchUsersResults!
+    public var searchUsersSearchTermLimitClosure: ((String, UInt64) throws -> SearchUsersResults)?
+
+    public func `searchUsers`(`searchTerm`: String, `limit`: UInt64) throws -> SearchUsersResults {
+        if let error = searchUsersSearchTermLimitThrowableError {
+            throw error
+        }
+        searchUsersSearchTermLimitCallsCount += 1
+        searchUsersSearchTermLimitReceivedArguments = (`searchTerm`: `searchTerm`, `limit`: `limit`)
+        searchUsersSearchTermLimitReceivedInvocations.append((`searchTerm`: `searchTerm`, `limit`: `limit`))
+        if let searchUsersSearchTermLimitClosure = searchUsersSearchTermLimitClosure {
+            return try searchUsersSearchTermLimitClosure(`searchTerm`, `limit`)
+        } else {
+            return searchUsersSearchTermLimitReturnValue
+        }
+    }
+    //MARK: - `session`
+
+    public var sessionThrowableError: Error?
+    public var sessionCallsCount = 0
+    public var sessionCalled: Bool {
+        return sessionCallsCount > 0
+    }
+    public var sessionReturnValue: Session!
+    public var sessionClosure: (() throws -> Session)?
+
+    public func `session`() throws -> Session {
+        if let error = sessionThrowableError {
+            throw error
+        }
+        sessionCallsCount += 1
+        if let sessionClosure = sessionClosure {
+            return try sessionClosure()
+        } else {
+            return sessionReturnValue
+        }
+    }
+    //MARK: - `setAccountData`
+
+    public var setAccountDataEventTypeContentThrowableError: Error?
+    public var setAccountDataEventTypeContentCallsCount = 0
+    public var setAccountDataEventTypeContentCalled: Bool {
+        return setAccountDataEventTypeContentCallsCount > 0
+    }
+    public var setAccountDataEventTypeContentReceivedArguments: (`eventType`: String, `content`: String)?
+    public var setAccountDataEventTypeContentReceivedInvocations: [(`eventType`: String, `content`: String)] = []
+    public var setAccountDataEventTypeContentClosure: ((String, String) throws -> Void)?
+
+    public func `setAccountData`(`eventType`: String, `content`: String) throws {
+        if let error = setAccountDataEventTypeContentThrowableError {
+            throw error
+        }
+        setAccountDataEventTypeContentCallsCount += 1
+        setAccountDataEventTypeContentReceivedArguments = (`eventType`: `eventType`, `content`: `content`)
+        setAccountDataEventTypeContentReceivedInvocations.append((`eventType`: `eventType`, `content`: `content`))
+        try setAccountDataEventTypeContentClosure?(`eventType`, `content`)
+    }
+    //MARK: - `setDelegate`
+
+    public var setDelegateDelegateCallsCount = 0
+    public var setDelegateDelegateCalled: Bool {
+        return setDelegateDelegateCallsCount > 0
+    }
+    public var setDelegateDelegateReceivedDelegate: ClientDelegate?
+    public var setDelegateDelegateReceivedInvocations: [ClientDelegate?] = []
+    public var setDelegateDelegateClosure: ((ClientDelegate?) -> Void)?
+
+    public func `setDelegate`(`delegate`: ClientDelegate?) {
+        setDelegateDelegateCallsCount += 1
+        setDelegateDelegateReceivedDelegate = delegate
+        setDelegateDelegateReceivedInvocations.append(`delegate`)
+        setDelegateDelegateClosure?(`delegate`)
+    }
+    //MARK: - `setDisplayName`
+
+    public var setDisplayNameNameThrowableError: Error?
+    public var setDisplayNameNameCallsCount = 0
+    public var setDisplayNameNameCalled: Bool {
+        return setDisplayNameNameCallsCount > 0
+    }
+    public var setDisplayNameNameReceivedName: String?
+    public var setDisplayNameNameReceivedInvocations: [String] = []
+    public var setDisplayNameNameClosure: ((String) throws -> Void)?
+
+    public func `setDisplayName`(`name`: String) throws {
+        if let error = setDisplayNameNameThrowableError {
+            throw error
+        }
+        setDisplayNameNameCallsCount += 1
+        setDisplayNameNameReceivedName = name
+        setDisplayNameNameReceivedInvocations.append(`name`)
+        try setDisplayNameNameClosure?(`name`)
+    }
+    //MARK: - `setNotificationDelegate`
+
+    public var setNotificationDelegateNotificationDelegateCallsCount = 0
+    public var setNotificationDelegateNotificationDelegateCalled: Bool {
+        return setNotificationDelegateNotificationDelegateCallsCount > 0
+    }
+    public var setNotificationDelegateNotificationDelegateReceivedNotificationDelegate: NotificationDelegate?
+    public var setNotificationDelegateNotificationDelegateReceivedInvocations: [NotificationDelegate?] = []
+    public var setNotificationDelegateNotificationDelegateClosure: ((NotificationDelegate?) -> Void)?
+
+    public func `setNotificationDelegate`(`notificationDelegate`: NotificationDelegate?) {
+        setNotificationDelegateNotificationDelegateCallsCount += 1
+        setNotificationDelegateNotificationDelegateReceivedNotificationDelegate = notificationDelegate
+        setNotificationDelegateNotificationDelegateReceivedInvocations.append(`notificationDelegate`)
+        setNotificationDelegateNotificationDelegateClosure?(`notificationDelegate`)
+    }
+    //MARK: - `setPusher`
+
+    public var setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangThrowableError: Error?
+    public var setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangCallsCount = 0
+    public var setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangCalled: Bool {
+        return setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangCallsCount > 0
+    }
+    public var setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangReceivedArguments: (`identifiers`: PusherIdentifiers, `kind`: PusherKind, `appDisplayName`: String, `deviceDisplayName`: String, `profileTag`: String?, `lang`: String)?
+    public var setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangReceivedInvocations: [(`identifiers`: PusherIdentifiers, `kind`: PusherKind, `appDisplayName`: String, `deviceDisplayName`: String, `profileTag`: String?, `lang`: String)] = []
+    public var setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangClosure: ((PusherIdentifiers, PusherKind, String, String, String?, String) throws -> Void)?
+
+    public func `setPusher`(`identifiers`: PusherIdentifiers, `kind`: PusherKind, `appDisplayName`: String, `deviceDisplayName`: String, `profileTag`: String?, `lang`: String) throws {
+        if let error = setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangThrowableError {
+            throw error
+        }
+        setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangCallsCount += 1
+        setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangReceivedArguments = (`identifiers`: `identifiers`, `kind`: `kind`, `appDisplayName`: `appDisplayName`, `deviceDisplayName`: `deviceDisplayName`, `profileTag`: `profileTag`, `lang`: `lang`)
+        setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangReceivedInvocations.append((`identifiers`: `identifiers`, `kind`: `kind`, `appDisplayName`: `appDisplayName`, `deviceDisplayName`: `deviceDisplayName`, `profileTag`: `profileTag`, `lang`: `lang`))
+        try setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangClosure?(`identifiers`, `kind`, `appDisplayName`, `deviceDisplayName`, `profileTag`, `lang`)
+    }
+    //MARK: - `unignoreUser`
+
+    public var unignoreUserUserIdThrowableError: Error?
+    public var unignoreUserUserIdCallsCount = 0
+    public var unignoreUserUserIdCalled: Bool {
+        return unignoreUserUserIdCallsCount > 0
+    }
+    public var unignoreUserUserIdReceivedUserId: String?
+    public var unignoreUserUserIdReceivedInvocations: [String] = []
+    public var unignoreUserUserIdClosure: ((String) throws -> Void)?
+
+    public func `unignoreUser`(`userId`: String) throws {
+        if let error = unignoreUserUserIdThrowableError {
+            throw error
+        }
+        unignoreUserUserIdCallsCount += 1
+        unignoreUserUserIdReceivedUserId = userId
+        unignoreUserUserIdReceivedInvocations.append(`userId`)
+        try unignoreUserUserIdClosure?(`userId`)
+    }
+    //MARK: - `uploadMedia`
+
+    public var uploadMediaMimeTypeDataThrowableError: Error?
+    public var uploadMediaMimeTypeDataCallsCount = 0
+    public var uploadMediaMimeTypeDataCalled: Bool {
+        return uploadMediaMimeTypeDataCallsCount > 0
+    }
+    public var uploadMediaMimeTypeDataReceivedArguments: (`mimeType`: String, `data`: [UInt8])?
+    public var uploadMediaMimeTypeDataReceivedInvocations: [(`mimeType`: String, `data`: [UInt8])] = []
+    public var uploadMediaMimeTypeDataReturnValue: String!
+    public var uploadMediaMimeTypeDataClosure: ((String, [UInt8]) throws -> String)?
+
+    public func `uploadMedia`(`mimeType`: String, `data`: [UInt8]) throws -> String {
+        if let error = uploadMediaMimeTypeDataThrowableError {
+            throw error
+        }
+        uploadMediaMimeTypeDataCallsCount += 1
+        uploadMediaMimeTypeDataReceivedArguments = (`mimeType`: `mimeType`, `data`: `data`)
+        uploadMediaMimeTypeDataReceivedInvocations.append((`mimeType`: `mimeType`, `data`: `data`))
+        if let uploadMediaMimeTypeDataClosure = uploadMediaMimeTypeDataClosure {
+            return try uploadMediaMimeTypeDataClosure(`mimeType`, `data`)
+        } else {
+            return uploadMediaMimeTypeDataReturnValue
+        }
+    }
+    //MARK: - `userId`
+
+    public var userIdThrowableError: Error?
+    public var userIdCallsCount = 0
+    public var userIdCalled: Bool {
+        return userIdCallsCount > 0
+    }
+    public var userIdReturnValue: String!
+    public var userIdClosure: (() throws -> String)?
+
+    public func `userId`() throws -> String {
+        if let error = userIdThrowableError {
+            throw error
+        }
+        userIdCallsCount += 1
+        if let userIdClosure = userIdClosure {
+            return try userIdClosure()
+        } else {
+            return userIdReturnValue
+        }
+    }
+    //MARK: - `slidingSync`
+
+    public var slidingSyncCallsCount = 0
+    public var slidingSyncCalled: Bool {
+        return slidingSyncCallsCount > 0
+    }
+    public var slidingSyncReturnValue: SlidingSyncBuilder!
+    public var slidingSyncClosure: (() -> SlidingSyncBuilder)?
+
+    public func `slidingSync`() -> SlidingSyncBuilder {
+        slidingSyncCallsCount += 1
+        if let slidingSyncClosure = slidingSyncClosure {
+            return slidingSyncClosure()
+        } else {
+            return slidingSyncReturnValue
+        }
+    }
+}
+// swiftlint:enable all

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -559,6 +559,23 @@ class SDKClientMock: SDKClientProtocol {
         setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangReceivedInvocations.append((`identifiers`: `identifiers`, `kind`: `kind`, `appDisplayName`: `appDisplayName`, `deviceDisplayName`: `deviceDisplayName`, `profileTag`: `profileTag`, `lang`: `lang`))
         try setPusherIdentifiersKindAppDisplayNameDeviceDisplayNameProfileTagLangClosure?(`identifiers`, `kind`, `appDisplayName`, `deviceDisplayName`, `profileTag`, `lang`)
     }
+    //MARK: - `slidingSync`
+
+    public var slidingSyncCallsCount = 0
+    public var slidingSyncCalled: Bool {
+        return slidingSyncCallsCount > 0
+    }
+    public var slidingSyncReturnValue: SlidingSyncBuilder!
+    public var slidingSyncClosure: (() -> SlidingSyncBuilder)?
+
+    public func `slidingSync`() -> SlidingSyncBuilder {
+        slidingSyncCallsCount += 1
+        if let slidingSyncClosure = slidingSyncClosure {
+            return slidingSyncClosure()
+        } else {
+            return slidingSyncReturnValue
+        }
+    }
     //MARK: - `unignoreUser`
 
     public var unignoreUserUserIdThrowableError: Error?
@@ -623,23 +640,6 @@ class SDKClientMock: SDKClientProtocol {
             return try userIdClosure()
         } else {
             return userIdReturnValue
-        }
-    }
-    //MARK: - `slidingSync`
-
-    public var slidingSyncCallsCount = 0
-    public var slidingSyncCalled: Bool {
-        return slidingSyncCallsCount > 0
-    }
-    public var slidingSyncReturnValue: SlidingSyncBuilder!
-    public var slidingSyncClosure: (() -> SlidingSyncBuilder)?
-
-    public func `slidingSync`() -> SlidingSyncBuilder {
-        slidingSyncCallsCount += 1
-        if let slidingSyncClosure = slidingSyncClosure {
-            return slidingSyncClosure()
-        } else {
-            return slidingSyncReturnValue
         }
     }
 }

--- a/ElementX/Sources/Mocks/SDK/ClientMock.swift
+++ b/ElementX/Sources/Mocks/SDK/ClientMock.swift
@@ -15,14 +15,7 @@
 //
 
 import Foundation
-
-enum UserDiscoveryErrorType: Error {
-    case failedSearchingUsers
-    case failedFetchingSuggestedUsers
-}
+import MatrixRustSDK
 
 // sourcery: AutoMockable
-protocol UserDiscoveryServiceProtocol {
-    func searchProfiles(with searchQuery: String) async -> Result<[UserProfileProxy], UserDiscoveryErrorType>
-    func fetchSuggestions() async -> Result<[UserProfileProxy], UserDiscoveryErrorType>
-}
+protocol SDKClientProtocol: ClientProtocol { }

--- a/ElementX/Sources/Mocks/UserProfile+Mock.swift
+++ b/ElementX/Sources/Mocks/UserProfile+Mock.swift
@@ -16,21 +16,21 @@
 
 import Foundation
 
-extension UserProfile {
+extension UserProfileProxy {
     // Mocks
-    static var mockAlice: UserProfile {
+    static var mockAlice: UserProfileProxy {
         .init(userID: "@alice:matrix.org", displayName: "Alice", avatarURL: URL(staticString: "mxc://matrix.org/UcCimidcvpFvWkPzvjXMQPHA"))
     }
 
-    static var mockBob: UserProfile {
+    static var mockBob: UserProfileProxy {
         .init(userID: "@bob:matrix.org", displayName: "Bob", avatarURL: nil)
     }
 
-    static var mockBobby: UserProfile {
+    static var mockBobby: UserProfileProxy {
         .init(userID: "@bobby:matrix.org", displayName: "Bobby", avatarURL: nil)
     }
 
-    static var mockCharlie: UserProfile {
+    static var mockCharlie: UserProfileProxy {
         .init(userID: "@charlie:matrix.org", displayName: "Charlie", avatarURL: nil)
     }
 }

--- a/ElementX/Sources/Other/SwiftUI/Views/UserProfileCell.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/UserProfileCell.swift
@@ -18,7 +18,7 @@ import MatrixRustSDK
 import SwiftUI
 
 struct UserProfileCell: View {
-    let user: UserProfile
+    let user: UserProfileProxy
     let membership: MembershipState?
     let imageProvider: ImageProviderProtocol?
     

--- a/ElementX/Sources/Screens/CreateRoom/CreateRoomCoordinator.swift
+++ b/ElementX/Sources/Screens/CreateRoom/CreateRoomCoordinator.swift
@@ -21,12 +21,12 @@ struct CreateRoomCoordinatorParameters {
     let userSession: UserSessionProtocol
     weak var userIndicatorController: UserIndicatorControllerProtocol?
     let createRoomParameters: CurrentValuePublisher<CreateRoomFlowParameters, Never>
-    let selectedUsers: CurrentValuePublisher<[UserProfile], Never>
+    let selectedUsers: CurrentValuePublisher<[UserProfileProxy], Never>
 }
 
 enum CreateRoomCoordinatorAction {
     case openRoom(withIdentifier: String)
-    case deselectUser(UserProfile)
+    case deselectUser(UserProfileProxy)
     case updateDetails(CreateRoomFlowParameters)
 }
 

--- a/ElementX/Sources/Screens/CreateRoom/CreateRoomModels.swift
+++ b/ElementX/Sources/Screens/CreateRoom/CreateRoomModels.swift
@@ -23,12 +23,12 @@ enum CreateRoomScreenErrorType: Error {
 
 enum CreateRoomViewModelAction {
     case openRoom(withIdentifier: String)
-    case deselectUser(UserProfile)
+    case deselectUser(UserProfileProxy)
     case updateDetails(CreateRoomFlowParameters)
 }
 
 struct CreateRoomViewState: BindableState {
-    var selectedUsers: [UserProfile]
+    var selectedUsers: [UserProfileProxy]
     var bindings: CreateRoomViewStateBindings
     
     var canCreateRoom: Bool {
@@ -47,5 +47,5 @@ struct CreateRoomViewStateBindings {
 
 enum CreateRoomViewAction {
     case createRoom
-    case deselectUser(UserProfile)
+    case deselectUser(UserProfileProxy)
 }

--- a/ElementX/Sources/Screens/CreateRoom/CreateRoomViewModel.swift
+++ b/ElementX/Sources/Screens/CreateRoom/CreateRoomViewModel.swift
@@ -32,7 +32,7 @@ class CreateRoomViewModel: CreateRoomViewModelType, CreateRoomViewModelProtocol 
     init(userSession: UserSessionProtocol,
          userIndicatorController: UserIndicatorControllerProtocol?,
          createRoomParameters: CurrentValuePublisher<CreateRoomFlowParameters, Never>,
-         selectedUsers: CurrentValuePublisher<[UserProfile], Never>) {
+         selectedUsers: CurrentValuePublisher<[UserProfileProxy], Never>) {
         let parameters = createRoomParameters.value
         self.userSession = userSession
         self.userIndicatorController = userIndicatorController

--- a/ElementX/Sources/Screens/CreateRoom/View/CreateRoomScreen.swift
+++ b/ElementX/Sources/Screens/CreateRoom/View/CreateRoomScreen.swift
@@ -164,7 +164,7 @@ struct CreateRoom_Previews: PreviewProvider {
         let userSession = MockUserSession(clientProxy: MockClientProxy(userID: "@userid:example.com"),
                                           mediaProvider: MockMediaProvider())
         let parameters = CreateRoomFlowParameters()
-        let selectedUsers: [UserProfile] = [.mockAlice, .mockBob, .mockCharlie]
+        let selectedUsers: [UserProfileProxy] = [.mockAlice, .mockBob, .mockCharlie]
         
         return CreateRoomViewModel(userSession: userSession, userIndicatorController: nil, createRoomParameters: .init(parameters), selectedUsers: .init(selectedUsers))
     }()

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenCoordinator.swift
@@ -18,7 +18,7 @@ import Combine
 import SwiftUI
 
 struct InviteUsersScreenCoordinatorParameters {
-    let selectedUsers: CurrentValuePublisher<[UserProfile], Never>
+    let selectedUsers: CurrentValuePublisher<[UserProfileProxy], Never>
     let roomType: InviteUsersScreenRoomType
     let mediaProvider: MediaProviderProtocol
     let userDiscoveryService: UserDiscoveryServiceProtocol
@@ -27,7 +27,7 @@ struct InviteUsersScreenCoordinatorParameters {
 enum InviteUsersScreenCoordinatorAction {
     case proceed
     case invite(users: [String])
-    case toggleUser(UserProfile)
+    case toggleUser(UserProfileProxy)
 }
 
 final class InviteUsersScreenCoordinator: CoordinatorProtocol {

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenModels.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenModels.swift
@@ -24,7 +24,7 @@ enum InviteUsersScreenErrorType: Error {
 enum InviteUsersScreenViewModelAction {
     case proceed
     case invite(users: [String])
-    case toggleUser(UserProfile)
+    case toggleUser(UserProfileProxy)
 }
 
 enum InviteUsersScreenRoomType {
@@ -37,7 +37,7 @@ struct InviteUsersScreenViewState: BindableState {
     
     var usersSection: UserDiscoverySection = .init(type: .suggestions, users: [])
     
-    var selectedUsers: [UserProfile] = []
+    var selectedUsers: [UserProfileProxy] = []
     var membershipState: [String: MembershipState] = .init()
     
     var isSearching: Bool {
@@ -50,16 +50,16 @@ struct InviteUsersScreenViewState: BindableState {
     
     var scrollToLastID: String?
     
-    func isUserSelected(_ user: UserProfile) -> Bool {
+    func isUserSelected(_ user: UserProfileProxy) -> Bool {
         isUserDisabled(user) || selectedUsers.contains { $0.userID == user.userID }
     }
     
-    func isUserDisabled(_ user: UserProfile) -> Bool {
+    func isUserDisabled(_ user: UserProfileProxy) -> Bool {
         let membershipState = membershipState(user)
         return membershipState == .invite || membershipState == .join
     }
     
-    func membershipState(_ user: UserProfile) -> MembershipState? {
+    func membershipState(_ user: UserProfileProxy) -> MembershipState? {
         membershipState[user.userID]
     }
     
@@ -87,5 +87,5 @@ struct InviteUsersScreenViewStateBindings {
 
 enum InviteUsersScreenViewAction {
     case proceed
-    case toggleUser(UserProfile)
+    case toggleUser(UserProfileProxy)
 }

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
@@ -30,7 +30,7 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
         actionsSubject.eraseToAnyPublisher()
     }
     
-    init(selectedUsers: CurrentValuePublisher<[UserProfile], Never>,
+    init(selectedUsers: CurrentValuePublisher<[UserProfileProxy], Never>,
          roomType: InviteUsersScreenRoomType,
          mediaProvider: MediaProviderProtocol,
          userDiscoveryService: UserDiscoveryServiceProtocol) {
@@ -85,7 +85,7 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
     @CancellableTask
     private var fetchUsersTask: Task<Void, Never>?
     
-    private func setupSubscriptions(selectedUsers: CurrentValuePublisher<[UserProfile], Never>) {
+    private func setupSubscriptions(selectedUsers: CurrentValuePublisher<[UserProfileProxy], Never>) {
         context.$viewState
             .map(\.bindings.searchQuery)
             .debounceAndRemoveDuplicates()
@@ -125,7 +125,7 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
         }
     }
     
-    private func handleResult(for sectionType: UserDiscoverySectionType, result: Result<[UserProfile], UserDiscoveryErrorType>) {
+    private func handleResult(for sectionType: UserDiscoverySectionType, result: Result<[UserProfileProxy], UserDiscoveryErrorType>) {
         switch result {
         case .success(let users):
             state.usersSection = .init(type: sectionType, users: users)

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -123,7 +123,7 @@ struct InviteUsersScreen: View {
         .disabled(context.viewState.isActionDisabled)
     }
     
-    private func deselect(_ user: UserProfile) {
+    private func deselect(_ user: UserProfileProxy) {
         context.send(viewAction: .toggleUser(user))
     }
 }

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreenSelectedItem.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreenSelectedItem.swift
@@ -17,7 +17,7 @@
 import SwiftUI
 
 struct InviteUsersScreenSelectedItem: View {
-    let user: UserProfile
+    let user: UserProfileProxy
     let imageProvider: ImageProviderProtocol?
     let dismissAction: () -> Void
     

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenCoordinator.swift
@@ -33,7 +33,7 @@ final class RoomDetailsScreenCoordinator: CoordinatorProtocol {
     private let parameters: RoomDetailsScreenCoordinatorParameters
     private var viewModel: RoomDetailsScreenViewModelProtocol
     private var cancellables: Set<AnyCancellable> = .init()
-    private let selectedUsers: CurrentValueSubject<[UserProfile], Never> = .init([])
+    private let selectedUsers: CurrentValueSubject<[UserProfileProxy], Never> = .init([])
     private var navigationStackCoordinator: NavigationStackCoordinator {
         parameters.navigationStackCoordinator
     }
@@ -142,7 +142,7 @@ final class RoomDetailsScreenCoordinator: CoordinatorProtocol {
         parameters.navigationStackCoordinator.setSheetCoordinator(userIndicatorController)
     }
     
-    private func toggleUser(_ user: UserProfile) {
+    private func toggleUser(_ user: UserProfileProxy) {
         var selectedUsers = selectedUsers.value
         if let index = selectedUsers.firstIndex(where: { $0.userID == user.userID }) {
             selectedUsers.remove(at: index)

--- a/ElementX/Sources/Screens/StartChatScreen/StartChatScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/StartChatScreen/StartChatScreenCoordinator.swift
@@ -40,8 +40,8 @@ final class StartChatScreenCoordinator: CoordinatorProtocol {
         createRoomParameters.asCurrentValuePublisher()
     }
     
-    private let selectedUsers = CurrentValueSubject<[UserProfile], Never>([])
-    private var selectedUsersPublisher: CurrentValuePublisher<[UserProfile], Never> {
+    private let selectedUsers = CurrentValueSubject<[UserProfileProxy], Never>([])
+    private var selectedUsersPublisher: CurrentValuePublisher<[UserProfileProxy], Never> {
         selectedUsers.asCurrentValuePublisher()
     }
     
@@ -128,7 +128,7 @@ final class StartChatScreenCoordinator: CoordinatorProtocol {
     
     // MARK: - Private
     
-    private func toggleUser(_ user: UserProfile) {
+    private func toggleUser(_ user: UserProfileProxy) {
         var selectedUsers = selectedUsers.value
         if let index = selectedUsers.firstIndex(where: { $0.userID == user.userID }) {
             selectedUsers.remove(at: index)

--- a/ElementX/Sources/Screens/StartChatScreen/StartChatScreenModels.swift
+++ b/ElementX/Sources/Screens/StartChatScreen/StartChatScreenModels.swift
@@ -51,5 +51,5 @@ struct StartChatScreenViewStateBindings {
 enum StartChatScreenViewAction {
     case close
     case createRoom
-    case selectUser(UserProfile)
+    case selectUser(UserProfileProxy)
 }

--- a/ElementX/Sources/Screens/StartChatScreen/StartChatScreenViewModel.swift
+++ b/ElementX/Sources/Screens/StartChatScreen/StartChatScreenViewModel.swift
@@ -117,7 +117,7 @@ class StartChatScreenViewModel: StartChatScreenViewModelType, StartChatScreenVie
         }
     }
     
-    private func handleResult(for sectionType: UserDiscoverySectionType, result: Result<[UserProfile], UserDiscoveryErrorType>) {
+    private func handleResult(for sectionType: UserDiscoverySectionType, result: Result<[UserProfileProxy], UserDiscoveryErrorType>) {
         switch result {
         case .success(let users):
             state.usersSection = .init(type: sectionType, users: users)
@@ -126,7 +126,7 @@ class StartChatScreenViewModel: StartChatScreenViewModelType, StartChatScreenVie
         }
     }
     
-    private func createDirectRoom(with user: UserProfile) async {
+    private func createDirectRoom(with user: UserProfileProxy) async {
         defer {
             hideLoadingIndicator()
         }

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -351,7 +351,7 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
     
-    func searchUsers(searchTerm: String, limit: UInt) async -> Result<SearchUsersResults, ClientProxyError> {
+    func searchUsers(searchTerm: String, limit: UInt) async -> Result<SearchUsersResultsProxy, ClientProxyError> {
         await Task.dispatch(on: clientQueue) {
             do {
                 return try .success(.init(sdkResults: self.client.searchUsers(searchTerm: searchTerm, limit: UInt64(limit))))
@@ -361,7 +361,7 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
     
-    func profile(for userID: String) async -> Result<UserProfile, ClientProxyError> {
+    func profile(for userID: String) async -> Result<UserProfileProxy, ClientProxyError> {
         await Task.dispatch(on: clientQueue) {
             do {
                 return try .success(.init(sdkUserProfile: self.client.getProfile(userId: userID)))

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -110,7 +110,7 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
 
     func setPusher(with configuration: PusherConfiguration) async throws
     
-    func searchUsers(searchTerm: String, limit: UInt) async -> Result<SearchUsersResults, ClientProxyError>
+    func searchUsers(searchTerm: String, limit: UInt) async -> Result<SearchUsersResultsProxy, ClientProxyError>
     
-    func profile(for userID: String) async -> Result<UserProfile, ClientProxyError>
+    func profile(for userID: String) async -> Result<UserProfileProxy, ClientProxyError>
 }

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -127,14 +127,14 @@ class MockClientProxy: ClientProxyProtocol {
         setPusherArgument = configuration
     }
     
-    var searchUsersResult: Result<SearchUsersResults, ClientProxyError> = .success(.init(results: [], limited: false))
-    func searchUsers(searchTerm: String, limit: UInt) async -> Result<SearchUsersResults, ClientProxyError> {
+    var searchUsersResult: Result<SearchUsersResultsProxy, ClientProxyError> = .success(.init(results: [], limited: false))
+    func searchUsers(searchTerm: String, limit: UInt) async -> Result<SearchUsersResultsProxy, ClientProxyError> {
         searchUsersResult
     }
     
-    var getProfileResult: Result<UserProfile, ClientProxyError> = .success(.init(userID: "@a:b.com", displayName: "Some user"))
+    var getProfileResult: Result<UserProfileProxy, ClientProxyError> = .success(.init(userID: "@a:b.com", displayName: "Some user"))
     private(set) var getProfileCalled = false
-    func profile(for userID: String) async -> Result<UserProfile, ClientProxyError> {
+    func profile(for userID: String) async -> Result<UserProfileProxy, ClientProxyError> {
         getProfileCalled = true
         return getProfileResult
     }

--- a/ElementX/Sources/Services/Timeline/MockRoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/MockRoomTimelineProvider.swift
@@ -15,6 +15,7 @@
 //
 
 import Combine
+import MatrixRustSDK
 
 struct MockRoomTimelineProvider: RoomTimelineProviderProtocol {
     var itemsPublisher = CurrentValuePublisher<[TimelineItemProxy], Never>([])

--- a/ElementX/Sources/Services/Users/UserDiscoverySection.swift
+++ b/ElementX/Sources/Services/Users/UserDiscoverySection.swift
@@ -18,7 +18,7 @@ import Foundation
 
 struct UserDiscoverySection {
     let type: UserDiscoverySectionType
-    let users: [UserProfile]
+    let users: [UserProfileProxy]
     
     var title: String? {
         switch type {

--- a/ElementX/Sources/Services/Users/UserDiscoveryService.swift
+++ b/ElementX/Sources/Services/Users/UserDiscoveryService.swift
@@ -23,11 +23,11 @@ final class UserDiscoveryService: UserDiscoveryServiceProtocol {
         self.clientProxy = clientProxy
     }
     
-    func fetchSuggestions() async -> Result<[UserProfile], UserDiscoveryErrorType> {
+    func fetchSuggestions() async -> Result<[UserProfileProxy], UserDiscoveryErrorType> {
         .success([.mockAlice, .mockBob, .mockCharlie])
     }
     
-    func searchProfiles(with searchQuery: String) async -> Result<[UserProfile], UserDiscoveryErrorType> {
+    func searchProfiles(with searchQuery: String) async -> Result<[UserProfileProxy], UserDiscoveryErrorType> {
         do {
             async let queriedProfile = try? profileIfPossible(with: searchQuery).get()
             async let searchedUsers = clientProxy.searchUsers(searchTerm: searchQuery, limit: 5)
@@ -38,8 +38,8 @@ final class UserDiscoveryService: UserDiscoveryServiceProtocol {
         }
     }
     
-    private func merge(searchQuery: String, queriedProfile: UserProfile?, searchResults: SearchUsersResults) -> [UserProfile] {
-        let localProfile = queriedProfile ?? UserProfile(searchQuery: searchQuery)
+    private func merge(searchQuery: String, queriedProfile: UserProfileProxy?, searchResults: SearchUsersResultsProxy) -> [UserProfileProxy] {
+        let localProfile = queriedProfile ?? UserProfileProxy(searchQuery: searchQuery)
         let searchResults = searchResults.results
         guard let localProfile else {
             return searchResults
@@ -52,7 +52,7 @@ final class UserDiscoveryService: UserDiscoveryServiceProtocol {
         return [localProfile] + filteredSearchResult
     }
     
-    private func profileIfPossible(with searchQuery: String) async -> Result<UserProfile, ClientProxyError> {
+    private func profileIfPossible(with searchQuery: String) async -> Result<UserProfileProxy, ClientProxyError> {
         guard searchQuery.isMatrixIdentifier else {
             return .failure(.failedGettingUserProfile)
         }
@@ -67,7 +67,7 @@ private extension String {
     }
 }
 
-private extension UserProfile {
+private extension UserProfileProxy {
     init?(searchQuery: String) {
         guard searchQuery.isMatrixIdentifier else {
             return nil

--- a/ElementX/Sources/Services/Users/UserProfileProxy.swift
+++ b/ElementX/Sources/Services/Users/UserProfileProxy.swift
@@ -17,7 +17,7 @@
 import Foundation
 import MatrixRustSDK
 
-struct UserProfile {
+struct UserProfileProxy {
     let userID: String
     let displayName: String?
     let avatarURL: URL?
@@ -41,14 +41,14 @@ struct UserProfile {
     }
 }
 
-struct SearchUsersResults {
-    let results: [UserProfile]
+struct SearchUsersResultsProxy {
+    let results: [UserProfileProxy]
     let limited: Bool
 }
 
-extension SearchUsersResults {
+extension SearchUsersResultsProxy {
     init(sdkResults: MatrixRustSDK.SearchUsersResults) {
-        results = sdkResults.results.map(UserProfile.init)
+        results = sdkResults.results.map(UserProfileProxy.init)
         limited = sdkResults.limited
     }
 }

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -464,7 +464,7 @@ class MockScreen: Identifiable {
             userDiscoveryMock.fetchSuggestionsReturnValue = .success([.mockAlice, .mockBob, .mockCharlie])
             userDiscoveryMock.searchProfilesWithReturnValue = .success([])
             let mediaProvider = MockMediaProvider()
-            let usersSubject = CurrentValueSubject<[UserProfile], Never>([])
+            let usersSubject = CurrentValueSubject<[UserProfileProxy], Never>([])
             let members: [RoomMemberProxyMock] = id == .inviteUsersInRoomExistingMembers ? [.mockInvitedAlice, .mockBob] : []
             let roomType: InviteUsersScreenRoomType = id == .inviteUsers ? .draft : .room(members: members, userIndicatorController: MockUserIndicatorController())
             let coordinator = InviteUsersScreenCoordinator(parameters: .init(selectedUsers: usersSubject.asCurrentValuePublisher(), roomType: roomType, mediaProvider: mediaProvider, userDiscoveryService: userDiscoveryMock))
@@ -490,7 +490,7 @@ class MockScreen: Identifiable {
             let clientProxy = MockClientProxy(userID: "@mock:client.com")
             let mockUserSession = MockUserSession(clientProxy: clientProxy, mediaProvider: MockMediaProvider())
             let createRoomParameters = CreateRoomFlowParameters()
-            let selectedUsers: [UserProfile] = [.mockAlice, .mockBob, .mockCharlie]
+            let selectedUsers: [UserProfileProxy] = [.mockAlice, .mockBob, .mockCharlie]
             let parameters = CreateRoomCoordinatorParameters(userSession: mockUserSession, userIndicatorController: nil, createRoomParameters: .init(createRoomParameters), selectedUsers: .init(selectedUsers))
             let coordinator = CreateRoomCoordinator(parameters: parameters)
             navigationStackCoordinator.setRootCoordinator(coordinator)

--- a/Tools/Sourcery/AutoMockable.stencil
+++ b/Tools/Sourcery/AutoMockable.stencil
@@ -23,7 +23,7 @@ import {{ import }}
         {% endfor -%}
     {% endset %}
     {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
-        {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = {{ param.name }}{% endfor %}
+        {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name |  replace:"`","" | upperFirstLetter  }} = {{ param.name | replace:"`","" }}{% endfor %}
         {% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append({% for param in method.parameters %}{{ param.name }}){% endfor %}
     {% else %}
     {% if not method.parameters.count == 0 and not hasNonEscapingClosures %}
@@ -56,7 +56,7 @@ import {{ import }}
         {% endfor -%}
     {% endset %}
     {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}?{% endfor %}
+    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name| replace:"`","" | upperFirstLetter }}: {{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}?{% endfor %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
     {% elif not method.parameters.count == 0 and not hasNonEscapingClosures %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})?

--- a/Tools/Sourcery/sourcery_automockable_config.yml
+++ b/Tools/Sourcery/sourcery_automockable_config.yml
@@ -1,5 +1,8 @@
 sources:
-  - ../../ElementX
+  include:
+    - ../../ElementX
+  exclude:
+    - ../../ElementX/Sources/Mocks/SDK
 templates:
   - AutoMockable.stencil
 output:

--- a/Tools/Sources/BuildSDK.swift
+++ b/Tools/Sources/BuildSDK.swift
@@ -26,10 +26,7 @@ struct BuildSDK: ParsableCommand {
     
     @Option(help: "The profile to use when building the SDK. Omit this option to build in debug mode.")
     var profile: Profile = .debug
-    
-    private var parentDirectoryURL: URL { Utilities.projectDirectoryURL.deletingLastPathComponent() }
-    private var sdkDirectoryURL: URL { parentDirectoryURL.appendingPathComponent("matrix-rust-sdk") }
-    
+
     enum Error: LocalizedError {
         case rustupOutputFailure
         case missingRustTargets([String])
@@ -81,14 +78,14 @@ struct BuildSDK: ParsableCommand {
     
     /// Clones the Rust SDK if a copy isn't found in the parent directory.
     func cloneSDKIfNeeded() throws {
-        guard !FileManager.default.fileExists(atPath: sdkDirectoryURL.path) else { return }
-        try Utilities.zsh("git clone https://github.com/matrix-org/matrix-rust-sdk", workingDirectoryURL: parentDirectoryURL)
+        guard !FileManager.default.fileExists(atPath: Utilities.sdkDirectoryURL.path) else { return }
+        try Utilities.zsh("git clone https://github.com/matrix-org/matrix-rust-sdk", workingDirectoryURL: Utilities.parentDirectoryURL)
     }
     
     /// Checkout the specified branch of the SDK if supplied.
     func checkoutBranchIfSupplied() throws {
         guard let branch else { return }
-        try Utilities.zsh("git checkout \(branch)", workingDirectoryURL: sdkDirectoryURL)
+        try Utilities.zsh("git checkout \(branch)", workingDirectoryURL: Utilities.sdkDirectoryURL)
     }
     
     /// Build the Rust SDK as an XCFramework with the debug profile.
@@ -98,7 +95,7 @@ struct BuildSDK: ParsableCommand {
         if let target {
             buildCommand.append(" --only-target \(target.rawValue)")
         }
-        try Utilities.zsh(buildCommand, workingDirectoryURL: sdkDirectoryURL)
+        try Utilities.zsh(buildCommand, workingDirectoryURL: Utilities.sdkDirectoryURL)
     }
     
     /// Update the Xcode project to use the build of the SDK.

--- a/Tools/Sources/GenerateSDKMocks.swift
+++ b/Tools/Sources/GenerateSDKMocks.swift
@@ -1,0 +1,61 @@
+import ArgumentParser
+import Foundation
+
+struct GenerateSDKMocks: ParsableCommand {
+    enum GenerateSDKMocksError: Error {
+        case invalidFileUrl
+    }
+
+    static var configuration = CommandConfiguration(abstract: "A tool to setup the mocks for the Matrix Rust SDK")
+
+    @Argument(help: "The argument to specify a branch of the SDK. Use `local` to use your local version")
+    var version: String
+
+    private var fileURLFormat = "https://raw.githubusercontent.com/matrix-org/matrix-rust-components-swift/%@/Sources/MatrixRustSDK/matrix_sdk_ffi.swift"
+
+    func run() throws {
+        if version == "local" {
+            try generateSDKMocks(ffiPath: "\(Utilities.sdkDirectoryURL.path)/bindings/apple/generated/swift")
+        } else {
+            try downloadSDK(version: version) { path in
+                try generateSDKMocks(ffiPath: path)
+                try FileManager.default.removeItem(atPath: path)
+            }
+        }
+    }
+
+    /// Generates the SDK mocks using Sourcery.
+    func generateSDKMocks(ffiPath: String) throws {
+        try Utilities.zsh("sourcery --sources \(ffiPath) --sources ElementX/Sources/Mocks/SDK --templates Tools/Sourcery --output ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift --args autoMockableImports=\"Foundation\",autoMockableImports=\"MatrixRustSDK\"")
+    }
+
+    /// Downloads the specified version of the `matrix_sdk_ffi.swift` file and returns the path to the downloaded file.
+    func downloadSDK(version: String, completionHandler: @escaping (String) throws -> Void) throws {
+        var sdkFilePath = ""
+        let fileURLString = String(format: fileURLFormat, version)
+        guard let fileURL = URL(string: fileURLString) else {
+            throw GenerateSDKMocksError.invalidFileUrl
+        }
+
+        let task = URLSession.shared.downloadTask(with: fileURL) { tempURL, _, error in
+            guard let tempURL = tempURL else {
+                if let error = error {
+                    print("Error downloading SDK file: \(error)")
+                } else {
+                    print("Unknown error occurred while downloading SDK file.")
+                }
+                return
+            }
+
+            do {
+                sdkFilePath = NSTemporaryDirectory().appending("matrix_sdk_ffi.swift")
+                try FileManager.default.moveItem(at: tempURL, to: URL(fileURLWithPath: sdkFilePath))
+                try completionHandler(sdkFilePath)
+            } catch {
+                print("Error setting up SDK: \(error)")
+            }
+        }
+
+        task.resume()
+    }
+}

--- a/Tools/Sources/Tools.swift
+++ b/Tools/Sources/Tools.swift
@@ -8,5 +8,6 @@ struct Tools: ParsableCommand {
                                                                   SetupProject.self,
                                                                   OutdatedPackages.self,
                                                                   DownloadStrings.self,
-                                                                  Locheck.self])
+                                                                  Locheck.self,
+                                                                  GenerateSDKMocks.self])
 }

--- a/Tools/Sources/Utilities.swift
+++ b/Tools/Sources/Utilities.swift
@@ -14,6 +14,8 @@ enum Utilities {
     }
 
     static var projectDirectoryURL: URL { URL(fileURLWithPath: FileManager.default.currentDirectoryPath) }
+    static var parentDirectoryURL: URL { Utilities.projectDirectoryURL.deletingLastPathComponent() }
+    static var sdkDirectoryURL: URL { parentDirectoryURL.appendingPathComponent("matrix-rust-sdk") }
 
     /// Runs a command in zsh.
     @discardableResult

--- a/UnitTests/Sources/CreateRoomViewModelTests.swift
+++ b/UnitTests/Sources/CreateRoomViewModelTests.swift
@@ -25,7 +25,7 @@ class CreateRoomScreenViewModelTests: XCTestCase {
     var clientProxy: MockClientProxy!
     var userSession: MockUserSession!
     
-    private let usersSubject = CurrentValueSubject<[LocalUserProfile], Never>([])
+    private let usersSubject = CurrentValueSubject<[UserProfileProxy], Never>([])
     private var cancellables: Set<AnyCancellable> = []
     
     var context: CreateRoomViewModel.Context {
@@ -59,9 +59,9 @@ class CreateRoomScreenViewModelTests: XCTestCase {
     func testDeselectUser() {
         XCTAssertFalse(context.viewState.selectedUsers.isEmpty)
         XCTAssertEqual(context.viewState.selectedUsers.count, 3)
-        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, LocalUserProfile.mockAlice.userID)
+        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, UserProfileProxy.mockAlice.userID)
         context.send(viewAction: .deselectUser(.mockAlice))
-        XCTAssertNotEqual(context.viewState.selectedUsers.first?.userID, LocalUserProfile.mockAlice.userID)
+        XCTAssertNotEqual(context.viewState.selectedUsers.first?.userID, UserProfileProxy.mockAlice.userID)
     }
     
     func testDefaulSecurity() {

--- a/UnitTests/Sources/CreateRoomViewModelTests.swift
+++ b/UnitTests/Sources/CreateRoomViewModelTests.swift
@@ -25,7 +25,7 @@ class CreateRoomScreenViewModelTests: XCTestCase {
     var clientProxy: MockClientProxy!
     var userSession: MockUserSession!
     
-    private let usersSubject = CurrentValueSubject<[UserProfile], Never>([])
+    private let usersSubject = CurrentValueSubject<[LocalUserProfile], Never>([])
     private var cancellables: Set<AnyCancellable> = []
     
     var context: CreateRoomViewModel.Context {
@@ -59,9 +59,9 @@ class CreateRoomScreenViewModelTests: XCTestCase {
     func testDeselectUser() {
         XCTAssertFalse(context.viewState.selectedUsers.isEmpty)
         XCTAssertEqual(context.viewState.selectedUsers.count, 3)
-        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, UserProfile.mockAlice.userID)
+        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, LocalUserProfile.mockAlice.userID)
         context.send(viewAction: .deselectUser(.mockAlice))
-        XCTAssertNotEqual(context.viewState.selectedUsers.first?.userID, UserProfile.mockAlice.userID)
+        XCTAssertNotEqual(context.viewState.selectedUsers.first?.userID, LocalUserProfile.mockAlice.userID)
     }
     
     func testDefaulSecurity() {

--- a/UnitTests/Sources/InviteUsersViewModelTests.swift
+++ b/UnitTests/Sources/InviteUsersViewModelTests.swift
@@ -36,7 +36,7 @@ class InviteUsersScreenViewModelTests: XCTestCase {
         XCTAssertTrue(context.viewState.selectedUsers.isEmpty)
         context.send(viewAction: .toggleUser(.mockAlice))
         XCTAssertTrue(context.viewState.selectedUsers.count == 1)
-        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, UserProfile.mockAlice.userID)
+        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, LocalUserProfile.mockAlice.userID)
     }
     
     func testReselectUser() {
@@ -44,7 +44,7 @@ class InviteUsersScreenViewModelTests: XCTestCase {
         XCTAssertTrue(context.viewState.selectedUsers.isEmpty)
         context.send(viewAction: .toggleUser(.mockAlice))
         XCTAssertEqual(context.viewState.selectedUsers.count, 1)
-        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, UserProfile.mockAlice.userID)
+        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, LocalUserProfile.mockAlice.userID)
         context.send(viewAction: .toggleUser(.mockAlice))
         XCTAssertTrue(context.viewState.selectedUsers.isEmpty)
     }
@@ -54,7 +54,7 @@ class InviteUsersScreenViewModelTests: XCTestCase {
         XCTAssertTrue(context.viewState.selectedUsers.isEmpty)
         context.send(viewAction: .toggleUser(.mockAlice))
         XCTAssertEqual(context.viewState.selectedUsers.count, 1)
-        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, UserProfile.mockAlice.userID)
+        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, LocalUserProfile.mockAlice.userID)
         context.send(viewAction: .toggleUser(.mockAlice))
         XCTAssertTrue(context.viewState.selectedUsers.isEmpty)
     }
@@ -80,7 +80,7 @@ class InviteUsersScreenViewModelTests: XCTestCase {
     }
     
     private func setupWithRoomType(roomType: InviteUsersScreenRoomType) {
-        let usersSubject = CurrentValueSubject<[UserProfile], Never>([])
+        let usersSubject = CurrentValueSubject<[LocalUserProfile], Never>([])
         clientProxy = .init(userID: "")
         userDiscoveryService = UserDiscoveryServiceMock()
         userDiscoveryService.fetchSuggestionsReturnValue = .success([])

--- a/UnitTests/Sources/InviteUsersViewModelTests.swift
+++ b/UnitTests/Sources/InviteUsersViewModelTests.swift
@@ -36,7 +36,7 @@ class InviteUsersScreenViewModelTests: XCTestCase {
         XCTAssertTrue(context.viewState.selectedUsers.isEmpty)
         context.send(viewAction: .toggleUser(.mockAlice))
         XCTAssertTrue(context.viewState.selectedUsers.count == 1)
-        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, LocalUserProfile.mockAlice.userID)
+        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, UserProfileProxy.mockAlice.userID)
     }
     
     func testReselectUser() {
@@ -44,7 +44,7 @@ class InviteUsersScreenViewModelTests: XCTestCase {
         XCTAssertTrue(context.viewState.selectedUsers.isEmpty)
         context.send(viewAction: .toggleUser(.mockAlice))
         XCTAssertEqual(context.viewState.selectedUsers.count, 1)
-        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, LocalUserProfile.mockAlice.userID)
+        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, UserProfileProxy.mockAlice.userID)
         context.send(viewAction: .toggleUser(.mockAlice))
         XCTAssertTrue(context.viewState.selectedUsers.isEmpty)
     }
@@ -54,7 +54,7 @@ class InviteUsersScreenViewModelTests: XCTestCase {
         XCTAssertTrue(context.viewState.selectedUsers.isEmpty)
         context.send(viewAction: .toggleUser(.mockAlice))
         XCTAssertEqual(context.viewState.selectedUsers.count, 1)
-        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, LocalUserProfile.mockAlice.userID)
+        XCTAssertEqual(context.viewState.selectedUsers.first?.userID, UserProfileProxy.mockAlice.userID)
         context.send(viewAction: .toggleUser(.mockAlice))
         XCTAssertTrue(context.viewState.selectedUsers.isEmpty)
     }
@@ -80,7 +80,7 @@ class InviteUsersScreenViewModelTests: XCTestCase {
     }
     
     private func setupWithRoomType(roomType: InviteUsersScreenRoomType) {
-        let usersSubject = CurrentValueSubject<[LocalUserProfile], Never>([])
+        let usersSubject = CurrentValueSubject<[UserProfileProxy], Never>([])
         clientProxy = .init(userID: "")
         userDiscoveryService = UserDiscoveryServiceMock()
         userDiscoveryService.fetchSuggestionsReturnValue = .success([])

--- a/UnitTests/Sources/MediaProvider/MediaLoaderTests.swift
+++ b/UnitTests/Sources/MediaProvider/MediaLoaderTests.swift
@@ -20,7 +20,8 @@ import XCTest
 
 final class MediaLoaderTests: XCTestCase {
     func testMediaRequestCoalescing() async {
-        let mediaLoadingClient = MockMediaLoadingClient()
+        let mediaLoadingClient = SDKClientMock()
+        mediaLoadingClient.getMediaContentMediaSourceReturnValue = []
         let mediaLoader = MediaLoader(client: mediaLoadingClient)
         
         let mediaSource = MediaSourceProxy(url: URL.documentsDirectory, mimeType: nil)
@@ -30,14 +31,15 @@ final class MediaLoaderTests: XCTestCase {
                 _ = try await mediaLoader.loadMediaContentForSource(mediaSource)
             }
             
-            XCTAssertEqual(mediaLoadingClient.numberOfInvocations, 10)
+            XCTAssertEqual(mediaLoadingClient.getMediaContentMediaSourceCallsCount, 10)
         } catch {
             fatalError()
         }
     }
     
     func testMediaThumbnailRequestCoalescing() async {
-        let mediaLoadingClient = MockMediaLoadingClient()
+        let mediaLoadingClient = SDKClientMock()
+        mediaLoadingClient.getMediaThumbnailMediaSourceWidthHeightReturnValue = []
         let mediaLoader = MediaLoader(client: mediaLoadingClient)
         
         let mediaSource = MediaSourceProxy(url: URL.documentsDirectory, mimeType: nil)
@@ -47,107 +49,9 @@ final class MediaLoaderTests: XCTestCase {
                 _ = try await mediaLoader.loadMediaThumbnailForSource(mediaSource, width: 100, height: 100)
             }
             
-            XCTAssertEqual(mediaLoadingClient.numberOfInvocations, 10)
+            XCTAssertEqual(mediaLoadingClient.getMediaThumbnailMediaSourceWidthHeightCallsCount, 10)
         } catch {
             fatalError()
         }
-    }
-}
-
-private class MockMediaLoadingClient: ClientProtocol {
-    private(set) var numberOfInvocations = 0
-    
-    func getMediaContent(mediaSource: MatrixRustSDK.MediaSource) throws -> [UInt8] {
-        numberOfInvocations += 1
-        return []
-    }
-    
-    func getMediaThumbnail(mediaSource: MatrixRustSDK.MediaSource, width: UInt64, height: UInt64) throws -> [UInt8] {
-        numberOfInvocations += 1
-        return []
-    }
-    
-    // MARK: - Not implemented
-    
-    func setDelegate(delegate: MatrixRustSDK.ClientDelegate?) { }
-    
-    func login(username: String, password: String, initialDeviceName: String?, deviceId: String?) throws { }
-    
-    func restoreSession(session: MatrixRustSDK.Session) throws { }
-    
-    func session() throws -> MatrixRustSDK.Session { fatalError() }
-    
-    func userId() throws -> String { fatalError() }
-    
-    func displayName() throws -> String { fatalError() }
-    
-    func setDisplayName(name: String) throws { }
-    
-    func avatarUrl() throws -> String? { fatalError() }
-
-    func cachedAvatarUrl() throws -> String? { fatalError() }
-    
-    func deviceId() throws -> String { fatalError() }
-    
-    func accountData(eventType: String) throws -> String? { fatalError() }
-    
-    func setAccountData(eventType: String, content: String) throws { fatalError() }
-    
-    func uploadMedia(mimeType: String, data content: [UInt8]) throws -> String { fatalError() }
-    
-    func getMediaFile(mediaSource: MatrixRustSDK.MediaSource, body: String?, mimeType: String) throws -> MatrixRustSDK.MediaFileHandle { fatalError() }
-    
-    func getProfile(userId: String) throws -> MatrixRustSDK.UserProfile { fatalError() }
-    
-    func getSessionVerificationController() throws -> MatrixRustSDK.SessionVerificationController { fatalError() }
-    
-    func fullSlidingSync() throws -> MatrixRustSDK.SlidingSync { fatalError() }
-    
-    func logout() throws { }
-    
-    func hasFirstSynced() -> Bool { fatalError() }
-    
-    func homeserver() -> String { fatalError() }
-    
-    func isSoftLogout() -> Bool { fatalError() }
-    
-    func isSyncing() -> Bool { fatalError() }
-    
-    func rooms() -> [MatrixRustSDK.Room] { fatalError() }
-    
-    func slidingSync() -> MatrixRustSDK.SlidingSyncBuilder { fatalError() }
-    
-    func startSync(timelineLimit: UInt16?) { }
-    
-    func createRoom(request: MatrixRustSDK.CreateRoomParameters) throws -> String { fatalError() }
-
-    func getDmRoom(userId: String) throws -> MatrixRustSDK.Room? {
-        fatalError()
-    }
-
-    func ignoreUser(userId: String) throws {
-        fatalError()
-    }
-
-    func unignoreUser(userId: String) throws {
-        fatalError()
-    }
-
-    // swiftlint:disable:next function_parameter_count
-    func setPusher(identifiers: MatrixRustSDK.PusherIdentifiers,
-                   kind: MatrixRustSDK.PusherKind,
-                   appDisplayName: String,
-                   deviceDisplayName: String,
-                   profileTag: String?,
-                   lang: String) throws {
-        fatalError()
-    }
-    
-    func searchUsers(searchTerm: String, limit: UInt64) throws -> MatrixRustSDK.SearchUsersResults { fatalError() }
-
-    func setNotificationDelegate(notificationDelegate: MatrixRustSDK.NotificationDelegate?) { }
-
-    func getNotificationItem(roomId: String, eventId: String) throws -> MatrixRustSDK.NotificationItem {
-        fatalError()
     }
 }

--- a/UnitTests/Sources/UserDiscoveryService/UserDiscoveryServiceTest.swift
+++ b/UnitTests/Sources/UserDiscoveryService/UserDiscoveryServiceTest.swift
@@ -29,7 +29,7 @@ class UserDiscoveryServiceTest: XCTestCase {
     }
     
     func testQueryShowingResults() async throws {
-        clientProxy.searchUsersResult = .success(.init(results: [LocalUserProfile.mockAlice], limited: true))
+        clientProxy.searchUsersResult = .success(.init(results: [UserProfileProxy.mockAlice], limited: true))
         
         let results = await (try? search(query: "AAA").get()) ?? []
         assertSearchResults(results, toBe: 1)
@@ -79,17 +79,17 @@ class UserDiscoveryServiceTest: XCTestCase {
     
     // MARK: - Private
     
-    private func assertSearchResults(_ results: [LocalUserProfile], toBe count: Int) {
+    private func assertSearchResults(_ results: [UserProfileProxy], toBe count: Int) {
         XCTAssertTrue(count >= 0)
         XCTAssertEqual(results.count, count)
         XCTAssertEqual(results.isEmpty, count == 0)
     }
     
-    private func search(query: String) async -> Result<[LocalUserProfile], UserDiscoveryErrorType> {
+    private func search(query: String) async -> Result<[UserProfileProxy], UserDiscoveryErrorType> {
         await service.searchProfiles(with: query)
     }
     
-    private var searchResults: [LocalUserProfile] {
+    private var searchResults: [UserProfileProxy] {
         [
             .mockAlice,
             .mockBob,

--- a/UnitTests/Sources/UserDiscoveryService/UserDiscoveryServiceTest.swift
+++ b/UnitTests/Sources/UserDiscoveryService/UserDiscoveryServiceTest.swift
@@ -29,7 +29,7 @@ class UserDiscoveryServiceTest: XCTestCase {
     }
     
     func testQueryShowingResults() async throws {
-        clientProxy.searchUsersResult = .success(.init(results: [UserProfile.mockAlice], limited: true))
+        clientProxy.searchUsersResult = .success(.init(results: [LocalUserProfile.mockAlice], limited: true))
         
         let results = await (try? search(query: "AAA").get()) ?? []
         assertSearchResults(results, toBe: 1)
@@ -79,17 +79,17 @@ class UserDiscoveryServiceTest: XCTestCase {
     
     // MARK: - Private
     
-    private func assertSearchResults(_ results: [UserProfile], toBe count: Int) {
+    private func assertSearchResults(_ results: [LocalUserProfile], toBe count: Int) {
         XCTAssertTrue(count >= 0)
         XCTAssertEqual(results.count, count)
         XCTAssertEqual(results.isEmpty, count == 0)
     }
     
-    private func search(query: String) async -> Result<[UserProfile], UserDiscoveryErrorType> {
+    private func search(query: String) async -> Result<[LocalUserProfile], UserDiscoveryErrorType> {
         await service.searchProfiles(with: query)
     }
     
-    private var searchResults: [UserProfile] {
+    private var searchResults: [LocalUserProfile] {
         [
             .mockAlice,
             .mockBob,


### PR DESCRIPTION
You need to specify the version for the mocks you want to generate.
For example the current mocks are generated using 1.0.69-alpha.
`swift run tools generate-sdk-mocks 1.0.69-alpha`

However if you like to generate mocks for your local implementation, you just ned to use:
`swift run tools generate-sdk-mocks local`

For now the only mock that we are generating is the one for the `ClientProtocol` however we can add them for as many protocols as we want, remember that they need to be placesd inside the Sources/Mocks/SDK folder to be parsed by the tool.

These mock generation tool is separated from the internal project default one used each time the app is run.

