### PR TITLE
Tweak to parsing of performance data

### DIFF
--- a/Tools/Scripts/parsePerformanceMetrics.sh
+++ b/Tools/Scripts/parsePerformanceMetrics.sh
@@ -13,7 +13,7 @@ NOW=`date -u -Iminutes`
 # Find all the measurement lines in the file, then strip out the gumph into a CSV-like format.
 grep ".*measured.*values" $1 | sed -e "s/.*Test Case .*-\[//" -e "s/\]' measured \[/,/" -e "s/\].*values: \[/,/" -e "s/\], performance.*//" -e "s/^/$2,/" \
    -e "s/IntegrationTests.ApplicationTests testLaunchPerformance,Duration (AppLaunch), s/launchPerformance/" \
-   -e "s/IntegrationTests.LoginTests testLoginFlow/loginPerformance/" \
+   -e "s/IntegrationTests.LoginTests testLoginFlow,Clock Monotonic Time, s/loginPerformance/" \
    -e "s/^/$NOW,/"
 
 # The output should contain fields for the identifier, name, type, unit, then a list of recorded values (normally 5)


### PR DESCRIPTION
Tiny change to parser of performance data; my test data didn't include this part,  but it does exist when run in GHA. I'm not sure whether this format is actually that stable across versions; hopefully we can iterate over time if it comes to it.