### PR TITLE
Fix membersPublisher thread

### DIFF
--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -39,7 +39,9 @@ class RoomProxy: RoomProxyProtocol {
     private let backPaginationStateSubject = PassthroughSubject<BackPaginationStatus, Never>()
     private let membersSubject = CurrentValueSubject<[RoomMemberProxyProtocol], Never>([])
     var membersPublisher: AnyPublisher<[RoomMemberProxyProtocol], Never> {
-        membersSubject.eraseToAnyPublisher()
+        membersSubject
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
     }
     
     private var timelineListener: RoomTimelineListener?


### PR DESCRIPTION
After this [PR](https://github.com/vector-im/element-x-ios/pull/1268) there is no guarantee on the thread where the proxy publishes an update on the `membersSubject`.
However ATM clients of the room proxy are using the `membersPublisher` as if it publishes always on the main thread.
This causes runtime UI issues.

This PR brings the `memberPublisher`'s updates back on the main queue.