### PR TITLE
Fix SwiftUI-Flow package version

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -5183,7 +5183,7 @@
 			repositoryURL = "https://github.com/tevelee/SwiftUI-Flow";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.2.1;
+				minimumVersion = 1.2.0;
 			};
 		};
 		6582B5AF3F104B0F7E031E7D /* XCRemoteSwiftPackageReference "SwiftState" */ = {

--- a/project.yml
+++ b/project.yml
@@ -105,4 +105,4 @@ packages:
     minorVersion: 2.0.0
   Flow:
     url: https://github.com/tevelee/SwiftUI-Flow
-    minorVersion: 1.2.1
+    minorVersion: 1.2.0


### PR DESCRIPTION
Apparently there is no more the `1.2.1` version for [SwiftUI-Flow](https://github.com/tevelee/SwiftUI-Flow/tags).
This PR fixes that (otherwise Xcode errors when resolving packages).
