### PR TITLE
Fixes #1072 - Crashes when trying to save media to the photo library

### DIFF
--- a/ElementX/SupportingFiles/Info.plist
+++ b/ElementX/SupportingFiles/Info.plist
@@ -30,6 +30,8 @@
 	<string>The camera is used to take and upload photos and videos.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>The microphone is used to take videos.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Allows saving photos and videos to your library.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>INSendMessageIntent</string>

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -64,6 +64,7 @@ targets:
         ]
         NSCameraUsageDescription: The camera is used to take and upload photos and videos.
         NSMicrophoneUsageDescription: The microphone is used to take videos.
+        NSPhotoLibraryAddUsageDescription: Allows saving photos and videos to your library.
         UIBackgroundModes: [
           fetch
         ]

--- a/changelog.d/1072.bugfix
+++ b/changelog.d/1072.bugfix
@@ -1,0 +1,1 @@
+Fixed crashes when trying to save media to the photo library


### PR DESCRIPTION
The saving is powered by system dialogs but we need to specify `NSPhotoLibraryAddUsageDescription` in order for them to work.