### PR TITLE
Fix for flipped image notification placeholder on iPhone

### DIFF
--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -189,12 +189,13 @@ extension UNMutableNotificationContent {
         // But on other devices is rendered upside down so we need to flip it
         #if targetEnvironment(simulator)
         return image.pngData()
-        #endif
+        #else
         if ProcessInfo.processInfo.isiOSAppOnMac {
             return image.pngData()
         } else {
             return image.flippedVertically().pngData()
         }
+        #endif
     }
 }
 

--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -310,7 +310,7 @@ extension NotificationItemProxyProtocol {
     private func processText(content: TextMessageContent,
                              mediaProvider: MediaProviderProtocol?) async throws -> UNMutableNotificationContent {
         let notification = try await processCommon(mediaProvider: mediaProvider)
-        notification.body = "\(ProcessInfo.processInfo.isiOSAppOnMac)"
+        notification.body = content.body
 
         return notification
     }

--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -310,7 +310,7 @@ extension NotificationItemProxyProtocol {
     private func processText(content: TextMessageContent,
                              mediaProvider: MediaProviderProtocol?) async throws -> UNMutableNotificationContent {
         let notification = try await processCommon(mediaProvider: mediaProvider)
-        notification.body = content.body
+        notification.body = "\(ProcessInfo.processInfo.isiOSAppOnMac)"
 
         return notification
     }

--- a/changelog.d/1194.bugfix
+++ b/changelog.d/1194.bugfix
@@ -1,1 +1,1 @@
-Fix for the flipped image placeholder image on iOS.
+Fix for the flipped notification image placeholder on iOS.

--- a/changelog.d/1194.bugfix
+++ b/changelog.d/1194.bugfix
@@ -1,0 +1,1 @@
+Fix for the flipped image placeholder image on iOS.


### PR DESCRIPTION
This problem was happening only on device, but was working properly on macOS and simulator.

I added a function that flips the image only on iOS devices