### PR TITLE
Two Sync Loop always enabled by default and removed the feature flag

### DIFF
--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,7 +11,7 @@
     {
       "identity" : "compound-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vector-im/compound-ios",
+      "location" : "https://github.com/vector-im/compound-ios.git",
       "state" : {
         "revision" : "d9e119fbef20857eb790dd4aafbe16ff46011eca"
       }

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -187,10 +187,6 @@ final class AppSettings {
     /// Tag describing which set of device specific rules a pusher executes.
     @UserPreference(key: UserDefaultsKeys.pusherProfileTag, storageType: .userDefaults(store))
     var pusherProfileTag: String?
-
-    /// Tag describing if the app and the NSE should use the encryption sync
-    @UserPreference(key: SharedUserDefaultsKeys.isEncryptionSyncEnabled, defaultValue: true, storageType: .userDefaults(store))
-    var isEncryptionSyncEnabled
         
     // MARK: - Other
     

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -46,7 +46,6 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var shouldCollapseRoomStateEvents: Bool { get set }
     var userSuggestionsEnabled: Bool { get set }
     var readReceiptsEnabled: Bool { get set }
-    var isEncryptionSyncEnabled: Bool { get set }
     var notificationSettingsEnabled: Bool { get set }
 }
 

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -34,11 +34,6 @@ struct DeveloperOptionsScreen: View {
             }
 
             Section("Notifications") {
-                Toggle(isOn: $context.isEncryptionSyncEnabled) {
-                    Text("Use notification encryption sync")
-                    Text("Requires app reboot")
-                }
-                
                 Toggle(isOn: $context.notificationSettingsEnabled) {
                     Text("Show notification settings")
                 }

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -406,7 +406,7 @@ class ClientProxy: ClientProxyProtocol {
         do {
             let syncService = try await client
                 .syncService()
-                .withEncryptionSync(withCrossProcessLock: appSettings.isEncryptionSyncEnabled,
+                .withEncryptionSync(withCrossProcessLock: true,
                                     appIdentifier: "MainApp")
                 .finish()
             let roomListService = syncService.roomListService()

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -71,7 +71,7 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
         MXLog.info("\(tag) run with roomId: \(roomId), eventId: \(eventId)")
 
         do {
-            let userSession = try NSEUserSession(credentials: credentials, isEncryptionSyncEnabled: settings.isEncryptionSyncEnabled)
+            let userSession = try NSEUserSession(credentials: credentials)
             self.userSession = userSession
             guard let itemProxy = await userSession.notificationItemProxy(roomID: roomId, eventID: eventId) else {
                 MXLog.info("\(tag) no notification for the event, discard")

--- a/NSE/Sources/Other/NSESettings.swift
+++ b/NSE/Sources/Other/NSESettings.swift
@@ -21,8 +21,4 @@ final class NSESettings {
 
     /// UserDefaults to be used on reads and writes.
     private static var store: UserDefaults! = UserDefaults(suiteName: suiteName)
-
-    /// Tag describing if the app and the NSE should use the encryption sync
-    @UserPreference(key: SharedUserDefaultsKeys.isEncryptionSyncEnabled, defaultValue: true, storageType: .userDefaults(store))
-    var isEncryptionSyncEnabled
 }

--- a/NSE/Sources/Other/NSEUserSession.swift
+++ b/NSE/Sources/Other/NSEUserSession.swift
@@ -25,7 +25,7 @@ final class NSEUserSession {
                                                                                imageCache: .onlyOnDisk,
                                                                                backgroundTaskService: nil)
 
-    init(credentials: KeychainCredentials, isEncryptionSyncEnabled: Bool) throws {
+    init(credentials: KeychainCredentials) throws {
         userID = credentials.userID
         baseClient = try ClientBuilder()
             .basePath(path: URL.sessionsBaseDirectory.path)
@@ -36,7 +36,7 @@ final class NSEUserSession {
 
         notificationClient = baseClient
             .notificationClient()
-            .retryDecryption(withCrossProcessLock: isEncryptionSyncEnabled)
+            .retryDecryption(withCrossProcessLock: true)
             .finish()
     }
 


### PR DESCRIPTION
We have this in nightly since a month, seems to be quite stable, so we can start rolling it out.