### PR TITLE
Use generated UIColors everywhere.

### DIFF
--- a/DesignKit/Package.swift
+++ b/DesignKit/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "DesignKit", targets: ["DesignKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/vector-im/compound-ios.git", revision: "d9e119fbef20857eb790dd4aafbe16ff46011eca"),
+        .package(url: "https://github.com/vector-im/compound-ios.git", revision: "1f3eb60c4f87249d95addf84ce1aef22c2968763"),
         .package(url: "https://github.com/vector-im/element-design-tokens.git", exact: "0.0.3"),
         .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", from: "0.9.0")
     ],

--- a/DesignKit/Sources/TextFields/ElementTextFieldStyle.swift
+++ b/DesignKit/Sources/TextFields/ElementTextFieldStyle.swift
@@ -80,7 +80,7 @@ public struct ElementTextFieldStyle: TextFieldStyle {
     }
     
     /// The color of the placeholder text inside the text field.
-    private var placeholderColor: Color {
+    private var placeholderColor: UIColor {
         .compound.textPlaceholder
     }
     
@@ -134,7 +134,7 @@ public struct ElementTextFieldStyle: TextFieldStyle {
                 .introspect(.textField, on: .iOS(.v16)) { textField in
                     textField.clearButtonMode = .whileEditing
                     textField.attributedPlaceholder = NSAttributedString(string: textField.placeholder ?? "",
-                                                                         attributes: [NSAttributedString.Key.foregroundColor: UIColor(placeholderColor)])
+                                                                         attributes: [NSAttributedString.Key.foregroundColor: placeholderColor])
                     textField.accessibilityIdentifier = accessibilityIdentifier
                 }
  

--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -3624,7 +3624,7 @@
 			path = Timeline;
 			sourceTree = "<group>";
 		};
-		"TEMP_43147A32-A06C-4EEF-8C45-FDEA43A25C1E" /* element-x-ios */ = {
+		"TEMP_8B4A8977-AAD5-44D7-8CB7-F1BC31A64C84" /* element-x-ios */ = {
 			isa = PBXGroup;
 			children = (
 				41553551C55AD59885840F0E /* secrets.xcconfig */,
@@ -5351,7 +5351,7 @@
 			repositoryURL = "https://github.com/vector-im/compound-ios";
 			requirement = {
 				kind = revision;
-				revision = d9e119fbef20857eb790dd4aafbe16ff46011eca;
+				revision = 1f3eb60c4f87249d95addf84ce1aef22c2968763;
 			};
 		};
 		9A472EE0218FE7DCF5283429 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,15 +5,15 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vector-im/compound-design-tokens.git",
       "state" : {
-        "revision" : "cc950d575f8536ff5bebbd02e28c0b8ab541aa29"
+        "revision" : "aa55111d94486acbfd3344cf4d08b64723bd6703"
       }
     },
     {
       "identity" : "compound-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vector-im/compound-ios",
+      "location" : "https://github.com/vector-im/compound-ios.git",
       "state" : {
-        "revision" : "d9e119fbef20857eb790dd4aafbe16ff46011eca"
+        "revision" : "1f3eb60c4f87249d95addf84ce1aef22c2968763"
       }
     },
     {

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -37,9 +37,7 @@ struct Application: App {
                 .statusBarHidden(shouldHideStatusBar)
                 .introspect(.window, on: .iOS(.v16)) { window in
                     // Workaround for SwiftUI not consistently applying the tint colour to Alerts/Confirmation Dialogs.
-                    window.tintColor = UIColor(named: "colorGray1400",
-                                               in: Bundle(identifier: "CompoundDesignTokens-CompoundDesignTokens-resources"),
-                                               compatibleWith: nil)
+                    window.tintColor = .compound.textActionPrimary
                 }
                 .task {
                     appCoordinator.start()

--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -117,7 +117,7 @@ struct AttributedStringBuilder: AttributedStringBuilderProtocol {
         attributedString.enumerateAttribute(.backgroundColor, in: .init(location: 0, length: attributedString.length), options: []) { value, range, _ in
             if let value = value as? UIColor,
                value == temporaryCodeBlockMarkingColor {
-                attributedString.addAttribute(.backgroundColor, value: UIColor(.compound._bgCodeBlock) as Any, range: range)
+                attributedString.addAttribute(.backgroundColor, value: UIColor.compound._bgCodeBlock as Any, range: range)
             }
         }
     }

--- a/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/MessageComposerTextField.swift
@@ -69,7 +69,7 @@ private struct UITextViewWrapper: UIViewRepresentable {
         textView.isMultiline = $isMultiline
         textView.delegate = context.coordinator
         textView.elementDelegate = context.coordinator
-        textView.textColor = UIColor(.compound.textPrimary)
+        textView.textColor = .compound.textPrimary
         textView.isEditable = true
         textView.font = font
         textView.isSelectable = true

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemMacContextMenu.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemMacContextMenu.swift
@@ -31,13 +31,23 @@ struct TimelineItemMacContextMenu: View {
                             TimelineItemMenuAction.react.label
                         }
                     }
+                    
                     ForEach(menuActions.actions) { action in
-                        Button { send(action) } label: { action.label }
+                        Button(role: action.isDestructive ? .destructive : nil) {
+                            send(action)
+                        } label: {
+                            action.label
+                        }
                     }
                 }
+                
                 Section {
                     ForEach(menuActions.debugActions) { action in
-                        Button { send(action) } label: { action.label }
+                        Button(role: action.isDestructive ? .destructive : nil) {
+                            send(action)
+                        } label: {
+                            action.label
+                        }
                     }
                 }
             }

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemMenu.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemMenu.swift
@@ -84,7 +84,17 @@ enum TimelineItemMenuAction: Identifiable, Hashable {
         }
     }
     
-    /// The item's label.
+    /// Whether or not the action is destructive.
+    var isDestructive: Bool {
+        switch self {
+        case .redact, .report:
+            return true
+        default:
+            return false
+        }
+    }
+    
+    /// The action's label.
     var label: some View {
         switch self {
         case .copy: return Label(L10n.actionCopy, systemImage: "doc.on.doc")
@@ -232,7 +242,9 @@ public struct TimelineItemMenu: View {
     
     private func viewsForActions(_ actions: [TimelineItemMenuAction]) -> some View {
         ForEach(actions, id: \.self) { action in
-            Button { send(action) } label: {
+            Button(role: action.isDestructive ? .destructive : nil) {
+                send(action)
+            } label: {
                 action.label
                     .labelStyle(FixedIconSizeLabelStyle())
                     .multilineTextAlignment(.leading)

--- a/project.yml
+++ b/project.yml
@@ -54,7 +54,7 @@ packages:
     minorVersion: 5.13.0
   Compound:
     url: https://github.com/vector-im/compound-ios
-    revision: d9e119fbef20857eb790dd4aafbe16ff46011eca
+    revision: 1f3eb60c4f87249d95addf84ce1aef22c2968763
     # path: ../compound-ios
   Algorithms:
     url: https://github.com/apple/swift-algorithms


### PR DESCRIPTION
This PR uses the generated `UIColor`s from Compound instead of wrapping SwiftUI colours (which caused an issue in dark mode when setting the window's tint colour).

Additionally fixes a bug introduced by #1383 which lost the destructive role for some timeline action buttons.