### PR TITLE
UI Tests fixes.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration tests
 
 on:
   schedule:
-    - cron:  '0 * * * *'
+    - cron:  '0 6,18 * * *'
     
   workflow_dispatch:
 

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -8,7 +8,7 @@ on:
         required: false
 
   schedule:
-    - cron:  '0 0 * * 1-5'
+    - cron:  '0 0,12 * * 1-5'
 
 jobs:
   tests:

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tests:
     name: Tests
-    runs-on: macos-13
+    runs-on: perf-only
 
     concurrency:
       # When running on develop, use the sha to allow all runs of this workflow to run concurrently.

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -328,7 +328,7 @@ class MockScreen: Identifiable {
             let parameters = SessionVerificationScreenCoordinatorParameters(sessionVerificationControllerProxy: sessionVerificationControllerProxy)
             return SessionVerificationScreenCoordinator(parameters: parameters)
         case .userSessionScreen:
-            let navigationSplitCoordinator = NavigationSplitCoordinator(placeholderCoordinator: SplashScreenCoordinator())
+            let navigationSplitCoordinator = NavigationSplitCoordinator(placeholderCoordinator: PlaceholderScreenCoordinator())
             
             let clientProxy = MockClientProxy(userID: "@mock:client.com", roomSummaryProvider: MockRoomSummaryProvider(state: .loaded(.mockRooms)))
             ServiceLocator.shared.settings.migratedAccounts[clientProxy.userID] = true

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -332,6 +332,7 @@ class MockScreen: Identifiable {
             
             let clientProxy = MockClientProxy(userID: "@mock:client.com", roomSummaryProvider: MockRoomSummaryProvider(state: .loaded(.mockRooms)))
             ServiceLocator.shared.settings.migratedAccounts[clientProxy.userID] = true
+            ServiceLocator.shared.settings.hasShownWelcomeScreen = true
             
             let coordinator = UserSessionFlowCoordinator(userSession: MockUserSession(clientProxy: clientProxy, mediaProvider: MockMediaProvider()),
                                                          navigationSplitCoordinator: navigationSplitCoordinator,

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.invites-1.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.invites-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67b0f777fa6fd1ed23d94f9fa5ed43bba83f27ef534b98d883f01d08295e441a
-size 193142
+oid sha256:777e8f3870c413d3eddd2695f3029b43d2515f7f2b35f9916a9912f14c9562ed
+size 195001

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.userSessionScreen-1.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.userSessionScreen-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:769f79b42f5263e3d36a17e3f80881dfc01e5f4ccae0e553ba9ba3a4a116061a
-size 155285
+oid sha256:f47c0c687dee847461a81d16355e0e71f3e177cf032f208efc6fb61990f00651
+size 145285

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.invites-1.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.invites-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:815255c0e24f3610494cf0c6703aafec5cc4bb3bb4ede3cfcd38b864281ea0ae
-size 376792
+oid sha256:5a8f4ee78328eb4490aa097ed3e88d699878f16ef14aa89c25ff298027b19ec4
+size 378302

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.invites-1.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.invites-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39faa4fa419a44ac9711c1a7bbb036db743a8b1e123d1aa434066ae1ee3052d5
-size 237909
+oid sha256:aef3ced77ed37b3df495a9d384732dad8802970833d1b7d9d890cfbe38dd220a
+size 249707

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.userSessionScreen-1.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.userSessionScreen-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4676610bd1891599ac9bdbd26d4009b0792411083f43289362e1e0c6c7a76e39
-size 157204
+oid sha256:7636f881b8ffe54ae9d25b2fad515df66b22647f6916a1a137cba1c2992ddda4
+size 147141

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.invites-1.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.invites-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d2cb405d141ec256e0f326da24e477c5dd474fa3740f7ca5616274864e55253
-size 530598
+oid sha256:c9f0d2eb756d5ec79e3cfe49fc25add7092a8e8b6365d7fe23566e564e500abc
+size 555624

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -110,6 +110,7 @@ lane :unit_tests do
 end
 
 lane :ui_tests do |options|
+  # Use a fresh simulator state to ensure hardware keyboard isn't attached.
   reset_simulator_contents()
   
   create_simulator_if_necessary(
@@ -140,6 +141,13 @@ lane :ui_tests do |options|
     scheme: "UITests",
     binary_basename: "ElementX.app"
   )
+  
+  # Zip the result bundle for faster upload.
+  zip(
+    path: "./fastlane/test_output/UITests.xcresult",
+    output_path: "./fastlane/test_output/UITests.xcresult.zip"
+  )
+  sh("rm -rf ./fastlane/test_output/UITests.xcresult")
 end
 
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -110,6 +110,8 @@ lane :unit_tests do
 end
 
 lane :ui_tests do |options|
+  reset_simulator_contents()
+  
   create_simulator_if_necessary(
     name: "iPad (9th generation)",
     type: "com.apple.CoreSimulator.SimDeviceType.iPad-9th-generation"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -147,7 +147,8 @@ lane :ui_tests do |options|
     path: "./fastlane/test_output/UITests.xcresult",
     output_path: "./fastlane/test_output/UITests.xcresult.zip"
   )
-  sh("rm -rf ./fastlane/test_output/UITests.xcresult")
+  # Shell working directory is already inside the fastlane dir.
+  sh("rm -rf ./test_output/UITests.xcresult")
 end
 
 


### PR DESCRIPTION
This PR makes various changes to UI tests:
- Fix stale snapshots.
- Fix incorrect placeholder coordinator.
- Move runs to the performance testing runner.
- Sync runs to every 12 hours with a 6 hour offset compared to integration tests.
- Reset the simulator before each run (likely unnecessary but *does* fix the keyboard being hidden)
- Zip the test results bundle to speed up uploads as it contains *lots* of little files.

Awaiting result from run [here](https://github.com/vector-im/element-x-ios/actions/runs/5542457472).