### PR TITLE
Fix room's details state after that the other person leaves the room

### DIFF
--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -165,7 +165,7 @@ extension RoomProxyProtocol {
     }
     
     var isEncryptedOneToOneRoom: Bool {
-        isDirect && isEncrypted && activeMembersCount == 2
+        isDirect && isEncrypted && activeMembersCount <= 2
     }
 
     func members() async -> [RoomMemberProxyProtocol]? {


### PR DESCRIPTION
Fixes a problem that made the room's details as a normal group chat after that the other person left a direct room.

| Before | After |
| --- | --- |
|![b](https://github.com/vector-im/element-x-ios/assets/19324622/32fc13d9-9d35-4dd3-ae7d-fa9fdcae54bf)|![a](https://github.com/vector-im/element-x-ios/assets/19324622/5e0d48fc-50c7-4c55-98eb-57f1f69631ed)|


