### PR TITLE
Fix regression on direct chat details

### DIFF
--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -159,6 +159,6 @@ extension RoomProxyProtocol {
     }
     
     var isEncryptedOneToOneRoom: Bool {
-        isDirect && isEncrypted && joinedMembersCount == 2
+        isDirect && isEncrypted && activeMembersCount == 2
     }
 }


### PR DESCRIPTION
Fixes a regression introduced [here](https://github.com/vector-im/element-x-ios/pull/1050).
After the fix the room's details will have the "direct chat appearance" even if one of the user needs to still accept the invite.