### PR TITLE
Enable animations + delay + possible crash fix

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -34,7 +34,6 @@ final class AppSettings {
         case readReceiptsEnabled
         case hasShownWelcomeScreen
         case notificationSettingsEnabled
-        case timelineDiffableAnimationsEnabled
     }
     
     private static var suiteName: String = InfoPlistReader.main.appGroupIdentifier
@@ -218,7 +217,4 @@ final class AppSettings {
     
     @UserPreference(key: UserDefaultsKeys.notificationSettingsEnabled, defaultValue: false, storageType: .userDefaults(store))
     var notificationSettingsEnabled
-
-    @UserPreference(key: UserDefaultsKeys.timelineDiffableAnimationsEnabled, defaultValue: false, storageType: .userDefaults(store))
-    var timelineDiffableAnimationsEnabled
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineTableViewController.swift
@@ -224,8 +224,7 @@ class TimelineTableViewController: UIViewController {
 
     /// Scrolls to the top of the timeline.
     private func scrollToTop(animated: Bool) {
-        let index = timelineItemsIDs.count - 1
-        guard index >= 0 else {
+        guard !timelineItemsIDs.isEmpty else {
             return
         }
         tableView.scrollToRow(at: IndexPath(item: timelineItemsIDs.count - 1, section: 0), at: .bottom, animated: animated)

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -30,7 +30,6 @@ struct DeveloperOptionsScreenViewStateBindings {
     var readReceiptsEnabled: Bool
     var isEncryptionSyncEnabled: Bool
     var notificationSettingsEnabled: Bool
-    var timelineDiffableAnimationsEnabled: Bool
 }
 
 enum DeveloperOptionsScreenViewAction {
@@ -39,6 +38,5 @@ enum DeveloperOptionsScreenViewAction {
     case changedReadReceiptsEnabled
     case changedIsEncryptionSyncEnabled
     case changedNotificationSettingsEnabled
-    case changedTimelineDiffableAnimationsEnabled
     case clearCache
 }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
@@ -30,8 +30,7 @@ class DeveloperOptionsScreenViewModel: DeveloperOptionsScreenViewModelType, Deve
                                                                userSuggestionsEnabled: appSettings.userSuggestionsEnabled,
                                                                readReceiptsEnabled: appSettings.readReceiptsEnabled,
                                                                isEncryptionSyncEnabled: appSettings.isEncryptionSyncEnabled,
-                                                               notificationSettingsEnabled: appSettings.notificationSettingsEnabled,
-                                                               timelineDiffableAnimationsEnabled: appSettings.timelineDiffableAnimationsEnabled)
+                                                               notificationSettingsEnabled: appSettings.notificationSettingsEnabled)
         let state = DeveloperOptionsScreenViewState(bindings: bindings)
         
         super.init(initialViewState: state)
@@ -53,8 +52,6 @@ class DeveloperOptionsScreenViewModel: DeveloperOptionsScreenViewModelType, Deve
             appSettings.isEncryptionSyncEnabled = state.bindings.isEncryptionSyncEnabled
         case .changedNotificationSettingsEnabled:
             appSettings.notificationSettingsEnabled = state.bindings.notificationSettingsEnabled
-        case .changedTimelineDiffableAnimationsEnabled:
-            appSettings.timelineDiffableAnimationsEnabled = state.bindings.timelineDiffableAnimationsEnabled
         case .clearCache:
             callback?(.clearCache)
         }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -63,13 +63,6 @@ struct DeveloperOptionsScreen: View {
                 .onChange(of: context.userSuggestionsEnabled) { _ in
                     context.send(viewAction: .changedUserSuggestionsEnabled)
                 }
-
-                Toggle(isOn: $context.timelineDiffableAnimationsEnabled) {
-                    Text("Enable diffable animations in the timeline")
-                }
-                .onChange(of: context.timelineDiffableAnimationsEnabled) { _ in
-                    context.send(viewAction: .changedTimelineDiffableAnimationsEnabled)
-                }
             }
 
             Section {


### PR DESCRIPTION
@manuroe let me know if we are happy merging scroll animations fully.
- Removes the animation FF and sets the animations true by default
- This PR also enabled them after a 2 seconds delay to hide the SS proxy issue (however this depends a lot on the user's connection 2 seconds might not be enough sometimes)
- Fixes a possible crash
