### PR TITLE
Loading state functions

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -377,6 +377,8 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
     }
     
     private func tearDownUserSession() {
+        ServiceLocator.shared.userIndicatorController.retractAllIndicators()
+        
         userSession = nil
         
         userSessionFlowCoordinator = nil

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -401,8 +401,7 @@ class ClientProxy: ClientProxyProtocol {
                     Task {
                         // Subscribe to invites later as the underlying SlidingSync list is only added when entering AllRooms
                         await self.inviteSummaryProvider?.subscribeIfNecessary(entriesFunction: roomListService.invites(listener:),
-                                                                               // This state function is wrong but it's not used
-                                                                               entriesLoadingStateFunction: roomListService.entriesLoadingState(listener:))
+                                                                               entriesLoadingStateFunction: nil)
                     }
                 }
             })

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
@@ -42,8 +42,8 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
         }
     }
     
-    func subscribeIfNecessary(entriesFunction: (RoomListEntriesListener) async throws -> RoomListEntriesResult,
-                              entriesLoadingStateFunction: (SlidingSyncListStateObserver) async throws -> RoomListEntriesLoadingStateResult) { }
+    func subscribeIfNecessary(entriesFunction: EntriesFunction,
+                              entriesLoadingStateFunction: LoadingStateFunction?) async { }
     
     func updateVisibleRange(_ range: Range<Int>) { }
 }

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
@@ -58,6 +58,9 @@ enum RoomSummary: CustomStringConvertible {
 }
 
 protocol RoomSummaryProviderProtocol {
+    typealias EntriesFunction = (RoomListEntriesListener) async throws -> RoomListEntriesResult
+    typealias LoadingStateFunction = (SlidingSyncListStateObserver) async throws -> RoomListEntriesLoadingStateResult
+    
     /// Publishes the currently available room summaries
     var roomListPublisher: CurrentValuePublisher<[RoomSummary], Never> { get }
     
@@ -66,8 +69,8 @@ protocol RoomSummaryProviderProtocol {
     
     /// A separate subscription method is needed instead of running this in the constructor because the invites list is added later on the Rust side.
     /// Wanted to be able to build the InvitesSummaryProvider directly instead of having to inform the HomeScreenViewModel about it later
-    func subscribeIfNecessary(entriesFunction: (RoomListEntriesListener) async throws -> RoomListEntriesResult,
-                              entriesLoadingStateFunction: (SlidingSyncListStateObserver) async throws -> RoomListEntriesLoadingStateResult) async
+    func subscribeIfNecessary(entriesFunction: EntriesFunction,
+                              entriesLoadingStateFunction: LoadingStateFunction?) async
     
     func updateVisibleRange(_ range: Range<Int>)
 }


### PR DESCRIPTION
* Prevent invites from stealing away the roomList's state listener
* Retract all user indicators when tearing down the user session