### PR TITLE
Reduce boilerplate in Developer Options Screen

### DIFF
--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -228,8 +228,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "4af50b38daf0037cfbab15514a241224c3f62f98",
-        "version" : "0.8.5"
+        "revision" : "245d527002f29c5a616c5b7131f6a50ac7f41cbf",
+        "version" : "0.8.6"
       }
     }
   ],

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenCoordinator.swift
@@ -26,7 +26,7 @@ final class DeveloperOptionsScreenCoordinator: CoordinatorProtocol {
     var callback: ((DeveloperOptionsScreenCoordinatorAction) -> Void)?
     
     init() {
-        viewModel = DeveloperOptionsScreenViewModel(appSettings: ServiceLocator.shared.settings)
+        viewModel = DeveloperOptionsScreenViewModel(developerOptions: ServiceLocator.shared.settings)
         viewModel.callback = { [weak self] action in
             switch action {
             case .clearCache:

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -48,7 +48,6 @@ protocol DeveloperOptions: AnyObject {
     var readReceiptsEnabled: Bool { get set }
     var isEncryptionSyncEnabled: Bool { get set }
     var notificationSettingsEnabled: Bool { get set }
-    var timelineDiffableAnimationsEnabled: Bool { get set }
 }
 
 extension AppSettings: DeveloperOptions { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -26,13 +26,13 @@ struct DeveloperOptionsScreenViewState: BindableState {
 
 @dynamicMemberLookup
 struct DeveloperOptionsScreenViewStateBindings {
-    private let developerOptions: DeveloperOptions
+    private let developerOptions: DeveloperOptionsProtocol
 
-    init(developerOptions: DeveloperOptions) {
+    init(developerOptions: DeveloperOptionsProtocol) {
         self.developerOptions = developerOptions
     }
 
-    subscript<Setting>(dynamicMember keyPath: ReferenceWritableKeyPath<DeveloperOptions, Setting>) -> Setting {
+    subscript<Setting>(dynamicMember keyPath: ReferenceWritableKeyPath<DeveloperOptionsProtocol, Setting>) -> Setting {
         get { developerOptions[keyPath: keyPath] }
         set { developerOptions[keyPath: keyPath] = newValue }
     }
@@ -42,7 +42,7 @@ enum DeveloperOptionsScreenViewAction {
     case clearCache
 }
 
-protocol DeveloperOptions: AnyObject {
+protocol DeveloperOptionsProtocol: AnyObject {
     var shouldCollapseRoomStateEvents: Bool { get set }
     var userSuggestionsEnabled: Bool { get set }
     var readReceiptsEnabled: Bool { get set }
@@ -50,4 +50,4 @@ protocol DeveloperOptions: AnyObject {
     var notificationSettingsEnabled: Bool { get set }
 }
 
-extension AppSettings: DeveloperOptions { }
+extension AppSettings: DeveloperOptionsProtocol { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -26,18 +26,29 @@ struct DeveloperOptionsScreenViewState: BindableState {
 
 @dynamicMemberLookup
 struct DeveloperOptionsScreenViewStateBindings {
-    private let appSettings: AppSettings
+    private let developerOptions: DeveloperOptions
 
-    init(appSettings: AppSettings) {
-        self.appSettings = appSettings
+    init(developerOptions: DeveloperOptions) {
+        self.developerOptions = developerOptions
     }
 
-    subscript<Setting>(dynamicMember keyPath: ReferenceWritableKeyPath<AppSettings, Setting>) -> Setting {
-        get { appSettings[keyPath: keyPath] }
-        set { appSettings[keyPath: keyPath] = newValue }
+    subscript<Setting>(dynamicMember keyPath: ReferenceWritableKeyPath<DeveloperOptions, Setting>) -> Setting {
+        get { developerOptions[keyPath: keyPath] }
+        set { developerOptions[keyPath: keyPath] = newValue }
     }
 }
 
 enum DeveloperOptionsScreenViewAction {
     case clearCache
 }
+
+protocol DeveloperOptions: AnyObject {
+    var shouldCollapseRoomStateEvents: Bool { get set }
+    var userSuggestionsEnabled: Bool { get set }
+    var readReceiptsEnabled: Bool { get set }
+    var isEncryptionSyncEnabled: Bool { get set }
+    var notificationSettingsEnabled: Bool { get set }
+    var timelineDiffableAnimationsEnabled: Bool { get set }
+}
+
+extension AppSettings: DeveloperOptions { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -24,19 +24,20 @@ struct DeveloperOptionsScreenViewState: BindableState {
     var bindings: DeveloperOptionsScreenViewStateBindings
 }
 
+@dynamicMemberLookup
 struct DeveloperOptionsScreenViewStateBindings {
-    var shouldCollapseRoomStateEvents: Bool
-    var userSuggestionsEnabled: Bool
-    var readReceiptsEnabled: Bool
-    var isEncryptionSyncEnabled: Bool
-    var notificationSettingsEnabled: Bool
+    private let appSettings: AppSettings
+
+    init(appSettings: AppSettings) {
+        self.appSettings = appSettings
+    }
+
+    subscript<Setting>(dynamicMember keyPath: ReferenceWritableKeyPath<AppSettings, Setting>) -> Setting {
+        get { appSettings[keyPath: keyPath] }
+        set { appSettings[keyPath: keyPath] = newValue }
+    }
 }
 
 enum DeveloperOptionsScreenViewAction {
-    case changedShouldCollapseRoomStateEvents
-    case changedUserSuggestionsEnabled
-    case changedReadReceiptsEnabled
-    case changedIsEncryptionSyncEnabled
-    case changedNotificationSettingsEnabled
     case clearCache
 }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
@@ -21,7 +21,7 @@ typealias DeveloperOptionsScreenViewModelType = StateStoreViewModel<DeveloperOpt
 class DeveloperOptionsScreenViewModel: DeveloperOptionsScreenViewModelType, DeveloperOptionsScreenViewModelProtocol {
     var callback: ((DeveloperOptionsScreenViewModelAction) -> Void)?
     
-    init(developerOptions: DeveloperOptions) {
+    init(developerOptions: DeveloperOptionsProtocol) {
         let bindings = DeveloperOptionsScreenViewStateBindings(developerOptions: developerOptions)
         let state = DeveloperOptionsScreenViewState(bindings: bindings)
         

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
@@ -21,8 +21,8 @@ typealias DeveloperOptionsScreenViewModelType = StateStoreViewModel<DeveloperOpt
 class DeveloperOptionsScreenViewModel: DeveloperOptionsScreenViewModelType, DeveloperOptionsScreenViewModelProtocol {
     var callback: ((DeveloperOptionsScreenViewModelAction) -> Void)?
     
-    init(appSettings: AppSettings) {
-        let bindings = DeveloperOptionsScreenViewStateBindings(appSettings: appSettings)
+    init(developerOptions: DeveloperOptions) {
+        let bindings = DeveloperOptionsScreenViewStateBindings(developerOptions: developerOptions)
         let state = DeveloperOptionsScreenViewState(bindings: bindings)
         
         super.init(initialViewState: state)

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenViewModel.swift
@@ -19,39 +19,17 @@ import SwiftUI
 typealias DeveloperOptionsScreenViewModelType = StateStoreViewModel<DeveloperOptionsScreenViewState, DeveloperOptionsScreenViewAction>
 
 class DeveloperOptionsScreenViewModel: DeveloperOptionsScreenViewModelType, DeveloperOptionsScreenViewModelProtocol {
-    private let appSettings: AppSettings
-    
     var callback: ((DeveloperOptionsScreenViewModelAction) -> Void)?
     
     init(appSettings: AppSettings) {
-        self.appSettings = appSettings
-        
-        let bindings = DeveloperOptionsScreenViewStateBindings(shouldCollapseRoomStateEvents: appSettings.shouldCollapseRoomStateEvents,
-                                                               userSuggestionsEnabled: appSettings.userSuggestionsEnabled,
-                                                               readReceiptsEnabled: appSettings.readReceiptsEnabled,
-                                                               isEncryptionSyncEnabled: appSettings.isEncryptionSyncEnabled,
-                                                               notificationSettingsEnabled: appSettings.notificationSettingsEnabled)
+        let bindings = DeveloperOptionsScreenViewStateBindings(appSettings: appSettings)
         let state = DeveloperOptionsScreenViewState(bindings: bindings)
         
         super.init(initialViewState: state)
-        
-        appSettings.$shouldCollapseRoomStateEvents
-            .weakAssign(to: \.state.bindings.shouldCollapseRoomStateEvents, on: self)
-            .store(in: &cancellables)
     }
     
     override func process(viewAction: DeveloperOptionsScreenViewAction) {
         switch viewAction {
-        case .changedShouldCollapseRoomStateEvents:
-            appSettings.shouldCollapseRoomStateEvents = state.bindings.shouldCollapseRoomStateEvents
-        case .changedUserSuggestionsEnabled:
-            appSettings.userSuggestionsEnabled = state.bindings.userSuggestionsEnabled
-        case .changedReadReceiptsEnabled:
-            appSettings.readReceiptsEnabled = state.bindings.readReceiptsEnabled
-        case .changedIsEncryptionSyncEnabled:
-            appSettings.isEncryptionSyncEnabled = state.bindings.isEncryptionSyncEnabled
-        case .changedNotificationSettingsEnabled:
-            appSettings.notificationSettingsEnabled = state.bindings.notificationSettingsEnabled
         case .clearCache:
             callback?(.clearCache)
         }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -48,10 +48,6 @@ struct DeveloperOptionsScreen: View {
                 Toggle(isOn: $context.userSuggestionsEnabled) {
                     Text("User suggestions")
                 }
-
-                Toggle(isOn: $context.timelineDiffableAnimationsEnabled) {
-                    Text("Enable diffable animations in the timeline")
-                }
             }
 
             Section {

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -105,7 +105,7 @@ struct DeveloperOptionsScreen: View {
 // MARK: - Previews
 
 struct DeveloperOptionsScreen_Previews: PreviewProvider {
-    static let viewModel = DeveloperOptionsScreenViewModel(appSettings: ServiceLocator.shared.settings)
+    static let viewModel = DeveloperOptionsScreenViewModel(developerOptions: ServiceLocator.shared.settings)
     static var previews: some View {
         NavigationStack {
             DeveloperOptionsScreen(context: viewModel.context)

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -26,16 +26,10 @@ struct DeveloperOptionsScreen: View {
                 Toggle(isOn: $context.shouldCollapseRoomStateEvents) {
                     Text("Collapse room state events")
                 }
-                .onChange(of: context.shouldCollapseRoomStateEvents) { _ in
-                    context.send(viewAction: .changedShouldCollapseRoomStateEvents)
-                }
                 
                 Toggle(isOn: $context.readReceiptsEnabled) {
                     Text("Show read receipts")
                     Text("Requires app reboot")
-                }
-                .onChange(of: context.readReceiptsEnabled) { _ in
-                    context.send(viewAction: .changedReadReceiptsEnabled)
                 }
             }
 
@@ -44,15 +38,9 @@ struct DeveloperOptionsScreen: View {
                     Text("Use notification encryption sync")
                     Text("Requires app reboot")
                 }
-                .onChange(of: context.isEncryptionSyncEnabled) { _ in
-                    context.send(viewAction: .changedIsEncryptionSyncEnabled)
-                }
                 
                 Toggle(isOn: $context.notificationSettingsEnabled) {
                     Text("Show notification settings")
-                }
-                .onChange(of: context.notificationSettingsEnabled) { _ in
-                    context.send(viewAction: .changedNotificationSettingsEnabled)
                 }
             }
 
@@ -60,8 +48,9 @@ struct DeveloperOptionsScreen: View {
                 Toggle(isOn: $context.userSuggestionsEnabled) {
                     Text("User suggestions")
                 }
-                .onChange(of: context.userSuggestionsEnabled) { _ in
-                    context.send(viewAction: .changedUserSuggestionsEnabled)
+
+                Toggle(isOn: $context.timelineDiffableAnimationsEnabled) {
+                    Text("Enable diffable animations in the timeline")
                 }
             }
 


### PR DESCRIPTION
This PR refactors the developer options screen to minimize the boilerplate.
Now most of the source of truth come directly from the `AppSettings` type.
