### PR TITLE
Parse output from IntegrationTests performance metrics

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,6 +46,33 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      - name: Archive raw file
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: raw-output
+          path: ~/Library/Logs/scan/IntegrationTests-IntegrationTests.log
+          retention-days: 2
+          if-no-files-found: ignore
+  
+     
+      - name: checkout gh-pages branch (for perf stats)
+        if: always()
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Post-process archive to obtain performance metrics and upload to gh-pages
+        if: always()
+        run: |
+          ./Tools/Scripts/parsePerformanceMetrics.sh ~/Library/Logs/scan/IntegrationTests-IntegrationTests.log $GITHUB_SHA | tee perf-results.csv
+          cat perf-results.csv >> $GITHUB_WORKSPACE/gh-pages/performance/perf-data.csv
+          cd $GITHUB_WORKSPACE/gh-pages/performance/
+          git add .
+          git commit -m "Results for $GITHUB_SHA"
+          git push
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,17 +46,17 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-      - name: Archive raw file
+      - name: Archive raw log file
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: raw-output
+          name: raw.log
           path: ~/Library/Logs/scan/IntegrationTests-IntegrationTests.log
           retention-days: 2
           if-no-files-found: ignore
   
      
-      - name: checkout gh-pages branch (for perf stats)
+      - name: Checkout gh-pages branch (for perf stats)
         if: always()
         uses: actions/checkout@v3
         with:

--- a/Tools/Scripts/parsePerformanceMetrics.sh
+++ b/Tools/Scripts/parsePerformanceMetrics.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Parses performance metrics from the full report of a IntegrationTest run (do not use xcpretty first!)
+# This file can normally be found in `~/Library/Logs/scan/IntegrationTests-IntegrationTests.log`
+
+# Provide file as $1
+# Provide identifier (eg, date, GITHUB_SHA) as $2
+
+echo "Parsing $1 for test results with identifier $2" >&2
+
+NOW=`date -u -Iminutes`
+
+# Find all the measurement lines in the file, then strip out the gumph into a CSV-like format.
+grep ".*measured.*values" $1 | sed -e "s/.*Test Case .*-\[//" -e "s/\]' measured \[/,/" -e "s/\].*values: \[/,/" -e "s/\], performance.*//" -e "s/^/$2,/" \
+   -e "s/IntegrationTests.ApplicationTests testLaunchPerformance,Duration (AppLaunch), s/launchPerformance/" \
+   -e "s/IntegrationTests.LoginTests testLoginFlow/loginPerformance/" \
+   -e "s/^/$NOW,/"
+
+# The output should contain fields for the identifier, name, type, unit, then a list of recorded values (normally 5)
+
+# Put this into a file somewhere for later usage.


### PR DESCRIPTION
In order to track performance changes over time; this PR appends metrics pulled from the nightly integration tests into a csv on the gh-pages branch.

We can then either pull the csv locally to poke at in libreoffice, or use a simple charting library to render the change in performance over time.

The code is written to fairly easily expand the coverage over time; and if mistakes get into the CSV we can just .. edit the CSV and fix them / delete bad data.

I know we could upload data into grafana or into metabase or ... something else; but this way should give us data we can look at easily from a web browser.

Demo of this working / the final result on a copy of the repo.

https://michaelkaye.github.io/element-x-ios/performance/
https://michaelkaye.github.io/element-x-ios/performance/perf-data.csv

If people are happy with this, before we merge we should create the gh-pages branch (with a minimal history) and copy over the index.html to render the graphs.It's just a html page to fiddle with as well; if someone wants to improve the graphs or make them dynamically filterable or whatever;  the raw data in the CSV is still going to be a fairly permanent source.

Part of the work for https://github.com/vector-im/internal-planning/issues/448