### PR TITLE
Sliding sync hang fix

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -4778,7 +4778,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "1.0.71-alpha";
+				version = "1.0.72-alpha";
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -102,8 +102,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "3cd19bf79bd89b71477642a1d2172f3ee48b44ef",
-        "version" : "1.0.71-alpha"
+        "revision" : "d0533a4ba40ff1d9ea9c6473a07639fa9b9c5079",
+        "version" : "1.0.72-alpha"
       }
     },
     {

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -436,19 +436,22 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
     
     private func observeNetworkState() {
         let reachabilityNotificationIdentifier = "io.element.elementx.reachability.notification"
-        networkMonitorObserver = ServiceLocator.shared.networkMonitor.reachabilityPublisher.sink { reachable in
-            MXLog.info("Reachability changed to \(reachable)")
-            
-            if reachable {
-                ServiceLocator.shared.userIndicatorController.retractIndicatorWithId(reachabilityNotificationIdentifier)
-            } else {
-                ServiceLocator.shared.userIndicatorController.submitIndicator(.init(id: reachabilityNotificationIdentifier,
-                                                                                    title: L10n.commonOffline,
-                                                                                    persistent: true))
+        networkMonitorObserver = ServiceLocator.shared.networkMonitor
+            .reachabilityPublisher
+            .removeDuplicates()
+            .sink { reachable in
+                MXLog.info("Reachability changed to \(reachable)")
+                
+                if reachable {
+                    ServiceLocator.shared.userIndicatorController.retractIndicatorWithId(reachabilityNotificationIdentifier)
+                } else {
+                    ServiceLocator.shared.userIndicatorController.submitIndicator(.init(id: reachabilityNotificationIdentifier,
+                                                                                        title: L10n.commonOffline,
+                                                                                        persistent: true))
+                }
             }
-        }
     }
-
+    
     private func handleAppRoute(_ appRoute: AppRoute) {
         if let userSessionFlowCoordinator {
             userSessionFlowCoordinator.handleAppRoute(appRoute, animated: UIApplication.shared.applicationState == .active)

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -278,6 +278,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         navigationStackCoordinator.popToRoot(animated: true)
         navigationSplitCoordinator.setDetailCoordinator(nil)
         roomProxy = nil
+        timelineController = nil
         
         actionsSubject.send(.dismissedRoom)
     }

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -168,8 +168,13 @@ class ClientProxy: ClientProxyProtocol {
 
     func stopSync() {
         MXLog.info("Stopping sync")
-        slidingSync?.stopSync()
         slidingSyncObserverToken = nil
+        
+        do {
+            try slidingSync?.stopSync()
+        } catch {
+            MXLog.error("Failed stopping sync with error: \(error). Ignore this error if ran just before the app being suspended")
+        }
     }
     
     func directRoomForUserID(_ userID: String) async -> Result<String?, ClientProxyError> {

--- a/project.yml
+++ b/project.yml
@@ -43,7 +43,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.71-alpha
+    exactVersion: 1.0.72-alpha
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
This PR fixes sliding sync not restarting properly when coming back from an app suspended mode. When that happens scrolling the list results in more range requests that the internal channel can support and blocks the main thread indefinitely