### PR TITLE
Specify ElementX target for coverage in integrations plan.

### DIFF
--- a/IntegrationTests/SupportingFiles/IntegrationTests.xctestplan
+++ b/IntegrationTests/SupportingFiles/IntegrationTests.xctestplan
@@ -9,6 +9,15 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:ElementX.xcodeproj",
+          "identifier" : "C0FAEB81CFD9776CD78CE489",
+          "name" : "ElementX"
+        }
+      ]
+    },
     "environmentVariableEntries" : [
       {
         "key" : "INTEGRATION_TESTS_HOST",

--- a/changelog.d/pr-1398.build
+++ b/changelog.d/pr-1398.build
@@ -1,0 +1,1 @@
+Specify the target for code coverage in the Integration Tests plan.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -154,6 +154,8 @@ end
 
 
 lane :integration_tests do
+  clear_derived_data()
+  
   create_simulator_if_necessary(
     name: "iPhone 14 Pro",
     type: "com.apple.CoreSimulator.SimDeviceType.iPhone-14-Pro"
@@ -173,6 +175,7 @@ lane :integration_tests do
     output_directory: "./fastlane/test_output",
     proj: "ElementX.xcodeproj",
     scheme: "IntegrationTests",
+    binary_basename: "ElementX.app"
   )
 end
 


### PR DESCRIPTION
This PR update coverage collecting to match UI tests (specify only the EX target) along with clearing derived data on each run as the Integration tests appeared to be uploading coverage from the UI tests.