### PR TITLE
Fixes #1102 - Crashes when opening the invites screen

### DIFF
--- a/ElementX/Sources/Screens/InvitesScreen/InvitesScreenModels.swift
+++ b/ElementX/Sources/Screens/InvitesScreen/InvitesScreenModels.swift
@@ -19,7 +19,7 @@ enum InvitesScreenViewModelAction {
 }
 
 struct InvitesScreenViewState: BindableState {
-    var invites: [InvitesScreenRoomDetails]?
+    var invites: [InvitesScreenRoomDetails] = []
     var bindings: InvitesScreenViewStateBindings = .init()
 }
 
@@ -27,13 +27,17 @@ struct InvitesScreenViewStateBindings {
     var alertInfo: AlertInfo<Bool>?
 }
 
-struct InvitesScreenRoomDetails {
+struct InvitesScreenRoomDetails: Identifiable {
     let roomDetails: RoomSummaryDetails
     var inviter: RoomMemberProxyProtocol?
     var isUnread: Bool
     
     var isDirect: Bool {
         roomDetails.isDirect
+    }
+    
+    var id: String {
+        roomDetails.id
     }
 }
 

--- a/ElementX/Sources/Screens/InvitesScreen/InvitesScreenViewModel.swift
+++ b/ElementX/Sources/Screens/InvitesScreen/InvitesScreenViewModel.swift
@@ -95,11 +95,11 @@ class InvitesScreenViewModel: InvitesScreenViewModelType, InvitesScreenViewModel
             
             let inviter: RoomMemberProxyProtocol? = await room.inviter()
             
-            guard let inviter, let inviteIndex = state.invites?.firstIndex(where: { $0.roomDetails.id == roomID }) else {
+            guard let inviter, let inviteIndex = state.invites.firstIndex(where: { $0.roomDetails.id == roomID }) else {
                 return
             }
             
-            state.invites?[inviteIndex].inviter = inviter
+            state.invites[inviteIndex].inviter = inviter
         }
     }
     

--- a/ElementX/Sources/Screens/InvitesScreen/View/InvitesScreen.swift
+++ b/ElementX/Sources/Screens/InvitesScreen/View/InvitesScreen.swift
@@ -21,9 +21,9 @@ struct InvitesScreen: View {
     
     var body: some View {
         ScrollView {
-            if let rooms = context.viewState.invites, !rooms.isEmpty {
+            if !context.viewState.invites.isEmpty {
                 LazyVStack(spacing: 0) {
-                    ForEach(rooms, id: \.roomDetails.id) { invite in
+                    ForEach(context.viewState.invites) { invite in
                         InvitesScreenCell(invite: invite,
                                           imageProvider: context.imageProvider,
                                           acceptAction: { context.send(viewAction: .accept(invite)) },

--- a/changelog.d/1102.bugfix
+++ b/changelog.d/1102.bugfix
@@ -1,0 +1,1 @@
+Fixed crashes when opening the invites screen


### PR DESCRIPTION
For some reason that still eludes me opening invites crashed on opening the screen while accessing the view state, **only** on release builds.
The fix is to make them non-optional and, while I have no idea why that works, it's simple enough to not warrant any further investigation