### PR TITLE
Default media upload file mime types to `application/octet-stream` so…

### DIFF
--- a/ElementX/Sources/Services/Media/MediaUploadingPreprocessor.swift
+++ b/ElementX/Sources/Services/Media/MediaUploadingPreprocessor.swift
@@ -117,7 +117,7 @@ struct MediaUploadingPreprocessor {
         // Process unknown types as plain files
         guard let type = UTType(filenameExtension: newURL.pathExtension),
               let mimeType = type.preferredMIMEType else {
-            return await processFile(at: newURL, mimeType: nil)
+            return await processFile(at: newURL, mimeType: "application/octet-stream")
         }
         
         if type.conforms(to: .image) {


### PR DESCRIPTION
… that uploading doesn't fail rust side

Fixes problems in uploading less common file types like dmg, apk etc.