### PR TITLE
Log the crash event's ID to see if duplicate logs are for the same event

### DIFF
--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -69,12 +69,12 @@ class BugReportService: NSObject, BugReportServiceProtocol {
             options.tracesSampleRate = 1.0
 
             options.beforeSend = { event in
-                MXLog.error("Sentry detected crash: \(event)")
+                MXLog.error("Sentry detected crash: \(event.eventId.sentryIdString)")
                 return event
             }
 
             options.onCrashedLastRun = { [weak self] event in
-                MXLog.error("Sentry detected application was crashed: \(event)")
+                MXLog.error("Sentry detected application was crashed: \(event.eventId.sentryIdString)")
                 self?.lastCrashEventId = event.eventId.sentryIdString
             }
         }


### PR DESCRIPTION
We're seeing multiple `BugReportService.swift:72: Sentry detected crash: <SentryTransaction: 0x1209b3090>` logs through a single rageshake. As the log only includes the object's has, this changes the log to use the event's ID instead. We can then see if these are multiple logs for the same crash or if something else is happening.