### PR TITLE
Fix navigation title in "invite people" scene

### DIFF
--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -24,7 +24,7 @@ struct InviteUsersScreen: View {
         mainContent
             .elementFormStyle()
             .scrollDismissesKeyboard(.immediately)
-            .navigationTitle(L10n.screenCreateRoomActionInvitePeople)
+            .navigationTitle(L10n.screenCreateRoomAddPeopleTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {


### PR DESCRIPTION
 A navigation title key was wrong.
 
 UI tests are good since the pervious value of the old key had the same copy of the current one.
 
 **Result**
![result](https://github.com/vector-im/element-x-ios/assets/19324622/4e1c380f-0f48-46e6-b067-65431b87453c)