### PR TITLE
Conform URL to ExpressibleByStringLiteral

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -91,19 +91,19 @@ final class AppSettings {
     // MARK: - Authentication
     
     /// The URL that is opened when tapping the Learn more button on the sliding sync alert during authentication.
-    let slidingSyncLearnMoreURL = URL(staticString: "https://github.com/matrix-org/sliding-sync/blob/main/docs/Landing.md")
+    let slidingSyncLearnMoreURL: URL = "https://github.com/matrix-org/sliding-sync/blob/main/docs/Landing.md"
     
     /// The redirect URL used for OIDC.
-    let oidcRedirectURL = URL(staticString: "io.element:/callback")
+    let oidcRedirectURL: URL = "io.element:/callback"
     /// The app's main URL shown when using OIDC.
-    let oidcClientURL = URL(staticString: "https://element.io")
+    let oidcClientURL: URL = "https://element.io"
     /// The app's Terms of Service URL shown when using OIDC.
-    let oidcTermsURL = URL(staticString: "https://element.io/user-terms-of-service")
+    let oidcTermsURL: URL = "https://element.io/user-terms-of-service"
     /// The app's Privacy Policy URL shown when using OIDC.
-    let oidcPolicyURL = URL(staticString: "https://element.io/privacy")
+    let oidcPolicyURL: URL = "https://element.io/privacy"
     /// Any pre-defined static client registrations for OIDC issuers.
-    let oidcStaticRegistrations = [URL(staticString: "https://id.thirdroom.io/realms/thirdroom"): "elementx"]
-    
+    let oidcStaticRegistrations: [URL: String] = ["https://id.thirdroom.io/realms/thirdroom": "elementx"]
+
     // MARK: - Notifications
     
     var pusherAppId: String {
@@ -114,12 +114,12 @@ final class AppSettings {
         #endif
     }
     
-    let pushGatewayBaseURL = URL(staticString: "https://matrix.org/_matrix/push/v1/notify")
+    let pushGatewayBaseURL: URL = "https://matrix.org/_matrix/push/v1/notify"
         
     // MARK: - Bug report
 
-    let bugReportServiceBaseURL = URL(staticString: "https://riot.im/bugreports")
-    let bugReportSentryURL = URL(staticString: "https://f39ac49e97714316965b777d9f3d6cd8@sentry.tools.element.io/44")
+    let bugReportServiceBaseURL: URL = "https://riot.im/bugreports"
+    let bugReportSentryURL: URL = "https://f39ac49e97714316965b777d9f3d6cd8@sentry.tools.element.io/44"
     // Use the name allocated by the bug report server
     let bugReportApplicationId = "element-x-ios"
     let bugReportUISIId = "element-auto-uisi"
@@ -134,7 +134,7 @@ final class AppSettings {
     let analyticsConfiguration = AnalyticsConfiguration(isEnabled: InfoPlistReader.main.bundleIdentifier.starts(with: "io.element.elementx"),
                                                         host: "https://posthog.element.dev",
                                                         apiKey: "phc_VtA1L35nw3aeAtHIx1ayrGdzGkss7k1xINeXcoIQzXN",
-                                                        termsURL: URL(staticString: "https://element.io/cookie-policy"))
+                                                        termsURL: "https://element.io/cookie-policy")
     #else
     /// The configuration to use for analytics. Set `isEnabled` to false to disable analytics.
     /// **Note:** Analytics are disabled by default for forks. If you are maintaining a fork, set custom configurations.
@@ -171,7 +171,7 @@ final class AppSettings {
         
     // MARK: - Other
     
-    let permalinkBaseURL = URL(staticString: "https://matrix.to")
+    let permalinkBaseURL: URL = "https://matrix.to"
     
     // MARK: - Maps
     

--- a/ElementX/Sources/Mocks/UserProfile+Mock.swift
+++ b/ElementX/Sources/Mocks/UserProfile+Mock.swift
@@ -19,7 +19,7 @@ import Foundation
 extension UserProfileProxy {
     // Mocks
     static var mockAlice: UserProfileProxy {
-        .init(userID: "@alice:matrix.org", displayName: "Alice", avatarURL: URL(staticString: "mxc://matrix.org/UcCimidcvpFvWkPzvjXMQPHA"))
+        .init(userID: "@alice:matrix.org", displayName: "Alice", avatarURL: "mxc://matrix.org/UcCimidcvpFvWkPzvjXMQPHA")
     }
 
     static var mockBob: UserProfileProxy {

--- a/ElementX/Sources/Other/Extensions/URL.swift
+++ b/ElementX/Sources/Other/Extensions/URL.swift
@@ -16,12 +16,12 @@
 
 import Foundation
 
-extension URL {
-    init(staticString: StaticString) {
-        guard let url = URL(string: "\(staticString)") else {
+extension URL: ExpressibleByStringLiteral {
+    public init(stringLiteral value: StaticString) {
+        guard let url = URL(string: "\(value)") else {
             fatalError("The static string used to create this URL is invalid")
         }
-        
+
         self = url
     }
 

--- a/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
@@ -120,7 +120,7 @@ class MediaPreviewItem: NSObject, QLPreviewItem {
 // MARK: - Previews
 
 struct PreviewView_Previews: PreviewProvider {
-    static let previewURL = URL(staticString: "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf")
+    static let previewURL: URL = "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
     static let previewItem = MediaPreviewItem(file: .unmanaged(url: previewURL),
                                               title: "Important Document")
     

--- a/ElementX/Sources/Screens/RoomScreen/View/Replies/TimelineReplyView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Replies/TimelineReplyView.swift
@@ -213,7 +213,7 @@ struct TimelineReplyView_Previews: PreviewProvider {
                                                                                          thumbnailSource: nil,
                                                                                          contentType: nil))))
             
-            let imageSource = MediaSourceProxy(url: .init(staticString: "https://mock.com"), mimeType: "image/png")
+            let imageSource = MediaSourceProxy(url: "https://mock.com", mimeType: "image/png")
             
             TimelineReplyView(placement: .timeline,
                               timelineItemReplyDetails: .loaded(sender: .init(id: "", displayName: "Alice"),

--- a/ElementX/Sources/Screens/Settings/LegalInformationScreen/View/LegalInformationScreen.swift
+++ b/ElementX/Sources/Screens/Settings/LegalInformationScreen/View/LegalInformationScreen.swift
@@ -24,13 +24,13 @@ struct LegalInformationScreen: View {
         Form {
             Section {
                 Button(L10n.commonCopyright) {
-                    openURL(URL(staticString: "https://element.io/copyright"))
+                    openURL("https://element.io/copyright")
                 }
                 Button(L10n.commonAcceptableUsePolicy) {
-                    openURL(URL(staticString: "https://element.io/acceptable-use-policy-terms"))
+                    openURL("https://element.io/acceptable-use-policy-terms")
                 }
                 Button(L10n.commonPrivacyPolicy) {
-                    openURL(URL(staticString: "https://element.io/privacy"))
+                    openURL("https://element.io/privacy")
                 }
             }
             .buttonStyle(.compoundForm(accessory: .navigationLink))

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxyProtocol.swift
@@ -71,7 +71,7 @@ struct OIDCAuthenticationDataProxy: Equatable {
 //    var url: URL {
 //        URL(string: underlyingData.loginUrl())!
 //    }
-    let url = URL(staticString: "https://theroadtonowhere")
+    let url: URL = "https://theroadtonowhere"
 }
 
 // extension OidcAuthenticationData: Equatable {

--- a/UnitTests/Sources/BugReportServiceTests.swift
+++ b/UnitTests/Sources/BugReportServiceTests.swift
@@ -47,8 +47,8 @@ class BugReportServiceTests: XCTestCase {
     }
     
     func testInitialStateWithRealService() throws {
-        let service = BugReportService(withBaseURL: URL(staticString: "https://www.example.com"),
-                                       sentryURL: URL(staticString: "https://1234@sentry.com/1234"),
+        let service = BugReportService(withBaseURL: "https://www.example.com",
+                                       sentryURL: "https://1234@sentry.com/1234",
                                        applicationId: "mock_app_id",
                                        maxUploadSize: ServiceLocator.shared.settings.bugReportMaxUploadSize,
                                        session: .mock)
@@ -56,8 +56,8 @@ class BugReportServiceTests: XCTestCase {
     }
     
     @MainActor func testSubmitBugReportWithRealService() async throws {
-        let service = BugReportService(withBaseURL: URL(staticString: "https://www.example.com"),
-                                       sentryURL: URL(staticString: "https://1234@sentry.com/1234"),
+        let service = BugReportService(withBaseURL: "https://www.example.com",
+                                       sentryURL: "https://1234@sentry.com/1234",
                                        applicationId: "mock_app_id",
                                        maxUploadSize: ServiceLocator.shared.settings.bugReportMaxUploadSize,
                                        session: .mock)

--- a/UnitTests/Sources/MediaProvider/MediaProviderTests.swift
+++ b/UnitTests/Sources/MediaProvider/MediaProviderTests.swift
@@ -154,14 +154,14 @@ final class MediaProviderTests: XCTestCase {
         let expectedURL = URL(filePath: "/some/file/path")
         let expectedResult: Result<MediaFileHandleProxy, MediaProviderError> = .success(.unmanaged(url: expectedURL))
         mediaLoader.mediaFileURL = expectedURL
-        let result = await mediaProvider.loadFileFromSource(MediaSourceProxy(url: URL(staticString: "test/test1"), mimeType: "video/mp4"))
+        let result = await mediaProvider.loadFileFromSource(MediaSourceProxy(url: "test/test1", mimeType: "video/mp4"))
         XCTAssertEqual(result, expectedResult)
     }
     
     func test_whenLoadFileFromSourceAndNoFileFromSourceExistsAndLoadContentSourceFails_failureIsReturned() async throws {
         let expectedResult: Result<MediaFileHandleProxy, MediaProviderError> = .failure(.failedRetrievingFile)
         mediaLoader.mediaFileURL = nil
-        let result = await mediaProvider.loadFileFromSource(MediaSourceProxy(url: URL(staticString: "test/test1"), mimeType: "video/mp4"))
+        let result = await mediaProvider.loadFileFromSource(MediaSourceProxy(url: "test/test1", mimeType: "video/mp4"))
         XCTAssertEqual(result, expectedResult)
     }
     

--- a/UnitTests/Sources/PermalinkBuilderTests.swift
+++ b/UnitTests/Sources/PermalinkBuilderTests.swift
@@ -108,19 +108,19 @@ class PermalinkBuilderTests: XCTestCase {
     }
     
     func testPermalinkDetection() {
-        var url = URL(staticString: "https://www.matrix.org")
+        var url: URL = "https://www.matrix.org"
         XCTAssertEqual(PermalinkBuilder.detectPermalink(in: url, baseURL: appSettings.permalinkBaseURL), nil)
 
-        url = URL(staticString: "https://matrix.to/#/@bob:matrix.org?via=matrix.org")
+        url = "https://matrix.to/#/@bob:matrix.org?via=matrix.org"
         XCTAssertEqual(PermalinkBuilder.detectPermalink(in: url, baseURL: appSettings.permalinkBaseURL), PermalinkType.userIdentifier("@bob:matrix.org"))
 
-        url = URL(staticString: "https://matrix.to/#/!roomidentifier:matrix.org?via=matrix.org")
+        url = "https://matrix.to/#/!roomidentifier:matrix.org?via=matrix.org"
         XCTAssertEqual(PermalinkBuilder.detectPermalink(in: url, baseURL: appSettings.permalinkBaseURL), PermalinkType.roomIdentifier("!roomidentifier:matrix.org"))
 
-        url = URL(staticString: "https://matrix.to/#/%23roomalias:matrix.org?via=matrix.org")
+        url = "https://matrix.to/#/%23roomalias:matrix.org?via=matrix.org"
         XCTAssertEqual(PermalinkBuilder.detectPermalink(in: url, baseURL: appSettings.permalinkBaseURL), PermalinkType.roomAlias("#roomalias:matrix.org"))
         
-        url = URL(staticString: "https://matrix.to/#/!roomidentifier:matrix.org/$eventidentifier?via=matrix.org")
+        url = "https://matrix.to/#/!roomidentifier:matrix.org/$eventidentifier?via=matrix.org"
         XCTAssertEqual(PermalinkBuilder.detectPermalink(in: url, baseURL: appSettings.permalinkBaseURL), PermalinkType.event(roomIdentifier: "!roomidentifier:matrix.org", eventIdentifier: "$eventidentifier"))
     }
 }


### PR DESCRIPTION
This PRs add some syntax sugar for creating URL by conforming URL to `ExpressibleByStringLiteral`  and deleting the old `init(staticString:)`.
