### PR TITLE
Improve LocationRoomTimelineView layout

### DIFF
--- a/ElementX/Sources/Other/MapLibre/MapLibreStaticMapView.swift
+++ b/ElementX/Sources/Other/MapLibre/MapLibreStaticMapView.swift
@@ -46,7 +46,6 @@ struct MapLibreStaticMapView<PinAnnotation: View>: View {
                                                      size: geometry.size,
                                                      attribution: mapTilerAttributionPlacement) {
                 AsyncImage(url: url) { phase in
-
                     switch phase {
                     case .empty:
                         Image("mapBlurred")

--- a/ElementX/Sources/Other/MapLibre/MapLibreStaticMapView.swift
+++ b/ElementX/Sources/Other/MapLibre/MapLibreStaticMapView.swift
@@ -24,48 +24,52 @@ struct MapLibreStaticMapView<PinAnnotation: View>: View {
     private let mapTilerAttributionPlacement: MapTilerAttributionPlacement
     private let pinAnnotationView: PinAnnotation
     @Environment(\.colorScheme) private var colorScheme
-    private let imageSize: CGSize
     @State private var fetchAttempt = 0
     
     init(coordinates: CLLocationCoordinate2D,
          zoomLevel: Double,
-         imageSize: CGSize,
          attributionPlacement: MapTilerAttributionPlacement,
          mapTilerStatic: MapTilerStaticMapProtocol,
          @ViewBuilder pinAnnotationView: () -> PinAnnotation) {
         self.coordinates = coordinates
         self.zoomLevel = zoomLevel
         self.mapTilerStatic = mapTilerStatic
-        self.imageSize = imageSize
         mapTilerAttributionPlacement = attributionPlacement
         self.pinAnnotationView = pinAnnotationView()
     }
     
     var body: some View {
-        if let url = mapTilerStatic.staticMapURL(for: colorScheme.mapStyle, coordinates: coordinates, zoomLevel: zoomLevel, size: imageSize, attribution: mapTilerAttributionPlacement) {
-            AsyncImage(url: url) { phase in
-                switch phase {
-                case .empty:
-                    Image("mapBlurred")
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                case .success(let image):
-                    ZStack {
-                        image
+        GeometryReader { geometry in
+            if let url = mapTilerStatic.staticMapURL(for: colorScheme.mapStyle,
+                                                     coordinates: coordinates,
+                                                     zoomLevel: zoomLevel,
+                                                     size: geometry.size,
+                                                     attribution: mapTilerAttributionPlacement) {
+                AsyncImage(url: url) { phase in
+
+                    switch phase {
+                    case .empty:
+                        Image("mapBlurred")
                             .resizable()
                             .aspectRatio(contentMode: .fill)
-                        pinAnnotationView
+                    case .success(let image):
+                        ZStack {
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                            pinAnnotationView
+                        }
+                    case .failure:
+                        errorView
+                    @unknown default:
+                        EmptyView()
                     }
-                case .failure:
-                    errorView
-                @unknown default:
-                    EmptyView()
                 }
+                .id(fetchAttempt)
+                .clipped()
+            } else {
+                Image("mapBlurred")
             }
-            .id(fetchAttempt)
-            .clipped()
-        } else {
-            Image("mapBlurred")
         }
     }
     
@@ -101,7 +105,6 @@ struct MapLibreStaticMapView_Previews: PreviewProvider {
     static var previews: some View {
         MapLibreStaticMapView(coordinates: CLLocationCoordinate2D(),
                               zoomLevel: 15,
-                              imageSize: .init(width: 300, height: 200),
                               attributionPlacement: .bottomLeft,
                               mapTilerStatic: MapTilerStaticMapMock()) {
             Image(systemName: "mappin.circle.fill")

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/LocationRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/LocationRoomTimelineView.swift
@@ -23,11 +23,11 @@ struct LocationRoomTimelineView: View {
     var body: some View {
         TimelineStyler(timelineItem: timelineItem) {
             if let geoURI = timelineItem.content.geoURI {
-                let mapSize: CGSize = .init(width: 292, height: 188)
-                MapLibreStaticMapView(geoURI: geoURI, size: mapSize) {
+                MapLibreStaticMapView(geoURI: geoURI) {
                     LocationMarkerView()
                 }
-                .frame(width: mapSize.width, height: mapSize.height)
+                .frame(maxWidth: .infinity, maxHeight: 300)
+                .aspectRatio(3 / 2, contentMode: .fit)
             } else {
                 FormattedBodyText(text: timelineItem.body)
             }
@@ -36,10 +36,9 @@ struct LocationRoomTimelineView: View {
 }
 
 private extension MapLibreStaticMapView {
-    init(geoURI: GeoURI, size: CGSize, @ViewBuilder pinAnnotationView: () -> PinAnnotation) {
+    init(geoURI: GeoURI, @ViewBuilder pinAnnotationView: () -> PinAnnotation) {
         self.init(coordinates: .init(latitude: geoURI.latitude, longitude: geoURI.longitude),
                   zoomLevel: 15,
-                  imageSize: size,
                   attributionPlacement: .bottomLeft,
                   mapTilerStatic: MapTilerStaticMap(key: ServiceLocator.shared.settings.mapTilerApiKey,
                                                     lightURL: ServiceLocator.shared.settings.lightTileMapStyleURL,

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/LocationRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/LocationRoomTimelineView.swift
@@ -26,7 +26,7 @@ struct LocationRoomTimelineView: View {
                 MapLibreStaticMapView(geoURI: geoURI) {
                     LocationMarkerView()
                 }
-                .frame(maxWidth: .infinity, maxHeight: 300)
+                .frame(maxHeight: 300)
                 .aspectRatio(3 / 2, contentMode: .fit)
             } else {
                 FormattedBodyText(text: timelineItem.body)


### PR DESCRIPTION
This PR improves `LocationRoomTimelineView` to respond better to large device screens like images are doing.

| Before | After |
| --- | --- |
|![b-ipad](https://github.com/vector-im/element-x-ios/assets/19324622/c5e29c71-7bae-4ace-b409-4de646323378)|![a-ipad](https://github.com/vector-im/element-x-ios/assets/19324622/1fad3f8a-7986-48c2-a48e-0f33fcf68e40)|
|![b-iPhone](https://github.com/vector-im/element-x-ios/assets/19324622/b1501ed6-45c6-48c8-bf98-1dff91f157b2)|![a-iPhone](https://github.com/vector-im/element-x-ios/assets/19324622/770b5c58-fa0d-4e99-a950-8d2c5eebae4e)|


