### PR TITLE
Improved bug report error handling

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -126,7 +126,7 @@ final class AppSettings {
     let bugReportApplicationId = "element-x-ios"
     let bugReportUISIId = "element-auto-uisi"
     /// The maximum size of the upload request. Default value is just below CloudFlare's max request size.
-    let bugReportMaxUploadSize = 95 * 1024 * 1024
+    let bugReportMaxUploadSize = 50 * 1024 * 1024
     
     // MARK: - Analytics
     

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -125,6 +125,8 @@ final class AppSettings {
     // Use the name allocated by the bug report server
     let bugReportApplicationId = "element-x-ios"
     let bugReportUISIId = "element-auto-uisi"
+    /// The maximum size of the upload request. Default value is just below CloudFlare's max request size.
+    let bugReportMaxUploadSize = 95 * 1024 * 1024
     
     // MARK: - Analytics
     

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -172,25 +172,21 @@ class BugReportServiceMock: BugReportServiceProtocol {
     }
     //MARK: - submitBugReport
 
-    var submitBugReportProgressListenerThrowableError: Error?
     var submitBugReportProgressListenerCallsCount = 0
     var submitBugReportProgressListenerCalled: Bool {
         return submitBugReportProgressListenerCallsCount > 0
     }
     var submitBugReportProgressListenerReceivedArguments: (bugReport: BugReport, progressListener: ProgressListener?)?
     var submitBugReportProgressListenerReceivedInvocations: [(bugReport: BugReport, progressListener: ProgressListener?)] = []
-    var submitBugReportProgressListenerReturnValue: SubmitBugReportResponse!
-    var submitBugReportProgressListenerClosure: ((BugReport, ProgressListener?) async throws -> SubmitBugReportResponse)?
+    var submitBugReportProgressListenerReturnValue: Result<SubmitBugReportResponse, BugReportServiceError>!
+    var submitBugReportProgressListenerClosure: ((BugReport, ProgressListener?) async -> Result<SubmitBugReportResponse, BugReportServiceError>)?
 
-    func submitBugReport(_ bugReport: BugReport, progressListener: ProgressListener?) async throws -> SubmitBugReportResponse {
-        if let error = submitBugReportProgressListenerThrowableError {
-            throw error
-        }
+    func submitBugReport(_ bugReport: BugReport, progressListener: ProgressListener?) async -> Result<SubmitBugReportResponse, BugReportServiceError> {
         submitBugReportProgressListenerCallsCount += 1
         submitBugReportProgressListenerReceivedArguments = (bugReport: bugReport, progressListener: progressListener)
         submitBugReportProgressListenerReceivedInvocations.append((bugReport: bugReport, progressListener: progressListener))
         if let submitBugReportProgressListenerClosure = submitBugReportProgressListenerClosure {
-            return try await submitBugReportProgressListenerClosure(bugReport, progressListener)
+            return await submitBugReportProgressListenerClosure(bugReport, progressListener)
         } else {
             return submitBugReportProgressListenerReturnValue
         }

--- a/ElementX/Sources/Other/Logging/MXLogger.swift
+++ b/ElementX/Sources/Other/Logging/MXLogger.swift
@@ -128,7 +128,7 @@ class MXLogger {
     
     /// The list of all log file URLs, sorted chronologically.
     static var logFiles: [URL] {
-        var logFiles = [(URL, Date)]()
+        var logFiles = [(url: URL, modificationDate: Date)]()
         
         let fileManager = FileManager.default
         let enumerator = fileManager.enumerator(at: logsFolderURL, includingPropertiesForKeys: [.contentModificationDateKey])
@@ -144,9 +144,9 @@ class MXLogger {
             }
         }
         
-        let sortedFiles = logFiles.sorted { $0.1 > $1.1 }.map(\.0)
+        let sortedFiles = logFiles.sorted { $0.modificationDate > $1.modificationDate }.map(\.url)
         
-        MXLog.info("logFiles: \(sortedFiles)")
+        MXLog.info("logFiles: \(sortedFiles.map(\.lastPathComponent))")
         
         return sortedFiles
     }

--- a/ElementX/Sources/Other/Logging/MXLogger.swift
+++ b/ElementX/Sources/Other/Logging/MXLogger.swift
@@ -126,23 +126,29 @@ class MXLogger {
         }
     }
     
-    /// The list of all log file URLs.
+    /// The list of all log file URLs, sorted chronologically.
     static var logFiles: [URL] {
-        var logFiles = [URL]()
+        var logFiles = [(URL, Date)]()
         
         let fileManager = FileManager.default
-        let enumerator = fileManager.enumerator(at: logsFolderURL, includingPropertiesForKeys: nil)
+        let enumerator = fileManager.enumerator(at: logsFolderURL, includingPropertiesForKeys: [.contentModificationDateKey])
         
-        // Find all *.log files
+        // Find all *.log files and their modification dates.
         while let logURL = enumerator?.nextObject() as? URL {
-            if logURL.lastPathComponent.hasPrefix("console") {
-                logFiles.append(logURL)
+            guard let resourceValues = try? logURL.resourceValues(forKeys: [.contentModificationDateKey]),
+                  let modificationDate = resourceValues.contentModificationDate
+            else { continue }
+            
+            if logURL.pathExtension == "log" {
+                logFiles.append((logURL, modificationDate))
             }
         }
         
-        MXLog.info("logFiles: \(logFiles)")
+        let sortedFiles = logFiles.sorted { $0.1 > $1.1 }.map(\.0)
         
-        return logFiles
+        MXLog.info("logFiles: \(sortedFiles)")
+        
+        return sortedFiles
     }
     
     // MARK: - Exceptions and crashes

--- a/ElementX/Sources/Screens/BugReportScreen/BugReportScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/BugReportScreen/BugReportScreenCoordinator.swift
@@ -100,6 +100,6 @@ final class BugReportScreenCoordinator: CoordinatorProtocol {
     }
     
     private func showError(label: String) {
-        parameters.userIndicatorController?.submitIndicator(UserIndicator(title: label))
+        parameters.userIndicatorController?.submitIndicator(UserIndicator(title: label, iconName: "xmark"))
     }
 }

--- a/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
@@ -31,6 +31,23 @@ struct SubmitBugReportResponse: Decodable {
     var reportUrl: String
 }
 
+enum BugReportServiceError: LocalizedError {
+    case uploadFailure(Error)
+    case serverError(URLResponse, String)
+    case httpError(HTTPURLResponse, String)
+    
+    var errorDescription: String? {
+        switch self {
+        case .uploadFailure(let error):
+            return error.localizedDescription
+        case .serverError(let urlResponse, let errorDescription):
+            return errorDescription
+        case .httpError(let httpResponse, let errorDescription):
+            return errorDescription
+        }
+    }
+}
+
 // sourcery: AutoMockable
 protocol BugReportServiceProtocol {
     var isRunning: Bool { get }
@@ -46,5 +63,5 @@ protocol BugReportServiceProtocol {
     func crash()
     
     func submitBugReport(_ bugReport: BugReport,
-                         progressListener: ProgressListener?) async throws -> SubmitBugReportResponse
+                         progressListener: ProgressListener?) async -> Result<SubmitBugReportResponse, BugReportServiceError>
 }

--- a/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportServiceProtocol.swift
@@ -40,9 +40,9 @@ enum BugReportServiceError: LocalizedError {
         switch self {
         case .uploadFailure(let error):
             return error.localizedDescription
-        case .serverError(let urlResponse, let errorDescription):
+        case .serverError(_, let errorDescription):
             return errorDescription
-        case .httpError(let httpResponse, let errorDescription):
+        case .httpError(_, let errorDescription):
             return errorDescription
         }
     }

--- a/UnitTests/Sources/BugReportServiceTests.swift
+++ b/UnitTests/Sources/BugReportServiceTests.swift
@@ -68,6 +68,31 @@ class BugReportServiceTests: XCTestCase {
         
         XCTAssertEqual(response.reportUrl, "https://example.com/123")
     }
+    
+    func testLogsMaxSize() {
+        // Given a new set of logs
+        var logs = BugReportService.Logs(maxFileSize: 1000)
+        XCTAssertEqual(logs.zippedSize, 0)
+        XCTAssertEqual(logs.originalSize, 0)
+        XCTAssertTrue(logs.files.isEmpty)
+        
+        // When adding new files within the size limit
+        logs.appendFile(at: .homeDirectory, zippedSize: 250, originalSize: 1000)
+        logs.appendFile(at: .picturesDirectory, zippedSize: 500, originalSize: 2000)
+        
+        // Then the logs should be included
+        XCTAssertEqual(logs.zippedSize, 750)
+        XCTAssertEqual(logs.originalSize, 3000)
+        XCTAssertEqual(logs.files, [.homeDirectory, .picturesDirectory])
+        
+        // When adding a new file larger that will exceed the size limit
+        logs.appendFile(at: .homeDirectory, zippedSize: 500, originalSize: 2000)
+        
+        // Then the files shouldn't be included.
+        XCTAssertEqual(logs.zippedSize, 750)
+        XCTAssertEqual(logs.originalSize, 3000)
+        XCTAssertEqual(logs.files, [.homeDirectory, .picturesDirectory])
+    }
 }
 
 private class MockURLProtocol: URLProtocol {

--- a/UnitTests/Sources/BugReportViewModelTests.swift
+++ b/UnitTests/Sources/BugReportViewModelTests.swift
@@ -64,7 +64,7 @@ class BugReportViewModelTests: XCTestCase {
         let mockService = BugReportServiceMock()
         mockService.submitBugReportProgressListenerClosure = { _, _ in
             await Task.yield()
-            return SubmitBugReportResponse(reportUrl: "https://test.test")
+            return .success(SubmitBugReportResponse(reportUrl: "https://test.test"))
         }
         let viewModel = BugReportScreenViewModel(bugReportService: mockService,
                                                  userID: "@mock.client.com",
@@ -90,7 +90,7 @@ class BugReportViewModelTests: XCTestCase {
     func testSendReportWithError() async throws {
         let mockService = BugReportServiceMock()
         mockService.submitBugReportProgressListenerClosure = { _, _ in
-            throw TestError.testError
+            .failure(.uploadFailure(TestError.testError))
         }
         let viewModel = BugReportScreenViewModel(bugReportService: mockService,
                                                  userID: "@mock.client.com",

--- a/changelog.d/pr-1018.change
+++ b/changelog.d/pr-1018.change
@@ -1,0 +1,1 @@
+Improve bug report uploads with file size checks and better error handling. 


### PR DESCRIPTION
This PR improves bug report uploading by
- Checking for a 200 response before decoding the response body.
- Showing the error from the server if the upload fails so its clearer what went wrong (as we can't get logs to find out)
- Chunking the log files every 10MB (before compression).
- Adding a max upload size and only adding files to the upload that don't exceed the limit.