### PR TITLE
Notification Placeholder Image Caching

### DIFF
--- a/ElementX/Sources/Other/Extensions/FileManager.swift
+++ b/ElementX/Sources/Other/Extensions/FileManager.swift
@@ -44,7 +44,8 @@ extension FileManager {
         
         return newURL
     }
-    
+
+    @discardableResult
     func writeDataToTemporaryDirectory(data: Data, fileName: String) throws -> URL {
         let newURL = URL.temporaryDirectory.appendingPathComponent(fileName)
         

--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -176,26 +176,46 @@ extension UNMutableNotificationContent {
     }
 
     private func getPlaceholderAvatarImageData(name: String, id: String) async -> Data? {
+        let fileName = "notification_placeholder_\(name)_\(id).png"
+        if let data = try? Data(contentsOf: URL.temporaryDirectory.appendingPathComponent(fileName)) {
+            MXLog.info("Found existing notification icon placeholder")
+            return data
+        }
+
+        MXLog.info("Generating notification icon placeholder")
         let image = PlaceholderAvatarImage(name: name,
                                            contentID: id)
             .clipShape(Circle())
-            .frame(width: 100, height: 100)
+            .frame(width: 50, height: 50)
         let renderer = await ImageRenderer(content: image)
         guard let image = await renderer.uiImage else {
+            MXLog.info("Generating notification icon placeholder failed")
             return nil
         }
 
+        let data: Data?
         // On simulator and macOS the image is rendered correctly
         // But on other devices is rendered upside down so we need to flip it
         #if targetEnvironment(simulator)
-        return image.pngData()
+        data = image.pngData()
         #else
         if ProcessInfo.processInfo.isiOSAppOnMac {
-            return image.pngData()
+            data = image.pngData()
         } else {
-            return image.flippedVertically().pngData()
+            data = image.flippedVertically().pngData()
         }
         #endif
+
+        if let data {
+            do {
+                // cache image data
+                try FileManager.default.writeDataToTemporaryDirectory(data: data, fileName: fileName)
+            } catch {
+                MXLog.error("Could not store placeholder image")
+                return data
+            }
+        }
+        return data
     }
 }
 

--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -105,7 +105,10 @@ extension UNMutableNotificationContent {
     func addSenderIcon(using mediaProvider: MediaProviderProtocol?,
                        senderID: String,
                        senderName: String,
-                       icon: NotificationIcon) async throws -> UNMutableNotificationContent {
+                       icon: NotificationIcon,
+                       requiresMediaProvider: Bool) async throws -> UNMutableNotificationContent {
+        let shouldSkipPlaceholder = requiresMediaProvider && mediaProvider == nil
+
         var fetchedImage: INImage?
         let image: INImage
         if let mediaSource = icon.mediaSource {
@@ -121,7 +124,8 @@ extension UNMutableNotificationContent {
 
         if let fetchedImage {
             image = fetchedImage
-        } else if let data = await getPlaceholderAvatarImageData(name: icon.groupInfo?.name ?? senderName,
+        } else if !shouldSkipPlaceholder,
+                  let data = await getPlaceholderAvatarImageData(name: icon.groupInfo?.name ?? senderName,
                                                                  id: icon.groupInfo?.id ?? senderID) {
             image = INImage(imageData: data)
         } else {

--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -163,7 +163,7 @@ extension NotificationItemProxyProtocol {
         return notification
     }
 
-    var requiresMediaProvider: Bool {
+    var hasMedia: Bool {
         if (isDirect && senderAvatarMediaSource != nil) ||
             (!isDirect && roomAvatarMediaSource != nil) {
             return true
@@ -256,8 +256,7 @@ extension NotificationItemProxyProtocol {
         notification = try await notification.addSenderIcon(using: mediaProvider,
                                                             senderID: event.senderID,
                                                             senderName: senderDisplayName ?? roomDisplayName,
-                                                            icon: icon,
-                                                            requiresMediaProvider: requiresMediaProvider)
+                                                            icon: icon)
         notification.body = body
         
         return notification
@@ -303,8 +302,7 @@ extension NotificationItemProxyProtocol {
         notification = try await notification.addSenderIcon(using: mediaProvider,
                                                             senderID: event.senderID,
                                                             senderName: senderDisplayName ?? roomDisplayName,
-                                                            icon: icon,
-                                                            requiresMediaProvider: requiresMediaProvider)
+                                                            icon: icon)
         return notification
     }
 

--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -164,7 +164,8 @@ extension NotificationItemProxyProtocol {
     }
 
     var requiresMediaProvider: Bool {
-        if senderAvatarMediaSource != nil || roomAvatarMediaSource != nil {
+        if (isDirect && senderAvatarMediaSource != nil) ||
+            (!isDirect && roomAvatarMediaSource != nil) {
             return true
         }
         switch event.type {
@@ -255,7 +256,8 @@ extension NotificationItemProxyProtocol {
         notification = try await notification.addSenderIcon(using: mediaProvider,
                                                             senderID: event.senderID,
                                                             senderName: senderDisplayName ?? roomDisplayName,
-                                                            icon: icon)
+                                                            icon: icon,
+                                                            requiresMediaProvider: requiresMediaProvider)
         notification.body = body
         
         return notification
@@ -301,7 +303,8 @@ extension NotificationItemProxyProtocol {
         notification = try await notification.addSenderIcon(using: mediaProvider,
                                                             senderID: event.senderID,
                                                             senderName: senderDisplayName ?? roomDisplayName,
-                                                            icon: icon)
+                                                            icon: icon,
+                                                            requiresMediaProvider: requiresMediaProvider)
         return notification
     }
 

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -98,7 +98,7 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
             // After the first processing, update the modified content
             modifiedContent = try await itemProxy.process(mediaProvider: nil)
 
-            guard itemProxy.requiresMediaProvider else {
+            guard itemProxy.hasMedia else {
                 MXLog.info("\(tag) no media needed")
 
                 // We've processed the item and no media operations needed, so no need to go further


### PR DESCRIPTION
This should fix the memory leak and slowdowns happening when generating a placeholder image.
Also added some logging and decreased the size of the placeholder image to 50x50 so that it's even smaller (100 was actually a bit too much for how small is the size of the icon)
