### PR TITLE
Prevent the app from crashing when multiple virtual timelineStart ite…

### DIFF
--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Virtual/TimelineStartRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Virtual/TimelineStartRoomTimelineItem.swift
@@ -17,6 +17,6 @@
 import Foundation
 
 struct TimelineStartRoomTimelineItem: DecorationTimelineItemProtocol, Identifiable, Hashable {
-    let id = "timelineStartTimelineItemIdentifier"
+    let id: String = UUID().uuidString
     let name: String?
 }


### PR DESCRIPTION
…ms appear in the timeline

This is an SDK bug and should be properly handled Rust side. 