### PR TITLE
Ignore more mocks in codecov.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,10 +10,13 @@ coverage:
 
 ignore:
   - "ElementX/Sources/Generated"
+  - "ElementX/Sources/Mocks"
   - "ElementX/Sources/Vendor"
   - "ElementX/Sources/UITests"
+  - "ElementX/Sources/UnitTests"
   - "Tools"
-  - "**/Mock*.swift" 
+  - "**/Mock*.swift"
+  - "**/*Mock.swift"
 
 flag_management:
   default_rules:


### PR DESCRIPTION
We're including quite a few new mocks in codecov (inc the Sourcery generated ones), so this PR updates the ignore list to cover them.