### PR TITLE
Render emote notifications like in the timeline

### DIFF
--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -360,7 +360,7 @@ extension NotificationItemProxyProtocol {
     private func processEmote(content: EmoteMessageContent,
                               mediaProvider: MediaProviderProtocol?) async throws -> UNMutableNotificationContent {
         let notification = try await processCommon(mediaProvider: mediaProvider)
-        notification.body = "🫥 " + content.body
+        notification.body = L10n.commonEmote(senderDisplayName ?? roomDisplayName, content.body)
 
         return notification
     }

--- a/changelog.d/1117.feature
+++ b/changelog.d/1117.feature
@@ -1,0 +1,1 @@
+Render emote notifications like in the timeline


### PR DESCRIPTION
This uses the `* DISPLAYNAME ...` format that's also used in the timeline to render emotes. It's likely not exactly perfect, but emotes are used fairly widely and this at least makes their notifications look somewhat less WIP than the 🫥 emoji prefix.

Fixes: #1117