### PR TITLE
Filter out some actions for failed local echoes

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -355,18 +355,13 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             .reply
         ]
         
-        if timelineItem is EventBasedMessageTimelineItemProtocol {
-            actions.append(.forward(itemID: itemId))
-        }
-        
+        actions.append(.forward(itemID: itemId))
+
         if item.isEditable {
             actions.append(.edit)
         }
         
-        if timelineItem is EventBasedMessageTimelineItemProtocol {
-            actions.append(.copy)
-        }
-        
+        actions.append(.copy)
         actions.append(.copyPermalink)
         
         if item.isOutgoing {
@@ -381,7 +376,15 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
            case let .megolmV1AesSha2(sessionID) = item.encryptionType {
             debugActions.append(.retryDecryption(sessionID: sessionID))
         }
-        
+
+        if item.hasFailedToSend {
+            actions = actions.filter(\.canAppearInFailedEcho)
+        }
+
+        if item is RedactedRoomTimelineItem {
+            actions = actions.filter(\.canAppearInRedacted)
+        }
+
         return .init(actions: actions, debugActions: debugActions)
     }
     
@@ -416,7 +419,12 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             }
         case .redact:
             Task {
-                await timelineController.redact(itemID)
+                if eventTimelineItem.hasFailedToSend,
+                   let transactionID = eventTimelineItem.properties.transactionID {
+                    await timelineController.cancelSend(transactionID)
+                } else {
+                    await timelineController.redact(itemID)
+                }
             }
         case .reply:
             state.bindings.composerFocused = true

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -354,14 +354,19 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         var actions: [TimelineItemMenuAction] = [
             .reply
         ]
-        
-        actions.append(.forward(itemID: itemId))
+
+        if item.isMessage {
+            actions.append(.forward(itemID: itemId))
+        }
 
         if item.isEditable {
             actions.append(.edit)
         }
+
+        if item.isMessage {
+            actions.append(.copy)
+        }
         
-        actions.append(.copy)
         actions.append(.copyPermalink)
         
         if item.isOutgoing {
@@ -381,7 +386,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             actions = actions.filter(\.canAppearInFailedEcho)
         }
 
-        if item is RedactedRoomTimelineItem {
+        if item.isRedacted {
             actions = actions.filter(\.canAppearInRedacted)
         }
 

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -151,7 +151,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
 
     @ViewBuilder
     var interactiveLocalizedSendInfo: some View {
-        if timelineItem.properties.deliveryStatus == .sendingFailed {
+        if timelineItem.hasFailedToSend {
             backgroundedLocalizedSendInfo
                 .onTapGesture {
                     context.sendFailedConfirmationDialogInfo = .init(transactionID: timelineItem.properties.transactionID)
@@ -186,12 +186,12 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                 Text(timelineItem.timestamp)
             }
 
-            if timelineItem.properties.deliveryStatus == .sendingFailed {
+            if timelineItem.hasFailedToSend {
                 Image(systemName: "exclamationmark.circle.fill")
             }
         }
         .font(.compound.bodyXS)
-        .foregroundColor(timelineItem.properties.deliveryStatus == .sendingFailed ? .compound.textCriticalPrimary : .compound.textSecondary)
+        .foregroundColor(timelineItem.hasFailedToSend ? .compound.textCriticalPrimary : .compound.textSecondary)
         .padding(.bottom, shouldFillBubble ? 0 : -4)
     }
     

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextBasedRoomTimelineViewProtocol.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextBasedRoomTimelineViewProtocol.swift
@@ -32,7 +32,7 @@ extension TextBasedRoomTimelineViewProtocol {
         }
 
         // To account for the extra spacing created by the alert icon
-        if timelineItem.properties.deliveryStatus == .sendingFailed {
+        if timelineItem.hasFailedToSend {
             whiteSpaces += 3
         }
 

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemMenu.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemMenu.swift
@@ -51,6 +51,24 @@ enum TimelineItemMenuAction: Identifiable, Hashable {
             return true
         }
     }
+
+    var canAppearInFailedEcho: Bool {
+        switch self {
+        case .copy, .redact, .viewSource:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var canAppearInRedacted: Bool {
+        switch self {
+        case .viewSource:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 public struct TimelineItemMenu: View {
@@ -59,6 +77,10 @@ public struct TimelineItemMenu: View {
     
     let item: EventBasedTimelineItemProtocol
     let actions: TimelineItemMenuActions
+
+    private var isRedacted: Bool {
+        item is RedactedRoomTimelineItem
+    }
     
     public var body: some View {
         VStack {
@@ -70,17 +92,21 @@ public struct TimelineItemMenu: View {
             
             ScrollView {
                 VStack(alignment: .leading, spacing: 0.0) {
-                    reactionsSection
-                        .padding(.top, 4.0)
-                        .padding(.bottom, 8.0)
-                    
-                    Divider()
-                        .background(Color.compound.bgSubtlePrimary)
-                    
-                    viewsForActions(actions.actions)
-                    
-                    Divider()
-                        .background(Color.compound.bgSubtlePrimary)
+                    if !isRedacted, !item.hasFailedToSend {
+                        reactionsSection
+                            .padding(.top, 4.0)
+                            .padding(.bottom, 8.0)
+
+                        Divider()
+                            .background(Color.compound.bgSubtlePrimary)
+                    }
+
+                    if !actions.actions.isEmpty {
+                        viewsForActions(actions.actions)
+
+                        Divider()
+                            .background(Color.compound.bgSubtlePrimary)
+                    }
                     
                     viewsForActions(actions.debugActions)
                 }

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemMenu.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemMenu.swift
@@ -77,10 +77,6 @@ public struct TimelineItemMenu: View {
     
     let item: EventBasedTimelineItemProtocol
     let actions: TimelineItemMenuActions
-
-    private var isRedacted: Bool {
-        item is RedactedRoomTimelineItem
-    }
     
     public var body: some View {
         VStack {
@@ -92,7 +88,7 @@ public struct TimelineItemMenu: View {
             
             ScrollView {
                 VStack(alignment: .leading, spacing: 0.0) {
-                    if !isRedacted, !item.hasFailedToSend {
+                    if !item.isRedacted, !item.hasFailedToSend {
                         reactionsSection
                             .padding(.top, 4.0)
                             .padding(.bottom, 8.0)
@@ -264,7 +260,7 @@ public struct TimelineItemMenu: View {
 
 struct TimelineItemMenu_Previews: PreviewProvider {
     static let viewModel = RoomScreenViewModel.mock
-    
+
     static var previews: some View {
         VStack {
             if let item = RoomTimelineItemFixtures.singleMessageChunk.first as? EventBasedTimelineItemProtocol,

--- a/ElementX/Sources/Services/Timeline/TimelineController/MockRoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/MockRoomTimelineController.swift
@@ -64,6 +64,8 @@ class MockRoomTimelineController: RoomTimelineControllerProtocol {
     func editMessage(_ newMessage: String, original itemID: String) async { }
     
     func redact(_ itemID: String) async { }
+
+    func cancelSend(_ transactionID: String) async { }
     
     func debugInfo(for itemID: String) -> TimelineItemDebugInfo {
         .init(model: "Mock debug description", originalJSON: nil, latestEditJSON: nil)

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
@@ -185,6 +185,11 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
             MXLog.error("Failed redacting message with error: \(error)")
         }
     }
+
+    func cancelSend(_ transactionID: String) async {
+        MXLog.info("Cancelling send in \(roomID)")
+        await roomProxy.cancelSend(transactionID: transactionID)
+    }
     
     // Handle this parallel to the timeline items so we're not forced
     // to bundle the Rust side objects within them

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerProtocol.swift
@@ -57,6 +57,8 @@ protocol RoomTimelineControllerProtocol {
     func toggleReaction(_ reaction: String, to itemID: String) async
 
     func redact(_ itemID: String) async
+
+    func cancelSend(_ transactionID: String) async
     
     func debugInfo(for itemID: String) -> TimelineItemDebugInfo
     

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
@@ -33,4 +33,8 @@ extension EventBasedTimelineItemProtocol {
     var description: String {
         "\(String(describing: Self.self)): id: \(id), timestamp: \(timestamp), isOutgoing: \(isOutgoing), properties: \(properties)"
     }
+
+    var hasFailedToSend: Bool {
+        properties.deliveryStatus == .sendingFailed
+    }
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
@@ -37,4 +37,12 @@ extension EventBasedTimelineItemProtocol {
     var hasFailedToSend: Bool {
         properties.deliveryStatus == .sendingFailed
     }
+
+    var isMessage: Bool {
+        self is EventBasedMessageTimelineItemProtocol
+    }
+
+    var isRedacted: Bool {
+        self is RedactedRoomTimelineItem
+    }
 }

--- a/changelog.d/1151.change
+++ b/changelog.d/1151.change
@@ -1,0 +1,1 @@
+Filter out some message actions and reactions for failed local echoes and redacted messages.


### PR DESCRIPTION
And also for redacted messages.

It also removes the reactions for these two cases, and for failed echos the "Remove" option is going to actually use the `cancelSend` API instead of the `redacted`

Here is the original issue: https://github.com/vector-im/element-x-ios/issues/1151


Failed message:
![Simulator Screenshot - iPhone 14 - 2023-06-27 at 17 34 31](https://github.com/vector-im/element-x-ios/assets/34335419/847eee4a-3a71-4093-90f7-f7559490d0cb)



Redacted message:
![Simulator Screenshot - iPhone 14 - 2023-06-27 at 17 33 45](https://github.com/vector-im/element-x-ios/assets/34335419/699b5c39-659c-4535-9342-ac3546d09ba6)
c-5f2e-41cf-b90a-658c7bcb4a12)

