### PR TITLE
Send location uncertainty within a geo uri

### DIFF
--- a/ElementX/Sources/Other/MapLibre/MapLibreMapView.swift
+++ b/ElementX/Sources/Other/MapLibre/MapLibreMapView.swift
@@ -211,25 +211,12 @@ extension MapLibreMapView {
         // MARK: Private
 
         private func updateGeolocationUncertainty(location: MGLUserLocation) {
-            guard let clLocation = location.location else {
+            guard let clLocation = location.location, clLocation.horizontalAccuracy >= 0 else {
                 mapLibreView.geolocationUncertainty = nil
                 return
             }
-            
-            let uncertainty: CLLocationAccuracy?
 
-            switch (clLocation.horizontalAccuracy, clLocation.verticalAccuracy) {
-            case (let hAccuracy, let vAccuracy) where hAccuracy < 0 && vAccuracy < 0:
-                uncertainty = nil
-            case (let hAccuracy, let vAccuracy) where hAccuracy >= 0 && vAccuracy < 0:
-                uncertainty = hAccuracy
-            case (let hAccuracy, let vAccuracy) where hAccuracy < 0 && vAccuracy >= 0:
-                uncertainty = vAccuracy
-            case (let hAccuracy, let vAccuracy):
-                uncertainty = max(hAccuracy, vAccuracy)
-            }
-
-            mapLibreView.geolocationUncertainty = uncertainty
+            mapLibreView.geolocationUncertainty = clLocation.horizontalAccuracy
         }
     }
 }

--- a/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenModels.swift
+++ b/ElementX/Sources/Screens/LocationSharing/LocationSharingScreenModels.swift
@@ -109,6 +109,7 @@ struct StaticLocationScreenViewState: BindableState {
 
 struct StaticLocationScreenBindings {
     var mapCenterLocation: CLLocationCoordinate2D?
+    var geolocationUncertainty: CLLocationAccuracy?
 
     var showsUserLocationMode: ShowUserLocationMode
     

--- a/ElementX/Sources/Screens/LocationSharing/StaticLocationScreenViewModel.swift
+++ b/ElementX/Sources/Screens/LocationSharing/StaticLocationScreenViewModel.swift
@@ -36,7 +36,8 @@ class StaticLocationScreenViewModel: StaticLocationScreenViewModelType, StaticLo
             actionsSubject.send(.close)
         case .selectLocation:
             guard let coordinate = state.bindings.mapCenterLocation else { return }
-            actionsSubject.send(.sendLocation(.init(coordinate: coordinate), isUserLocation: state.isSharingUserLocation))
+            let uncertainty = state.isSharingUserLocation ? context.geolocationUncertainty : nil
+            actionsSubject.send(.sendLocation(.init(coordinate: coordinate, uncertainty: uncertainty), isUserLocation: state.isSharingUserLocation))
         case .userDidPan:
             state.bindings.showsUserLocationMode = .show
         case .centerToUser:

--- a/ElementX/Sources/Screens/LocationSharing/View/StaticLocationScreen.swift
+++ b/ElementX/Sources/Screens/LocationSharing/View/StaticLocationScreen.swift
@@ -47,10 +47,12 @@ struct StaticLocationScreen: View {
                             showsUserLocationMode: $context.showsUserLocationMode,
                             error: $context.mapError,
                             mapCenterCoordinate: $context.mapCenterLocation,
-                            isLocationAuthorized: $context.isLocationAuthorized) {
+                            isLocationAuthorized: $context.isLocationAuthorized,
+                            geolocationUncertainty: $context.geolocationUncertainty) {
                 context.send(viewAction: .userDidPan)
             }
             .ignoresSafeArea(.all, edges: mapSafeAreaEdges)
+
             if context.viewState.isLocationPickerMode {
                 LocationMarkerView()
             }

--- a/ElementX/Sources/Services/Timeline/GeoURI.swift
+++ b/ElementX/Sources/Services/Timeline/GeoURI.swift
@@ -78,8 +78,8 @@ private extension RegexGeoURI {
 }
 
 extension GeoURI {
-    init(coordinate: CLLocationCoordinate2D) {
-        self.init(latitude: coordinate.latitude, longitude: coordinate.longitude)
+    init(coordinate: CLLocationCoordinate2D, uncertainty: CLLocationAccuracy?) {
+        self.init(latitude: coordinate.latitude, longitude: coordinate.longitude, uncertainty: uncertainty)
     }
 }
 

--- a/UnitTests/Sources/StaticLocationScreenViewModelTests.swift
+++ b/UnitTests/Sources/StaticLocationScreenViewModelTests.swift
@@ -76,4 +76,31 @@ class StaticLocationScreenViewModelTests: XCTestCase {
         let authorizationError = AlertInfo(locationSharingViewError: .missingAuthorization)
         XCTAssertEqual(authorizationError.message, L10n.errorMissingLocationAuth(InfoPlistReader.main.bundleDisplayName))
     }
+
+    func testSendUserLocation() async throws {
+        context.mapCenterLocation = .init(latitude: 0, longitude: 0)
+        context.geolocationUncertainty = 10
+        let deferred = deferFulfillment(viewModel.actions.first())
+        context.send(viewAction: .selectLocation)
+        guard case .sendLocation(let geoUri, let isUserLocation) = try await deferred.fulfill() else {
+            XCTFail("Sent action should be 'sendLocation'")
+            return
+        }
+        XCTAssertEqual(geoUri.uncertainty, 10)
+        XCTAssertTrue(isUserLocation)
+    }
+
+    func testSendPickedLocation() async throws {
+        context.mapCenterLocation = .init(latitude: 0, longitude: 0)
+        context.isLocationAuthorized = nil
+        context.geolocationUncertainty = 10
+        let deferred = deferFulfillment(viewModel.actions.first())
+        context.send(viewAction: .selectLocation)
+        guard case .sendLocation(let geoUri, let isUserLocation) = try await deferred.fulfill() else {
+            XCTFail("Sent action should be 'sendLocation'")
+            return
+        }
+        XCTAssertEqual(geoUri.uncertainty, nil)
+        XCTAssertFalse(isUserLocation)
+    }
 }


### PR DESCRIPTION
This PR changes the send of a location by including the `uncertainty` in the geo uri.
The uncertainty is sent only when the user shares his current position.