### PR TITLE
Handling cancelled as a sendingFailed case

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineItemStatusView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineItemStatusView.swift
@@ -74,8 +74,6 @@ struct TimelineItemStatusView: View {
                         context.sendFailedConfirmationDialogInfo = .init(transactionID: timelineItem.properties.transactionID)
                     }
             }
-        case .cancelled:
-            EmptyView()
         }
     }
 

--- a/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
@@ -39,7 +39,6 @@ enum TimelineItemDeliveryStatus: Hashable {
     case sending
     case sent
     case sendingFailed
-    case cancelled
 }
 
 /// A light wrapper around event timeline items returned from Rust.
@@ -66,12 +65,11 @@ struct EventTimelineItemProxy {
         switch localSendState {
         case .notSentYet:
             return .sending
-        case .sendingFailed:
+        // cancelled is exactly like sendingFailed but does not contain an error
+        case .sendingFailed, .cancelled:
             return .sendingFailed
         case .sent:
             return .sent
-        case .cancelled:
-            return .cancelled
         }
     }
         

--- a/changelog.d/1160.bugfix
+++ b/changelog.d/1160.bugfix
@@ -1,0 +1,1 @@
+Handled the cancelled state of a message properly as a failure state.


### PR DESCRIPTION
There is no reason on the app side for which this state should be handled differently from the sendingFailed case.
