### PR TITLE
Invitation Notification design improvements and navigation

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -155,8 +155,15 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
         }
         
         // Handle here the account switching when available
-        
-        handleAppRoute(.room(roomID: roomID))
+
+        switch content.categoryIdentifier {
+        case NotificationConstants.Category.message:
+            handleAppRoute(.room(roomID: roomID))
+        case NotificationConstants.Category.invite:
+            handleAppRoute(.invites)
+        default:
+            break
+        }
     }
     
     func handleInlineReply(_ service: NotificationManagerProtocol, content: UNNotificationContent, replyText: String) async {

--- a/ElementX/Sources/Application/FlowCoordinatorProtocol.swift
+++ b/ElementX/Sources/Application/FlowCoordinatorProtocol.swift
@@ -19,4 +19,5 @@ import Foundation
 @MainActor
 protocol FlowCoordinatorProtocol {
     func handleAppRoute(_ appRoute: AppRoute, animated: Bool)
+    func clearRoute(animated: Bool)
 }

--- a/ElementX/Sources/Application/Navigation/AppRouter.swift
+++ b/ElementX/Sources/Application/Navigation/AppRouter.swift
@@ -22,6 +22,7 @@ enum AppRoute {
     case roomList
     case room(roomID: String)
     case roomDetails(roomID: String)
+    case invites
 }
 
 struct AppRouterManager {

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -299,9 +299,8 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     }
     
     private func dismissRoom(animated: Bool) {
-        // The room isn't in the same navigation stack of the home screen.
-        // Animating the popToRoot causes weird animations on when the room is left from room's details
-        navigationStackCoordinator.popToRoot(animated: false)
+        // Setting the detail coordinator to nil afirst allows the dismiss to work properly
+        // if followed immediately by another navigation on iPhone
         navigationSplitCoordinator.setDetailCoordinator(nil, animated: animated)
         navigationStackCoordinator.popToRoot(animated: animated)
         roomProxy = nil

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -71,7 +71,16 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             stateMachine.tryEvent(.presentRoomDetails(roomID: roomID), userInfo: EventUserInfo(animated: animated))
         case .roomList:
             stateMachine.tryEvent(.dismissRoom, userInfo: EventUserInfo(animated: animated))
+        case .invites:
+            break
         }
+    }
+
+    func clearRoute(animated: Bool) {
+        guard stateMachine.state != .initial else {
+            return
+        }
+        stateMachine.tryEvent(.dismissRoom, userInfo: EventUserInfo(animated: animated))
     }
     
     // MARK: - Private
@@ -294,6 +303,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         // Animating the popToRoot causes weird animations on when the room is left from room's details
         navigationStackCoordinator.popToRoot(animated: false)
         navigationSplitCoordinator.setDetailCoordinator(nil, animated: animated)
+        navigationStackCoordinator.popToRoot(animated: animated)
         roomProxy = nil
         timelineController = nil
         

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -302,7 +302,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         // Setting the detail coordinator to nil afirst allows the dismiss to work properly
         // if followed immediately by another navigation on iPhone
         navigationSplitCoordinator.setDetailCoordinator(nil, animated: animated)
-        navigationStackCoordinator.popToRoot(animated: animated)
+        navigationStackCoordinator.popToRoot(animated: false)
         roomProxy = nil
         timelineController = nil
         

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -96,7 +96,9 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         case .room, .roomDetails, .roomList:
             roomFlowCoordinator.handleAppRoute(appRoute, animated: animated)
         case .invites:
-            roomFlowCoordinator.clearRoute(animated: animated)
+            if UIDevice.current.isPhone {
+                roomFlowCoordinator.clearRoute(animated: animated)
+            }
             stateMachine.processEvent(.showInvitesScreen, userInfo: .init(animated: animated))
         }
     }
@@ -148,6 +150,8 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                 
             case (.roomList, .showInvitesScreen, .invitesScreen):
                 self.presentInvitesList(animated: animated)
+            case (.invitesScreen, .showInvitesScreen, .invitesScreen):
+                break
             case (.invitesScreen, .closedInvitesScreen, .roomList):
                 break
                 

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -91,11 +91,18 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         case .roomList, .initial:
             break
         }
-        
+
         switch appRoute {
         case .room, .roomDetails, .roomList:
             roomFlowCoordinator.handleAppRoute(appRoute, animated: animated)
+        case .invites:
+            roomFlowCoordinator.clearRoute(animated: animated)
+            stateMachine.processEvent(.showInvitesScreen, userInfo: .init(animated: animated))
         }
+    }
+
+    func clearRoute(animated: Bool) {
+        fatalError("not necessary as of right now")
     }
 
     // MARK: - Private

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
@@ -131,6 +131,9 @@ class UserSessionFlowCoordinatorStateMachine {
             
             case (.showInvitesScreen, .roomList(let selectedRoomId)):
                 return .invitesScreen(selectedRoomId: selectedRoomId)
+            case (.showInvitesScreen, .invitesScreen(let selectedRoomId)):
+                return .invitesScreen(selectedRoomId: selectedRoomId)
+
             case (.closedInvitesScreen, .invitesScreen(let selectedRoomId)):
                 return .roomList(selectedRoomId: selectedRoomId)
                 

--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -18,24 +18,13 @@ import Foundation
 import Intents
 import UserNotifications
 
-enum NotificationIconType {
-    case sender(mediaSource: MediaSourceProxy?)
-    case group(mediaSource: MediaSourceProxy?, groupName: String)
+struct NotificationIcon {
+    let mediaSource: MediaSourceProxy?
+    // Requrted as the key to set images for groups
+    let groupName: String?
 
-    var mediaSource: MediaSourceProxy? {
-        switch self {
-        case .group(let mediaSource, _), .sender(let mediaSource):
-            return mediaSource
-        }
-    }
-
-    var isSenderIcon: Bool {
-        switch self {
-        case .sender:
-            return true
-        case .group:
-            return false
-        }
+    var shouldDisplayAsGroup: Bool {
+        groupName != nil
     }
 }
 
@@ -122,9 +111,9 @@ extension UNMutableNotificationContent {
     func addSenderIcon(using mediaProvider: MediaProviderProtocol?,
                        senderID: String,
                        senderName: String,
-                       iconType: NotificationIconType) async throws -> UNMutableNotificationContent {
+                       icon: NotificationIcon) async throws -> UNMutableNotificationContent {
         var image = INImage(named: "")
-        if let mediaSource = iconType.mediaSource {
+        if let mediaSource = icon.mediaSource {
             switch await mediaProvider?.loadImageDataFromSource(mediaSource) {
             case .success(let data):
                 image = INImage(imageData: data)
@@ -139,14 +128,14 @@ extension UNMutableNotificationContent {
         let sender = INPerson(personHandle: senderHandle,
                               nameComponents: nil,
                               displayName: senderName,
-                              image: iconType.isSenderIcon ? image : nil,
+                              image: !icon.shouldDisplayAsGroup ? image : nil,
                               contactIdentifier: nil,
                               customIdentifier: nil)
 
         // These are required to show the group name as subtitle
         var speakableGroupName: INSpeakableString?
         var recipients: [INPerson]?
-        if case let .group(_, groupName) = iconType {
+        if let groupName = icon.groupName {
             let meHandle = INPersonHandle(value: receiverID, type: .unknown)
             let me = INPerson(personHandle: meHandle, nameComponents: nil, displayName: nil, image: nil, contactIdentifier: nil, customIdentifier: nil, isMe: true)
             speakableGroupName = INSpeakableString(spokenPhrase: groupName)

--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -20,7 +20,7 @@ import UserNotifications
 
 struct NotificationIcon {
     let mediaSource: MediaSourceProxy?
-    // Requrted as the key to set images for groups
+    // Required as the key to set images for groups
     let groupName: String?
 
     var shouldDisplayAsGroup: Bool {

--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -246,21 +246,22 @@ extension NotificationItemProxyProtocol {
 
         notification.categoryIdentifier = NotificationConstants.Category.invite
 
-        var iconType: NotificationIconType
-        let senderName = senderDisplayName ?? roomDisplayName
-
+        let icon: NotificationIcon
+        let body: String
         if !isDirect {
-            iconType = .group(mediaSource: roomAvatarMediaSource, groupName: roomDisplayName)
+            icon = NotificationIcon(mediaSource: roomAvatarMediaSource, groupName: nil)
+            body = L10n.notificationRoomInviteBody(roomDisplayName)
         } else {
-            iconType = .sender(mediaSource: senderAvatarMediaSource)
+            icon = NotificationIcon(mediaSource: senderAvatarMediaSource, groupName: nil)
+            body = L10n.notificationInviteBody
         }
 
         notification = try await notification.addSenderIcon(using: mediaProvider,
                                                             senderID: event.senderID,
-                                                            senderName: senderName,
-                                                            iconType: iconType)
-
-        notification.body = L10n.notificationInviteBody
+                                                            senderName: senderDisplayName ?? roomDisplayName,
+                                                            icon: icon)
+        notification.body = body
+        
         return notification
     }
 
@@ -300,17 +301,17 @@ extension NotificationItemProxyProtocol {
         notification.categoryIdentifier = NotificationConstants.Category.message
 
         let senderName = senderDisplayName ?? roomDisplayName
-        let iconType: NotificationIconType
+        let icon: NotificationIcon
         if !isDirect {
-            iconType = .group(mediaSource: roomAvatarMediaSource, groupName: roomDisplayName)
+            icon = NotificationIcon(mediaSource: roomAvatarMediaSource, groupName: roomDisplayName)
         } else {
-            iconType = .sender(mediaSource: senderAvatarMediaSource)
+            icon = NotificationIcon(mediaSource: senderAvatarMediaSource, groupName: nil)
         }
 
         notification = try await notification.addSenderIcon(using: mediaProvider,
                                                             senderID: event.senderID,
                                                             senderName: senderName,
-                                                            iconType: iconType)
+                                                            icon: icon)
         return notification
     }
 

--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -41,8 +41,10 @@ protocol NotificationItemProxyProtocol {
 
     var isDirect: Bool { get }
 
+    /// Returns `true` if the event of the notification belongs to an encrypted room
     var isRoomEncrypted: Bool? { get }
 
+    /// Returns `true` if was not possible to decrypt the notification content
     var isEncrypted: Bool { get }
 }
 

--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -249,8 +249,8 @@ extension NotificationItemProxyProtocol {
         let icon: NotificationIcon
         let body: String
         if !isDirect {
-            icon = NotificationIcon(mediaSource: roomAvatarMediaSource, groupName: nil)
-            body = L10n.notificationRoomInviteBody(roomDisplayName)
+            icon = NotificationIcon(mediaSource: roomAvatarMediaSource, groupName: roomDisplayName)
+            body = L10n.notificationRoomInviteBody
         } else {
             icon = NotificationIcon(mediaSource: senderAvatarMediaSource, groupName: nil)
             body = L10n.notificationInviteBody


### PR DESCRIPTION
This is only going to work properly when the two sync loop is released, but since it's its own separate piece of work, and is not going to impact the current invite notifications (since they appear as generic ones most of the time), it's nice to already have it ready for when the two sync loop is ready

NOTE:
This branch is mostly cherry picks of the Two Syncs branch