### PR TITLE
Backport base Form style from Compound.

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Form Styles/FormSection.swift
+++ b/ElementX/Sources/Other/SwiftUI/Form Styles/FormSection.swift
@@ -16,32 +16,23 @@
 
 import SwiftUI
 
-/// Style for form section headers
-struct FormSectionHeaderStyle: ViewModifier {
-    func body(content: Content) -> some View {
-        content
-            .foregroundColor(.element.secondaryContent)
-            .font(.compound.bodyXS)
-    }
-}
-
-/// Standard style for form sections
-struct FormSectionStyle: ViewModifier {
-    func body(content: Content) -> some View {
-        content
-            .listRowSeparator(.hidden)
-            .listRowInsets(FormRow.insets)
-            .listRowBackground(Color.element.formRowBackground)
-    }
-}
-
 extension View {
-    /// Applies the `FormSectionHeaderStyle` modifier to the view
-    func formSectionHeader() -> some View {
-        modifier(FormSectionHeaderStyle())
+    /// Applies a standard style to forms.
+    func elementFormStyle() -> some View {
+        scrollContentBackground(.hidden)
+            .background(Color.element.formBackground.ignoresSafeArea())
     }
     
+    /// Applies a standard style for form header text.
+    func formSectionHeader() -> some View {
+        foregroundColor(.element.secondaryContent)
+            .font(.compound.bodyXS)
+    }
+    
+    /// Applies a standard style for form sections.
     func formSectionStyle() -> some View {
-        modifier(FormSectionStyle())
+        listRowSeparator(.hidden)
+            .listRowInsets(FormRow.insets)
+            .listRowBackground(Color.element.formRowBackground)
     }
 }

--- a/ElementX/Sources/Screens/CreateRoom/View/CreateRoomScreen.swift
+++ b/ElementX/Sources/Screens/CreateRoom/View/CreateRoomScreen.swift
@@ -28,8 +28,7 @@ struct CreateRoomScreen: View {
     var body: some View {
         mainContent
             .scrollDismissesKeyboard(.immediately)
-            .scrollContentBackground(.hidden)
-            .background(Color.element.formBackground.ignoresSafeArea())
+            .elementFormStyle()
             .navigationTitle(L10n.screenCreateRoomTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/ElementX/Sources/Screens/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -85,8 +85,7 @@ struct DeveloperOptionsScreen: View {
             }
         }
         .overlay(effectsView)
-        .scrollContentBackground(.hidden)
-        .background(Color.element.formBackground.ignoresSafeArea())
+        .elementFormStyle()
         .navigationTitle(L10n.commonDeveloperOptions)
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -22,8 +22,7 @@ struct InviteUsersScreen: View {
     
     var body: some View {
         mainContent
-            .scrollContentBackground(.hidden)
-            .background(Color.element.formBackground.ignoresSafeArea())
+            .elementFormStyle()
             .navigationTitle(L10n.screenCreateRoomActionInvitePeople)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/ElementX/Sources/Screens/RoomDetailsEditScreen/View/RoomDetailsEditScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsEditScreen/View/RoomDetailsEditScreen.swift
@@ -27,8 +27,7 @@ struct RoomDetailsEditScreen: View {
     
     var body: some View {
         mainContent
-            .scrollContentBackground(.hidden)
-            .background(Color.element.formBackground.ignoresSafeArea())
+            .elementFormStyle()
             .scrollDismissesKeyboard(.immediately)
             .navigationTitle(L10n.screenRoomDetailsEditRoomTitle)
             .navigationBarTitleDisplayMode(.inline)

--- a/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
@@ -41,8 +41,7 @@ struct RoomDetailsScreen: View {
                 leaveRoomSection
             }
         }
-        .scrollContentBackground(.hidden)
-        .background(Color.element.formBackground.ignoresSafeArea())
+        .elementFormStyle()
         .alert(item: $context.alertInfo) { $0.alert }
         .alert(item: $context.leaveRoomAlertItem,
                actions: leaveRoomAlertActions,

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
@@ -27,8 +27,7 @@ struct RoomMemberDetailsScreen: View {
                 blockUserSection
             }
         }
-        .scrollContentBackground(.hidden)
-        .background(Color.element.formBackground.ignoresSafeArea())
+        .elementFormStyle()
         .alert(item: $context.ignoreUserAlert, actions: blockUserAlertActions, message: blockUserAlertMessage)
         .errorAlert(item: $context.errorAlert)
     }

--- a/ElementX/Sources/Screens/StartChatScreen/View/StartChatScreen.swift
+++ b/ElementX/Sources/Screens/StartChatScreen/View/StartChatScreen.swift
@@ -28,8 +28,7 @@ struct StartChatScreen: View {
                 searchContent
             }
         }
-        .scrollContentBackground(.hidden)
-        .background(Color.element.formBackground.ignoresSafeArea())
+        .elementFormStyle()
         .navigationTitle(L10n.actionStartChat)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {


### PR DESCRIPTION
I had thought we'd be using the `.compoundForm()` style by now, but as we aren't this PR makes it easier than having to manually apply a colour.