### PR TITLE
Fix nightly icon label generation after switching to single image source

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -373,13 +373,12 @@ private_lane :update_app_icon do |options|
     # Change the icons color
     sh("convert '#{file_name}' -modulate #{modulate} '#{file_name}'")
 
-    caption_width = sh("identify -format %w '#{file_name}'")
-    caption_height = file_name.end_with?("@2x.png") ? 60 : 30
-    if caption_width.to_i > caption_height*2 then
+    image_width = sh("identify -format %w '#{file_name}'")
+    image_height = sh("identify -format %h '#{file_name}'").to_i
+    caption_height = image_height / 5
 
-      # Add a label on top
-      sh("convert -background '#0008' -fill white -gravity center -size '#{caption_width}'x'#{caption_height}' caption:'#{caption_text}' '#{file_name}' +swap -gravity south -composite '#{file_name}'")
-    end
+    # Add a label on top
+    sh("convert -background '#0008' -fill white -gravity center -size '#{image_width}'x'#{caption_height}' caption:'#{caption_text}' '#{file_name}' +swap -gravity south -composite '#{file_name}'")
   end
 end
 


### PR DESCRIPTION
- it was technically wrong before as it was hardcoded to 30 points for all images
- now it's reading the image height and using a fifth of it