### PR TITLE
Add posthog events (#1097)

### DIFF
--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -231,7 +231,6 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         }
     }
     
-    
     /// Updates the navigation stack so it displays the timeline for the given room
     /// - Parameters:
     ///   - roomID: the identifier of the room that is to be presented
@@ -282,6 +281,8 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
                                                                                            timelineItemFactory: timelineItemFactory,
                                                                                            mediaProvider: userSession.mediaProvider)
         self.timelineController = timelineController
+        
+        ServiceLocator.shared.analytics.trackViewRoom(roomProxy)
         
         let parameters = RoomScreenCoordinatorParameters(roomProxy: roomProxy,
                                                          timelineController: timelineController,

--- a/ElementX/Sources/Screens/InvitesScreen/View/InvitesScreen.swift
+++ b/ElementX/Sources/Screens/InvitesScreen/View/InvitesScreen.swift
@@ -37,6 +37,7 @@ struct InvitesScreen: View {
         .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
         .navigationTitle(L10n.actionInvitesList)
         .alert(item: $context.alertInfo)
+        .track(screen: .invites)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/RoomDetailsEditScreen/View/RoomDetailsEditScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsEditScreen/View/RoomDetailsEditScreen.swift
@@ -36,6 +36,7 @@ struct RoomDetailsEditScreen: View {
         .navigationTitle(L10n.screenRoomDetailsEditRoomTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { toolbar }
+        .track(screen: .roomSettings)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
@@ -60,6 +60,7 @@ struct RoomDetailsScreen: View {
                 }
             }
         }
+        .track(screen: .roomDetails)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
@@ -30,6 +30,7 @@ struct RoomMemberDetailsScreen: View {
         .elementFormStyle()
         .alert(item: $context.ignoreUserAlert, actions: blockUserAlertActions, message: blockUserAlertMessage)
         .alert(item: $context.alertInfo)
+        .track(screen: .user)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/View/RoomMembersListScreen.swift
@@ -39,6 +39,7 @@ struct RoomMembersListScreen: View {
                 inviteButton
             }
         }
+        .track(screen: .roomMembers)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Services/Analytics/Analytics.swift
+++ b/ElementX/Sources/Services/Analytics/Analytics.swift
@@ -148,4 +148,15 @@ extension Analytics {
             await capture(event: AnalyticsEvent.ViewRoom(activeSpace: nil, isDM: roomProxy.isDirect, isSpace: roomProxy.isSpace, trigger: nil, viaKeyboard: nil))
         }
     }
+    
+    /// Track the action of joining a room
+    func trackJoinedRoom(_ roomProxy: RoomProxyProtocol) {
+        Task {
+            guard let roomSize = await AnalyticsEvent.JoinedRoom.RoomSize(memberCount: UInt(roomProxy.activeMembersCount)) else {
+                MXLog.error("invalid room size")
+                return
+            }
+            await capture(event: AnalyticsEvent.JoinedRoom(isDM: roomProxy.isDirect, isSpace: roomProxy.isSpace, roomSize: roomSize, trigger: nil))
+        }
+    }
 }

--- a/ElementX/Sources/Services/Analytics/Analytics.swift
+++ b/ElementX/Sources/Services/Analytics/Analytics.swift
@@ -141,4 +141,11 @@ extension Analytics {
     func trackComposer(inThread: Bool, isEditing: Bool, isReply: Bool, startsThread: Bool?) {
         capture(event: AnalyticsEvent.Composer(inThread: inThread, isEditing: isEditing, isReply: isReply, startsThread: startsThread))
     }
+    
+    /// Track the presentation of a room
+    func trackViewRoom(_ roomProxy: RoomProxyProtocol) {
+        Task {
+            await capture(event: AnalyticsEvent.ViewRoom(activeSpace: nil, isDM: roomProxy.isDirect, isSpace: roomProxy.isSpace, trigger: nil, viaKeyboard: nil))
+        }
+    }
 }

--- a/ElementX/Sources/Services/Analytics/Analytics.swift
+++ b/ElementX/Sources/Services/Analytics/Analytics.swift
@@ -131,4 +131,14 @@ extension Analytics {
     func trackCreatedRoom(isDM: Bool) {
         capture(event: AnalyticsEvent.CreatedRoom(isDM: isDM))
     }
+    
+    /// Track the composer
+    /// - Parameters:
+    ///   - inThread: whether the composer is used in a Thread
+    ///   - isEditing: whether the composer is used to edit a message
+    ///   - isReply: whether the composer is used to reply a message
+    ///   - startsThread: whether the composer is used to start a new thread
+    func trackComposer(inThread: Bool, isEditing: Bool, isReply: Bool, startsThread: Bool?) {
+        capture(event: AnalyticsEvent.Composer(inThread: inThread, isEditing: isEditing, isReply: isReply, startsThread: startsThread))
+    }
 }

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -506,7 +506,9 @@ class RoomProxy: RoomProxyProtocol {
     func acceptInvitation() async -> Result<Void, RoomProxyError> {
         await Task.dispatch(on: .global()) {
             do {
-                return try .success(self.room.acceptInvitation())
+                try self.room.acceptInvitation()
+                ServiceLocator.shared.analytics.trackJoinedRoom(self)
+                return .success(())
             } catch {
                 return .failure(.failedAcceptingInvite)
             }


### PR DESCRIPTION
This PR add some missing posthog events as requested by #1097 

Added events:
- `Composer`
- `ViewRoom`
- `JoinedRoom`

Added screens:
- `invites`
- `roomDetails`
- `roomMembers`
- `roomSettings`
- `user`