### PR TITLE
Fix the background colour when replying.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposer.swift
@@ -126,7 +126,7 @@ private struct MessageComposerReplyHeader: View {
         TimelineReplyView(placement: .composer, timelineItemReplyDetails: replyDetails)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(4.0)
-            .background(.white)
+            .background(Color.element.background)
             .cornerRadius(13.0)
             .padding([.trailing, .vertical], 8.0)
             .padding([.leading], -4.0)

--- a/changelog.d/pr-1007.bugfix
+++ b/changelog.d/pr-1007.bugfix
@@ -1,0 +1,1 @@
+Fix an incorrect colour when replying to a message in dark mode. 


### PR DESCRIPTION
Fix an incorrect colour:

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-06-02 at 09 35 52](https://github.com/vector-im/element-x-ios/assets/6060466/a795f82a-5a62-4c93-b4e5-7672f3901fed) | ![Simulator Screenshot - iPhone 14 Pro - 2023-06-02 at 09 34 59](https://github.com/vector-im/element-x-ios/assets/6060466/d62d831a-c01b-4c63-b4dc-d2f330899ff7) |
