### PR TITLE
Disable interactive dismiss during loading on modals

### DIFF
--- a/ElementX/Sources/Other/UserIndicator/UserIndicator.swift
+++ b/ElementX/Sources/Other/UserIndicator/UserIndicator.swift
@@ -17,9 +17,13 @@
 import Combine
 import Foundation
 
-enum UserIndicatorType {
+enum UserIndicatorType: Equatable {
     case toast
-    case modal
+    case modal(interactiveDismissDisabled: Bool)
+    
+    static var modal: Self {
+        .modal(interactiveDismissDisabled: false)
+    }
 }
 
 struct UserIndicator: Equatable, Identifiable {
@@ -49,6 +53,15 @@ struct UserIndicator: Equatable, Identifiable {
             return Empty().eraseToAnyPublisher()
         case .some(.progress(let progress)):
             return progress.publisher.eraseToAnyPublisher()
+        }
+    }
+    
+    var interactiveDismissDisabled: Bool {
+        switch type {
+        case .toast:
+            return false
+        case .modal(let interactiveDismissDisabled):
+            return interactiveDismissDisabled
         }
     }
 }

--- a/ElementX/Sources/Other/UserIndicator/UserIndicatorModalView.swift
+++ b/ElementX/Sources/Other/UserIndicator/UserIndicatorModalView.swift
@@ -54,6 +54,7 @@ struct UserIndicatorModalView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.black.opacity(0.1))
         .ignoresSafeArea()
+        .interactiveDismissDisabled(indicator.interactiveDismissDisabled)
     }
 }
 

--- a/ElementX/Sources/Screens/CreateRoom/CreateRoomViewModel.swift
+++ b/ElementX/Sources/Screens/CreateRoom/CreateRoomViewModel.swift
@@ -168,7 +168,7 @@ class CreateRoomViewModel: CreateRoomViewModelType, CreateRoomViewModelProtocol 
     
     private func showLoadingIndicator() {
         userIndicatorController?.submitIndicator(UserIndicator(id: Self.loadingIndicatorIdentifier,
-                                                               type: .modal,
+                                                               type: .modal(interactiveDismissDisabled: true),
                                                                title: L10n.commonLoading,
                                                                persistent: true))
     }

--- a/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
@@ -80,7 +80,10 @@ class RoomDetailsEditScreenViewModel: RoomDetailsEditScreenViewModelType, RoomDe
             defer {
                 userIndicatorController.retractIndicatorWithId(userIndicatorID)
             }
-            userIndicatorController.submitIndicator(UserIndicator(id: userIndicatorID, type: .modal, title: L10n.commonLoading, persistent: true))
+            userIndicatorController.submitIndicator(UserIndicator(id: userIndicatorID,
+                                                                  type: .modal(interactiveDismissDisabled: true),
+                                                                  title: L10n.commonLoading,
+                                                                  persistent: true))
             
             let mediaResult = await mediaPreprocessor.processMedia(at: url)
             
@@ -101,7 +104,10 @@ class RoomDetailsEditScreenViewModel: RoomDetailsEditScreenViewModelType, RoomDe
             defer {
                 userIndicatorController.retractIndicatorWithId(userIndicatorID)
             }
-            userIndicatorController.submitIndicator(UserIndicator(id: userIndicatorID, type: .modal, title: L10n.screenRoomDetailsUpdatingRoom, persistent: true))
+            userIndicatorController.submitIndicator(UserIndicator(id: userIndicatorID,
+                                                                  type: .modal(interactiveDismissDisabled: true),
+                                                                  title: L10n.screenRoomDetailsUpdatingRoom,
+                                                                  persistent: true))
             
             do {
                 try await withThrowingTaskGroup(of: Void.self) { group in


### PR DESCRIPTION
This PR enhances the `UserIndicator` by supporting the possibility to prevent the dismiss of modals during blocking operations.

This new behavior has been added in:
- CreateRoomScreen
- RoomDetailsEditScreen

**Result**
![poc](https://github.com/vector-im/element-x-ios/assets/19324622/dffac684-125d-4b52-aef5-9645d93d08f9)