### PR TITLE
Add PublishedOnSet to the authentication service.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		7A71AEF419904209BB8C2833 /* UserAgentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2529D434C750ED78ADF1ED /* UserAgentBuilder.swift */; };
 		7AEC56ADEFC5A7198A17412F /* InviteUsersScreenUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB35E2DB4EFE8E6F3959629 /* InviteUsersScreenUITests.swift */; };
 		7BB31E67648CF32D2AB5E502 /* RoomScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE3C90E487B255B735D73C8 /* RoomScreenViewModel.swift */; };
+		7BEA98F7BFD001639A56BF3F /* PublishedOnSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0A76B7C5F6CC2EEF612FE5 /* PublishedOnSet.swift */; };
 		7C1A7B594B2F8143F0DD0005 /* ElementXAttributeScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = C024C151639C4E1B91FCC68B /* ElementXAttributeScope.swift */; };
 		7CD16990BA843BE9ED639129 /* ImageRoomTimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFE4453AB0B34C203447162 /* ImageRoomTimelineItem.swift */; };
 		7E3C34BC10936AD4F77975F4 /* EmojiMartJSONLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39001365B76B89983FDB7AD8 /* EmojiMartJSONLoader.swift */; };
@@ -1052,6 +1053,7 @@
 		9C698E30698EC59302A8EEBD /* NavigationStackCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStackCoordinatorTests.swift; sourceTree = "<group>"; };
 		9C7F7DE62D33C6A26CBFCD72 /* IntegrationTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = IntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9CE3C90E487B255B735D73C8 /* RoomScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreenViewModel.swift; sourceTree = "<group>"; };
+		9E0A76B7C5F6CC2EEF612FE5 /* PublishedOnSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishedOnSet.swift; sourceTree = "<group>"; };
 		9E6D88E8AFFBF2C1D589C0FA /* UIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConstants.swift; sourceTree = "<group>"; };
 		9F85164F9475FF2867F71AAA /* RoomTimelineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineController.swift; sourceTree = "<group>"; };
 		A00C7A331B72C0F05C00392F /* RoomScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -2845,6 +2847,7 @@
 				C789E7BFC066CF39B8AE0974 /* NetworkMonitor.swift */,
 				F754E66A8970963B15B2A41E /* PermalinkBuilder.swift */,
 				F28551E81CE3700E5F1EC9B5 /* ProgressTracker.swift */,
+				9E0A76B7C5F6CC2EEF612FE5 /* PublishedOnSet.swift */,
 				53482ECA4B6633961EC224F5 /* ScrollViewAdapter.swift */,
 				DBA8DC95C079805B0B56E8A9 /* SharedUserDefaultsKeys.swift */,
 				BB3073CCD77D906B330BC1D6 /* Tests.swift */,
@@ -3945,6 +3948,7 @@
 				9D79B94493FB32249F7E472F /* PlaceholderAvatarImage.swift in Sources */,
 				DF504B10A4918F971A57BEF2 /* PostHogAnalyticsClient.swift in Sources */,
 				F587A9AF25A262DE5A7B0369 /* ProgressTracker.swift in Sources */,
+				7BEA98F7BFD001639A56BF3F /* PublishedOnSet.swift in Sources */,
 				2835FD52F3F618D07F799B3D /* Publisher.swift in Sources */,
 				743790BF6A5B0577EA74AF14 /* ReadMarkerRoomTimelineItem.swift in Sources */,
 				8EF63DDDC1B54F122070B04D /* ReadMarkerRoomTimelineView.swift in Sources */,

--- a/ElementX/Sources/Other/PublishedOnSet.swift
+++ b/ElementX/Sources/Other/PublishedOnSet.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Combine
+
+/// Creates a property that provides a publisher via it's projected value. Similar to (ab)using `@Published` but
+/// works outside of an `ObservableObject` and the publisher is fired on `didSet` instead of `willSet`.
+@propertyWrapper struct PublishedOnSet<Value> {
+    private let subject: PassthroughSubject<Value, Never> = .init()
+    
+    var wrappedValue: Value {
+        didSet { subject.send(wrappedValue) }
+    }
+    
+    var projectedValue: AnyPublisher<Value, Never> { subject.eraseToAnyPublisher() }
+}

--- a/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/LoginScreen/LoginScreenCoordinator.swift
@@ -43,7 +43,7 @@ final class LoginScreenCoordinator: CoordinatorProtocol {
     init(parameters: LoginScreenCoordinatorParameters) {
         self.parameters = parameters
         
-        viewModel = LoginScreenViewModel(homeserver: parameters.authenticationService.homeserver.value)
+        viewModel = LoginScreenViewModel(homeserver: parameters.authenticationService.homeserver)
         
         oidcAuthenticationPresenter = OIDCAuthenticationPresenter(authenticationService: parameters.authenticationService)
     }
@@ -188,7 +188,7 @@ final class LoginScreenCoordinator: CoordinatorProtocol {
     
     /// Updates the view model with a different homeserver.
     private func updateViewModel() {
-        viewModel.update(homeserver: authenticationService.homeserver.value)
+        viewModel.update(homeserver: authenticationService.homeserver)
         indicateSuccess()
     }
     

--- a/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/ServerConfirmationScreenViewModel.swift
@@ -27,10 +27,10 @@ class ServerConfirmationScreenViewModel: ServerConfirmationScreenViewModelType, 
     }
 
     init(authenticationService: AuthenticationServiceProxyProtocol, authenticationFlow: AuthenticationFlow) {
-        super.init(initialViewState: ServerConfirmationScreenViewState(homeserverAddress: authenticationService.homeserver.value.address,
+        super.init(initialViewState: ServerConfirmationScreenViewState(homeserverAddress: authenticationService.homeserver.address,
                                                                        authenticationFlow: authenticationFlow))
         
-        authenticationService.homeserver
+        authenticationService.homeserverPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] homeserver in
                 guard let self else { return }

--- a/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerSelectionScreen/ServerSelectionScreenCoordinator.swift
@@ -39,7 +39,7 @@ final class ServerSelectionScreenCoordinator: CoordinatorProtocol {
     
     init(parameters: ServerSelectionScreenCoordinatorParameters) {
         self.parameters = parameters
-        viewModel = ServerSelectionScreenViewModel(homeserverAddress: parameters.authenticationService.homeserver.value.address,
+        viewModel = ServerSelectionScreenViewModel(homeserverAddress: parameters.authenticationService.homeserver.address,
                                                    isModallyPresented: parameters.isModallyPresented)
         userIndicatorController = parameters.userIndicatorController
     }

--- a/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/SoftLogoutScreenCoordinator.swift
@@ -53,7 +53,7 @@ final class SoftLogoutScreenCoordinator: CoordinatorProtocol {
         
         let homeserver = parameters.authenticationService.homeserver
         viewModel = SoftLogoutScreenViewModel(credentials: parameters.credentials,
-                                              homeserver: homeserver.value,
+                                              homeserver: homeserver,
                                               keyBackupNeeded: parameters.keyBackupNeeded)
         
         oidcAuthenticationPresenter = OIDCAuthenticationPresenter(authenticationService: parameters.authenticationService)

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
@@ -22,9 +22,9 @@ class AuthenticationServiceProxy: AuthenticationServiceProxyProtocol {
     private let authenticationService: AuthenticationService
     private let userSessionStore: UserSessionStoreProtocol
     
-    private let homeserverSubject: CurrentValueSubject<LoginHomeserver, Never> = .init(LoginHomeserver(address: ServiceLocator.shared.settings.defaultHomeserverAddress,
-                                                                                                       loginMode: .unknown))
-    var homeserver: CurrentValuePublisher<LoginHomeserver, Never> { homeserverSubject.asCurrentValuePublisher() }
+    @PublishedOnSet
+    private(set) var homeserver = LoginHomeserver(address: ServiceLocator.shared.settings.defaultHomeserverAddress, loginMode: .unknown)
+    var homeserverPublisher: AnyPublisher<LoginHomeserver, Never> { $homeserver }
     
     init(userSessionStore: UserSessionStoreProtocol) {
         self.userSessionStore = userSessionStore
@@ -63,7 +63,7 @@ class AuthenticationServiceProxy: AuthenticationServiceProxyProtocol {
                 }
             }
             
-            homeserverSubject.send(homeserver)
+            self.homeserver = homeserver
             return .success(())
         } catch AuthenticationError.SlidingSyncNotAvailable {
             MXLog.info("User entered a homeserver that isn't configured for sliding sync.")

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import Combine
 import Foundation
 import MatrixRustSDK
 
@@ -38,7 +39,9 @@ enum AuthenticationServiceError: Error {
 
 protocol AuthenticationServiceProxyProtocol {
     /// The currently configured homeserver.
-    var homeserver: CurrentValuePublisher<LoginHomeserver, Never> { get }
+    var homeserver: LoginHomeserver { get }
+    /// A publisher for the ``homeserver`` value.
+    var homeserverPublisher: AnyPublisher<LoginHomeserver, Never> { get }
     
     /// Sets up the service for login on the specified homeserver address.
     func configure(for homeserverAddress: String) async -> Result<Void, AuthenticationServiceError>


### PR DESCRIPTION
Adds a `PublishedOnSet` property wrapper as an alternative to using `CurrentValueSubject`.

This is PR is draft for now, to open a discussion. It is currently just scoped to the AuthenticationServiceProxy.

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
