### PR TITLE
Remove notes from failed releases.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,3 @@
-## Changes in 1.2.0 (2023-07-05)
-
-No significant changes.
-
-
-## Changes in 1.1.9 (2023-07-05)
-
-No significant changes.
-
-
 ## Changes in 1.1.8 (2023-07-05)
 
 ✨ Features


### PR DESCRIPTION
We had a couple of failed releases last night and ended up taking the artefacts from 1.1.8 to upload to ASC. This PR removes the changelog entries for the unused releases.

I've also tidied up on GitHub, removing releases and tags and restoring 1.1.8 back correctly.