### PR TITLE
fix: Do not call `fullRoom` on all rooms

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -5099,7 +5099,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "1.0.91-alpha";
+				version = "1.0.92-alpha";
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -111,8 +111,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "51c57a8c6c0d05fcaa249226e8e2a9df6e21e7cf",
-        "version" : "1.0.91-alpha"
+        "revision" : "a8c8e4917ecabf1ce6502057903ecf5f00b79a37",
+        "version" : "1.0.92-alpha"
       }
     },
     {

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -58,7 +58,7 @@ class RoomProxy: RoomProxyProtocol {
 
     init(roomListItem: RoomListItemProtocol,
          room: RoomProtocol,
-         backgroundTaskService: BackgroundTaskServiceProtocol) {
+         backgroundTaskService: BackgroundTaskServiceProtocol) async {
         self.roomListItem = roomListItem
         self.room = room
         self.backgroundTaskService = backgroundTaskService
@@ -77,7 +77,7 @@ class RoomProxy: RoomProxyProtocol {
 
         self.timelineListener = timelineListener
         
-        let result = room.addTimelineListener(listener: timelineListener)
+        let result = await room.addTimelineListener(listener: timelineListener)
         roomTimelineObservationToken = result.itemsStream
         
         innerTimelineProvider = RoomTimelineProvider(currentItems: result.items, updatePublisher: updatesPublisher)

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -155,17 +155,15 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
             lastMessageFormattedTimestamp = lastMessage.timestamp.formattedMinimal()
             attributedLastMessage = eventStringBuilder.buildAttributedString(for: lastMessage)
         }
-        
-        let room = roomListItem.fullRoom()
 
         let details = RoomSummaryDetails(id: roomListItem.id(),
-                                         name: roomListItem.name() ?? room.id(),
-                                         isDirect: room.isDirect(),
-                                         avatarURL: room.avatarUrl().flatMap(URL.init(string:)),
+                                         name: roomListItem.name() ?? roomListItem.id(),
+                                         isDirect: roomListItem.isDirect(),
+                                         avatarURL: roomListItem.avatarUrl().flatMap(URL.init(string:)),
                                          lastMessage: attributedLastMessage,
                                          lastMessageFormattedTimestamp: lastMessageFormattedTimestamp,
                                          unreadNotificationCount: UInt(roomListItem.unreadNotifications().notificationCount()),
-                                         canonicalAlias: room.canonicalAlias())
+                                         canonicalAlias: roomListItem.canonicalAlias())
 
         return invalidated ? .invalidated(details: details) : .filled(details: details)
     }

--- a/project.yml
+++ b/project.yml
@@ -44,7 +44,7 @@ include:
 packages:
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.91-alpha
+    exactVersion: 1.0.92-alpha
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
Address https://github.com/matrix-org/matrix-rust-sdk/issues/1911.

`fullRoom` creates a `Timeline` for the room. Calling this method on all rooms doesn't make the room list fast :-).

Needs https://github.com/matrix-org/matrix-rust-sdk/pull/2186 to be merged.