### PR TITLE
Update "user's location" dot color

### DIFF
--- a/ElementX/Sources/Other/MapLibre/MapLibreMapView.swift
+++ b/ElementX/Sources/Other/MapLibre/MapLibreMapView.swift
@@ -95,6 +95,7 @@ struct MapLibreMapView: UIViewRepresentable {
         mapView.logoViewPosition = .topLeft
         mapView.attributionButtonPosition = .topLeft
         mapView.attributionButtonMargins = .init(x: mapView.logoView.frame.maxX + 8, y: mapView.logoView.center.y / 2)
+        mapView.tintColor = .black
         return mapView
     }
     


### PR DESCRIPTION
This PR changes the user's location dot color, so that **doesn't** change in dark mode:

| Before | After |
| --- | --- |
| ![before](https://github.com/vector-im/element-x-ios/assets/19324622/7390b802-c108-4b48-b090-ce5932d42cf2)|![after](https://github.com/vector-im/element-x-ios/assets/19324622/ac7610ad-36e1-4ef3-b0bb-074e778aa750)|
