### PR TITLE
Fix reactions button faint outline.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReactionsView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReactionsView.swift
@@ -64,7 +64,7 @@ struct TimelineReactionButton: View {
         }
         .padding(.vertical, 6)
         .padding(.horizontal, 8)
-        .background(backgroundShape.fill(overlayBackgroundColor))
+        .background(backgroundShape.inset(by: 1).fill(overlayBackgroundColor))
         .overlay(backgroundShape.inset(by: 2.0).strokeBorder(overlayBorderColor))
         .overlay(backgroundShape.strokeBorder(Color.compound.bgCanvasDefault, lineWidth: 2))
         .accessibilityElement(children: .combine)


### PR DESCRIPTION
There is a very faint grey border around the reactions buttons. Its because the overlay border isn't quite covering the background, so this fixes it by insetting the background.
| Before | After |
| - | - |
| ![Screenshot 2023-06-30 at 2 18 06 pm](https://github.com/vector-im/element-x-ios/assets/6060466/d7a47b4b-61e6-4715-83e8-686d666c5848) | ![Screenshot 2023-06-30 at 2 17 51 pm](https://github.com/vector-im/element-x-ios/assets/6060466/ef66dd02-5127-4583-a7ce-c21b8f91662d) |
