### PR TITLE
Flipping the tableView

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -188,7 +188,7 @@ class TimelineTableViewController: UIViewController {
             .minSize(height: 1)
             .background(Color.clear)
 
-            cell.transform = CGAffineTransform(scaleX: 1, y: -1)
+            cell.contentView.transform = CGAffineTransform(scaleX: 1, y: -1)
             return cell
         }
 

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -119,16 +119,6 @@ class TimelineTableViewController: UIViewController {
             }
             .store(in: &cancellables)
         
-//        scrollAdapter.isScrolling
-//            .sink { [weak self] isScrolling in
-//                guard !isScrolling, let self, self.hasPendingUpdates else { return }
-//                // When scrolling has stopped, apply any pending updates.
-//                self.applySnapshot()
-//                self.hasPendingUpdates = false
-//                self.paginateBackwardsPublisher.send(())
-//            }
-//            .store(in: &cancellables)
-        
         paginateBackwardsPublisher
             .collect(.byTime(DispatchQueue.main, 0.1))
             .sink { [weak self] _ in
@@ -233,8 +223,7 @@ class TimelineTableViewController: UIViewController {
     private func paginateBackwardsIfNeeded() {
         guard canBackPaginate,
               !isBackPaginating,
-              // TODO: this probably needs to change
-              tableView.contentOffset.y < tableView.visibleSize.height * 2.0
+              tableView.contentOffset.y > tableView.contentSize.height - tableView.visibleSize.height
         else { return }
         
         coordinator.send(viewAction: .paginateBackwards)

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -142,6 +142,8 @@ class TimelineTableViewController: UIViewController {
         scrollToBottom(animated: false)
         hasAppearedOnce = true
         paginateBackwardsPublisher.send()
+        // This allows the reversed table view never fully be considered at the bottom
+        tableView.contentOffset.y = 1
     }
     
     override func viewWillLayoutSubviews() {
@@ -234,6 +236,7 @@ class TimelineTableViewController: UIViewController {
 
     private func scrollToTop(animated: Bool) {
         tableView.scrollToRow(at: IndexPath(item: timelineItemsIDs.count - 1, section: 0), at: .bottom, animated: animated)
+        scrollAdapter.scrollViewDidScrollToTop(tableView)
     }
 }
 
@@ -247,12 +250,16 @@ extension TimelineTableViewController: UITableViewDelegate {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             
-            let scrollToBottomButtonVisible = tableView.contentOffset.y > 15
+            let scrollToBottomButtonVisible = scrollView.contentOffset.y > 15
             
             // Only update the binding on changes to avoid needlessly recomputing the hierarchy when scrolling.
             if self.scrollToBottomButtonVisible != scrollToBottomButtonVisible {
                 self.scrollToBottomButtonVisible = scrollToBottomButtonVisible
             }
+        }
+
+        if scrollView.contentOffset.y == 0 {
+            scrollView.contentOffset.y = 1
         }
     }
 
@@ -274,10 +281,6 @@ extension TimelineTableViewController: UITableViewDelegate {
         
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         scrollAdapter.scrollViewDidEndDecelerating(scrollView)
-    }
-    
-    func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
-        scrollAdapter.scrollViewDidScrollToTop(scrollView)
     }
 
     func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -209,7 +209,12 @@ class TimelineTableViewController: UIViewController {
         let currentSnapshot = dataSource.snapshot()
         MXLog.verbose("DIFF: \(snapshot.itemIdentifiers.difference(from: currentSnapshot.itemIdentifiers))")
 
-        dataSource.apply(snapshot, animatingDifferences: shouldAnimate)
+        // We need to decide if we want to use animations only for the appearence at the bottom or in general
+        // however I noticed that while paginating since some remote messages may lag a bit behind in the first
+        // collected update, this may cause some moving around while scrolling very fast towards the top which is more
+        // noticeable by the animation. However it looks way cooler.
+        let animated = shouldAnimate && snapshot.itemIdentifiers.first != currentSnapshot.itemIdentifiers.first
+        dataSource.apply(snapshot, animatingDifferences: animated)
     }
     
     /// Scrolls to the bottom of the timeline.

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -161,13 +161,6 @@ class TimelineTableViewController: UIViewController {
         hasAppearedOnce = true
     }
     
-    override func didMove(toParent parent: UIViewController?) {
-        super.didMove(toParent: parent)
-        
-        // Ensure the padding is correct before display.
-//        updateTopPadding()
-    }
-    
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         
@@ -238,7 +231,7 @@ class TimelineTableViewController: UIViewController {
     
     /// Scrolls to the bottom of the timeline.
     private func scrollToTop(animated: Bool) {
-        tableView.setContentOffset(CGPoint(x: 0, y: 0), animated: animated)
+        tableView.scrollToRow(at: IndexPath(item: 0, section: 0), at: .top, animated: animated)
     }
     
     /// Checks whether or a backwards pagination is needed and requests one if so.
@@ -248,6 +241,7 @@ class TimelineTableViewController: UIViewController {
         guard canBackPaginate,
               !isBackPaginating,
               !hasPendingUpdates,
+              // TODO: this probably needs to change
               tableView.contentOffset.y < tableView.visibleSize.height * 2.0
         else { return }
         

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -115,7 +115,7 @@ class TimelineTableViewController: UIViewController {
         
         scrollToBottomPublisher
             .sink { [weak self] _ in
-                self?.scrollToTop(animated: true)
+                self?.scrollToBottom(animated: true)
             }
             .store(in: &cancellables)
         
@@ -150,7 +150,7 @@ class TimelineTableViewController: UIViewController {
         super.viewWillAppear(animated)
         
         guard !hasAppearedOnce else { return }
-        scrollToTop(animated: false)
+        scrollToBottom(animated: false)
         hasAppearedOnce = true
     }
     
@@ -223,7 +223,7 @@ class TimelineTableViewController: UIViewController {
     }
     
     /// Scrolls to the bottom of the timeline.
-    private func scrollToTop(animated: Bool) {
+    private func scrollToBottom(animated: Bool) {
         tableView.scrollToRow(at: IndexPath(item: 0, section: 0), at: .top, animated: animated)
     }
     

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -42,13 +42,6 @@ class TimelineTableViewController: UIViewController {
     var timelineStyle: TimelineStyle
     var timelineItemsDictionary = OrderedDictionary<String, RoomTimelineItemViewModel>() {
         didSet {
-            guard !scrollAdapter.isScrolling.value else {
-                // Delay updating until scrolling has stopped as programatic
-                // changes to the scroll position kills any inertia.
-                hasPendingUpdates = true
-                return
-            }
-
             applySnapshot()
 
             if timelineItemsDictionary.isEmpty {
@@ -92,7 +85,7 @@ class TimelineTableViewController: UIViewController {
     /// quick succession can execute before ``isBackPaginating`` becomes `true`.
     private let paginateBackwardsPublisher = PassthroughSubject<Void, Never>()
     /// Whether or not the ``timelineItems`` value should be applied when scrolling stops.
-    private var hasPendingUpdates = false
+//    private var hasPendingUpdates = false
     /// Whether or not the view has been shown on screen yet.
     private var hasAppearedOnce = false
     /// Whether the scroll and the animations should happen
@@ -126,15 +119,15 @@ class TimelineTableViewController: UIViewController {
             }
             .store(in: &cancellables)
         
-        scrollAdapter.isScrolling
-            .sink { [weak self] isScrolling in
-                guard !isScrolling, let self, self.hasPendingUpdates else { return }
-                // When scrolling has stopped, apply any pending updates.
-                self.applySnapshot()
-                self.hasPendingUpdates = false
-                self.paginateBackwardsPublisher.send(())
-            }
-            .store(in: &cancellables)
+//        scrollAdapter.isScrolling
+//            .sink { [weak self] isScrolling in
+//                guard !isScrolling, let self, self.hasPendingUpdates else { return }
+//                // When scrolling has stopped, apply any pending updates.
+//                self.applySnapshot()
+//                self.hasPendingUpdates = false
+//                self.paginateBackwardsPublisher.send(())
+//            }
+//            .store(in: &cancellables)
         
         paginateBackwardsPublisher
             .collect(.byTime(DispatchQueue.main, 0.1))
@@ -240,7 +233,6 @@ class TimelineTableViewController: UIViewController {
     private func paginateBackwardsIfNeeded() {
         guard canBackPaginate,
               !isBackPaginating,
-              !hasPendingUpdates,
               // TODO: this probably needs to change
               tableView.contentOffset.y < tableView.visibleSize.height * 2.0
         else { return }

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
@@ -277,11 +277,7 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
                 
                 let timelineItem = buildTimelineItem(for: itemProxy, chunkIndex: reversedIndex)
                 
-                if timelineItem is PaginationIndicatorRoomTimelineItem {
-                    isBackPaginating = true
-                } else if timelineItem is TimelineStartRoomTimelineItem {
-                    canBackPaginate = false
-                } else if timelineItem is EncryptedHistoryRoomTimelineItem {
+                if timelineItem is EncryptedHistoryRoomTimelineItem {
                     canBackPaginate = false
                 }
                 
@@ -319,8 +315,10 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
             case .timelineStartReached:
                 let timelineStart = TimelineStartRoomTimelineItem(name: roomProxy.displayName ?? roomProxy.name)
                 newTimelineItems.insert(timelineStart, at: 0)
+                canBackPaginate = false
             case .paginating:
                 newTimelineItems.insert(PaginationIndicatorRoomTimelineItem(), at: 0)
+                isBackPaginating = true
             case .idle:
                 break
             }


### PR DESCRIPTION
I know you have read this title and you are wondering what is this nonsense?

But by observing how Telegram and Whatsapp work, and by checking online:
https://stackoverflow.com/questions/40157645/how-to-add-new-rows-at-bottom-of-tableview-chat-messages
https://www.reddit.com/r/iOSProgramming/comments/vexs68/how_to_create_reverse_tableview/
This is probably an industry standard trick for chat apps.

Usually table views with a pagination system always have its pagination happen at the bottom, however a chat always paginates backwards... which creates a lot of extra complexities to handle... so what about flipping the tableView and its cells?

This does not only work very well, but literally reduced half of the code needed and the overall complexity of handling scrolling, padding, pagination, restoring scroll positions and so on... is all gone, the table view is very light now.

It probably requires some more testing, but the result is amazing, and by checking WhatsApp behaviour this is likely how they made it work.


https://github.com/vector-im/element-x-ios/assets/34335419/20e11191-d7fc-407f-bf3b-422673570ab9


