### PR TITLE
Tweak homebrew env vars.

### DIFF
--- a/changelog.d/pr-1374.build
+++ b/changelog.d/pr-1374.build
@@ -1,0 +1,1 @@
+Don't upgrade more homebrew deps than needed on GitHub runners.

--- a/ci_scripts/ci_common.sh
+++ b/ci_scripts/ci_common.sh
@@ -38,6 +38,9 @@ install_xcode_cloud_python_dependencies () {
 }
 
 setup_github_actions_environment() {
+    unset HOMEBREW_NO_INSTALL_FROM_API
+    export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+    
     brew update && brew install xcodegen swiftformat git-lfs imagemagick
     
     # brew "swiftlint" # Fails on the CI: `Target /usr/local/bin/swiftlint Target /usr/local/bin/swiftlint already exists`. Installed through https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md#linters


### PR DESCRIPTION
The PR sets homebrew to not upgrade dependants unprompted and tests using the API instead of the formulae repo.

Reduces the setup environment step from 4-5 mins down to 1:25 on the first run.