### PR TITLE
Improve user profile search

### DIFF
--- a/ElementX/Sources/Services/Users/UserDiscoveryService.swift
+++ b/ElementX/Sources/Services/Users/UserDiscoveryService.swift
@@ -22,35 +22,35 @@ final class UserDiscoveryService: UserDiscoveryServiceProtocol {
     init(clientProxy: ClientProxyProtocol) {
         self.clientProxy = clientProxy
     }
-    
+
     func fetchSuggestions() async -> Result<[UserProfileProxy], UserDiscoveryErrorType> {
-        .success([.mockAlice, .mockBob, .mockCharlie])
+        .success(filterAccountOwner([.mockAlice, .mockBob, .mockCharlie]))
     }
-    
+
     func searchProfiles(with searchQuery: String) async -> Result<[UserProfileProxy], UserDiscoveryErrorType> {
         async let queriedProfile = profileIfPossible(with: searchQuery)
-        
+
         do {
             async let searchedUsers = clientProxy.searchUsers(searchTerm: searchQuery, limit: 10).get()
             let users = try await merge(queriedProfile: queriedProfile, searchResults: searchedUsers)
-            return .success(users)
+            return .success(filterAccountOwner(users))
         } catch {
             // we want to show the profile (if any) even if the search fails
             if let queriedProfile = await queriedProfile {
-                return .success([queriedProfile])
+                return .success(filterAccountOwner([queriedProfile]))
             } else {
                 return .failure(.failedSearchingUsers)
             }
         }
     }
-    
+
     private func merge(queriedProfile: UserProfileProxy?, searchResults: SearchUsersResultsProxy) -> [UserProfileProxy] {
         let searchResults = searchResults.results
         
         guard let queriedProfile else {
             return searchResults
         }
-        
+
         let filteredSearchResult = searchResults.filter {
             $0.userID != queriedProfile.userID
         }
@@ -67,6 +67,11 @@ final class UserDiscoveryService: UserDiscoveryServiceProtocol {
         
         // fallback to a "local profile" if the profile api fails
         return getProfileResult ?? .init(userID: searchQuery)
+    }
+
+    private func filterAccountOwner(_ profiles: [UserProfileProxy]) -> [UserProfileProxy] {
+        let accountOwnerID = clientProxy.userID
+        return profiles.filter { $0.userID != accountOwnerID }
     }
 }
 

--- a/ElementX/Sources/Services/Users/UserDiscoveryService.swift
+++ b/ElementX/Sources/Services/Users/UserDiscoveryService.swift
@@ -37,7 +37,7 @@ final class UserDiscoveryService: UserDiscoveryServiceProtocol {
         } catch {
             // we want to show the profile (if any) even if the search fails
             if let queriedProfile = await queriedProfile {
-                return .success(filterAccountOwner([queriedProfile]))
+                return .success([queriedProfile])
             } else {
                 return .failure(.failedSearchingUsers)
             }
@@ -59,7 +59,7 @@ final class UserDiscoveryService: UserDiscoveryServiceProtocol {
     }
     
     private func profileIfPossible(with searchQuery: String) async -> UserProfileProxy? {
-        guard searchQuery.isMatrixIdentifier else {
+        guard searchQuery.isMatrixIdentifier, searchQuery != clientProxy.userID else {
             return nil
         }
         


### PR DESCRIPTION
This PR improves the user search by filtering out the account owner's user id.


**Result**

Account owner id is: **@alfotest6:matrix.org** 
| Before | After |
| --- | --- |
| ![b1](https://github.com/vector-im/element-x-ios/assets/19324622/52a3053a-c18b-484f-ba61-9907ec50b989)|![a1](https://github.com/vector-im/element-x-ios/assets/19324622/59af0038-879e-4a30-9b23-5ed27837ba26)|
|![b2](https://github.com/vector-im/element-x-ios/assets/19324622/08fcd223-16c0-4f79-aeb1-c9839116c70f)|![a2](https://github.com/vector-im/element-x-ios/assets/19324622/afbf45dc-8043-4686-bac7-d03335caa872)|



