### PR TITLE
Update the "remove avatar" logic in edit room details

### DIFF
--- a/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsEditScreen/RoomDetailsEditScreenViewModel.swift
@@ -66,11 +66,8 @@ class RoomDetailsEditScreenViewModel: RoomDetailsEditScreenViewModelType, RoomDe
         case .displayMediaPicker:
             actionsSubject.send(.displayMediaPicker)
         case .removeImage:
-            if state.localMedia != nil {
-                state.localMedia = nil
-            } else {
-                state.avatarURL = nil
-            }
+            state.avatarURL = nil
+            state.localMedia = nil
         }
     }
     

--- a/UnitTests/Sources/RoomDetailsEditScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomDetailsEditScreenViewModelTests.swift
@@ -108,6 +108,14 @@ class RoomDetailsEditScreenViewModelTests: XCTestCase {
         XCTAssertNotNil(userIndicatorController.alertInfo)
     }
     
+    func testDeleteAvatar() {
+        setupViewModel(accountOwner: .mockOwner(allowedStateEvents: [.roomAvatar, .roomName, .roomTopic]),
+                       roomProxyConfiguration: .init(name: "Some room", displayName: "Some room", avatarURL: .picturesDirectory))
+        XCTAssertNotNil(context.viewState.avatarURL)
+        context.send(viewAction: .removeImage)
+        XCTAssertNil(context.viewState.avatarURL)
+    }
+    
     // MARK: - Private
     
     private func setupViewModel(accountOwner: RoomMemberProxyMock, roomProxyConfiguration: RoomProxyMockConfiguration) {


### PR DESCRIPTION
This PR refactor the UX for removing the avatar in a room.
Now both the local image (if any) and the current avatar are removed together.

**Result**
![poc](https://github.com/vector-im/element-x-ios/assets/19324622/ee33e4e3-2262-41ad-a58a-d87e33e79def)