### PR TITLE
FF to enable filtering notifications by push rules

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -190,7 +190,7 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.pusherProfileTag, storageType: .userDefaults(store))
     var pusherProfileTag: String?
 
-    /// Alows notifications to he filtered based on the push context of the room
+    /// Allows notifications to be filtered based on the push context of the room
     @UserPreference(key: SharedUserDefaultsKeys.filterNotificationsByPushRulesEnabled, defaultValue: false, storageType: .userDefaults(store))
     var filterNotificationsByPushRulesEnabled
         

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -189,6 +189,10 @@ final class AppSettings {
     /// Tag describing which set of device specific rules a pusher executes.
     @UserPreference(key: UserDefaultsKeys.pusherProfileTag, storageType: .userDefaults(store))
     var pusherProfileTag: String?
+
+    /// Alows notifications to he filtered based on the push context of the room
+    @UserPreference(key: SharedUserDefaultsKeys.filterNotificationsByPushRulesEnabled, defaultValue: false, storageType: .userDefaults(store))
+    var filterNotificationsByPushRulesEnabled
         
     // MARK: - Other
     

--- a/ElementX/Sources/Other/SharedUserDefaultsKeys.swift
+++ b/ElementX/Sources/Other/SharedUserDefaultsKeys.swift
@@ -15,5 +15,5 @@
 //
 
 enum SharedUserDefaultsKeys: String {
-    case isEncryptionSyncEnabled
+    case filterNotificationsByPushRulesEnabled
 }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -49,6 +49,7 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var notificationSettingsEnabled: Bool { get set }
     var swiftUITimelineEnabled: Bool { get set }
     var pollsInTimelineEnabled: Bool { get set }
+    var filterNotificationsByPushRulesEnabled: Bool { get set }
 }
 
 extension AppSettings: DeveloperOptionsProtocol { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -42,6 +42,10 @@ struct DeveloperOptionsScreen: View {
                 Toggle(isOn: $context.notificationSettingsEnabled) {
                     Text("Show notification settings")
                 }
+
+                Toggle(isOn: $context.filterNotificationsByPushRulesEnabled) {
+                    Text("Filter notifications by push rules")
+                }
             }
 
             Section("Room creation") {

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -71,7 +71,7 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
         MXLog.info("\(tag) run with roomId: \(roomId), eventId: \(eventId)")
 
         do {
-            let userSession = try NSEUserSession(credentials: credentials)
+            let userSession = try NSEUserSession(credentials: credentials, filterByPushRulesEnabled: settings.filterNotificationsByPushRulesEnabled)
             self.userSession = userSession
             guard let itemProxy = await userSession.notificationItemProxy(roomID: roomId, eventID: eventId) else {
                 MXLog.info("\(tag) no notification for the event, discard")

--- a/NSE/Sources/Other/NSESettings.swift
+++ b/NSE/Sources/Other/NSESettings.swift
@@ -21,4 +21,8 @@ final class NSESettings {
 
     /// UserDefaults to be used on reads and writes.
     private static var store: UserDefaults! = UserDefaults(suiteName: suiteName)
+
+    /// Alows notifications to he filtered based on the push context of the room
+    @UserPreference(key: SharedUserDefaultsKeys.filterNotificationsByPushRulesEnabled, defaultValue: false, storageType: .userDefaults(store))
+    var filterNotificationsByPushRulesEnabled
 }

--- a/NSE/Sources/Other/NSESettings.swift
+++ b/NSE/Sources/Other/NSESettings.swift
@@ -22,7 +22,7 @@ final class NSESettings {
     /// UserDefaults to be used on reads and writes.
     private static var store: UserDefaults! = UserDefaults(suiteName: suiteName)
 
-    /// Alows notifications to he filtered based on the push context of the room
+    /// Allows notifications to be filtered based on the push context of the room
     @UserPreference(key: SharedUserDefaultsKeys.filterNotificationsByPushRulesEnabled, defaultValue: false, storageType: .userDefaults(store))
     var filterNotificationsByPushRulesEnabled
 }

--- a/changelog.d/1172.bugfix
+++ b/changelog.d/1172.bugfix
@@ -1,0 +1,1 @@
+Added an FF to enable push rules filtering. Also invitation notifications will now be always displayed reliably.


### PR DESCRIPTION
Now that notifications do a small sliding sync when received, they should be able to get the push rules and filter automatically.

Since this is experimental, this needs to be enabled as a FF.
