### PR TITLE
Media upload preview state machine crashes

### DIFF
--- a/ElementX/Sources/Screens/MediaPickerScreen/CameraPicker.swift
+++ b/ElementX/Sources/Screens/MediaPickerScreen/CameraPicker.swift
@@ -40,7 +40,7 @@ struct CameraPicker: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIImagePickerController {
         let imagePicker = UIImagePickerController()
         imagePicker.sourceType = .camera
-        imagePicker.allowsEditing = true
+        imagePicker.allowsEditing = false
         imagePicker.delegate = context.coordinator
         
         if let mediaTypes = UIImagePickerController.availableMediaTypes(for: .camera) {

--- a/ElementX/Sources/Screens/MediaPickerScreen/CameraPicker.swift
+++ b/ElementX/Sources/Screens/MediaPickerScreen/CameraPicker.swift
@@ -29,9 +29,11 @@ enum CameraPickerError: Error {
 }
 
 struct CameraPicker: UIViewControllerRepresentable {
+    private weak var userIndicatorController: UserIndicatorControllerProtocol?
     private let callback: (CameraPickerAction) -> Void
     
-    init(callback: @escaping (CameraPickerAction) -> Void) {
+    init(userIndicatorController: UserIndicatorControllerProtocol?, callback: @escaping (CameraPickerAction) -> Void) {
+        self.userIndicatorController = userIndicatorController
         self.callback = callback
     }
 
@@ -61,7 +63,16 @@ struct CameraPicker: UIViewControllerRepresentable {
             self.cameraPicker = cameraPicker
         }
         
+        private static let loadingIndicatorIdentifier = "CameraPickerLoadingIndicator"
+        
         func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            picker.delegate = nil
+            
+            cameraPicker.userIndicatorController?.submitIndicator(UserIndicator(id: Self.loadingIndicatorIdentifier, type: .modal, title: L10n.commonLoading))
+            defer {
+                cameraPicker.userIndicatorController?.retractIndicatorWithId(Self.loadingIndicatorIdentifier)
+            }
+            
             if let videoURL = info[.mediaURL] as? URL {
                 cameraPicker.callback(.selectFile(videoURL))
             } else if let image = info[.originalImage] as? UIImage {

--- a/ElementX/Sources/Screens/MediaPickerScreen/MediaPickerScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/MediaPickerScreen/MediaPickerScreenCoordinator.swift
@@ -48,7 +48,7 @@ class MediaPickerScreenCoordinator: CoordinatorProtocol {
         case .camera:
             cameraPicker
         case .photoLibrary:
-            PhotoLibraryPicker { [weak self] action in
+            PhotoLibraryPicker(userIndicatorController: userIndicatorController) { [weak self] action in
                 switch action {
                 case .cancel:
                     self?.callback?(.cancel)
@@ -62,7 +62,7 @@ class MediaPickerScreenCoordinator: CoordinatorProtocol {
         case .documents:
             // The document picker automatically dismisses everything on selection
             // Strongly retain self in the callback to forward actions correctly
-            DocumentPicker { action in
+            DocumentPicker(userIndicatorController: userIndicatorController) { action in
                 switch action {
                 case .cancel:
                     self.callback?(.cancel)
@@ -77,7 +77,7 @@ class MediaPickerScreenCoordinator: CoordinatorProtocol {
     }
     
     private var cameraPicker: some View {
-        CameraPicker { [weak self] action in
+        CameraPicker(userIndicatorController: userIndicatorController) { [weak self] action in
             switch action {
             case .cancel:
                 self?.callback?(.cancel)


### PR DESCRIPTION
The media pickers were allowing multiple selections if tapped fast enough which would in turn ask for media upload preview to be presented multiple times, which would lead to state machine crashes. This PR introduced loading indicators that show up when selecting media takes too long

Also disable "editing" on the resulting camera picker image