### PR TITLE
Notification settings screen

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -260,7 +260,16 @@
 "screen_media_upload_preview_error_failed_sending" = "Failed uploading media, please try again.";
 "screen_migration_message" = "This is a one time process, thanks for waiting.";
 "screen_migration_title" = "Setting up your account.";
+"screen_notification_settings_additional_settings_section_title" = "Additional settings";
+"screen_notification_settings_calls_label" = "Audio and video calls";
+"screen_notification_settings_direct_chats" = "Direct chats";
 "screen_notification_settings_enable_notifications" = "Enable notifications on this device";
+"screen_notification_settings_group_chats" = "Group chats";
+"screen_notification_settings_mentions_section_title" = "Mentions";
+"screen_notification_settings_mode_all" = "All";
+"screen_notification_settings_mode_mentions" = "Mentions";
+"screen_notification_settings_notification_section_title" = "Notify me for";
+"screen_notification_settings_room_mention_label" = "Notify me on @room";
 "screen_notification_settings_system_notifications_action_required" = "To receive notifications, please change your %1$@.";
 "screen_notification_settings_system_notifications_action_required_content_link" = "system settings";
 "screen_notification_settings_system_notifications_turned_off" = "System notifications turned off";

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -299,14 +299,21 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
     // MARK: Settings
     
     private func presentSettingsScreen(animated: Bool) {
+        Task {
+            await asyncPresentSettingsScreen(animated: animated)
+        }
+    }
+    
+    private func asyncPresentSettingsScreen(animated: Bool) async {
         let settingsNavigationStackCoordinator = NavigationStackCoordinator()
         
         let userIndicatorController = UserIndicatorController(rootCoordinator: settingsNavigationStackCoordinator)
         
-        let parameters = SettingsScreenCoordinatorParameters(navigationStackCoordinator: settingsNavigationStackCoordinator,
-                                                             userIndicatorController: userIndicatorController,
-                                                             userSession: userSession,
-                                                             bugReportService: bugReportService)
+        let parameters = await SettingsScreenCoordinatorParameters(navigationStackCoordinator: settingsNavigationStackCoordinator,
+                                                                   userIndicatorController: userIndicatorController,
+                                                                   userSession: userSession,
+                                                                   bugReportService: bugReportService,
+                                                                   notificationSettings: userSession.clientProxy.notificationSettings())
         let settingsScreenCoordinator = SettingsScreenCoordinator(parameters: parameters)
         settingsScreenCoordinator.callback = { [weak self] action in
             guard let self else { return }

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -672,8 +672,26 @@ public enum L10n {
   public static var screenMigrationMessage: String { return L10n.tr("Localizable", "screen_migration_message") }
   /// Setting up your account.
   public static var screenMigrationTitle: String { return L10n.tr("Localizable", "screen_migration_title") }
+  /// Additional settings
+  public static var screenNotificationSettingsAdditionalSettingsSectionTitle: String { return L10n.tr("Localizable", "screen_notification_settings_additional_settings_section_title") }
+  /// Audio and video calls
+  public static var screenNotificationSettingsCallsLabel: String { return L10n.tr("Localizable", "screen_notification_settings_calls_label") }
+  /// Direct chats
+  public static var screenNotificationSettingsDirectChats: String { return L10n.tr("Localizable", "screen_notification_settings_direct_chats") }
   /// Enable notifications on this device
   public static var screenNotificationSettingsEnableNotifications: String { return L10n.tr("Localizable", "screen_notification_settings_enable_notifications") }
+  /// Group chats
+  public static var screenNotificationSettingsGroupChats: String { return L10n.tr("Localizable", "screen_notification_settings_group_chats") }
+  /// Mentions
+  public static var screenNotificationSettingsMentionsSectionTitle: String { return L10n.tr("Localizable", "screen_notification_settings_mentions_section_title") }
+  /// All
+  public static var screenNotificationSettingsModeAll: String { return L10n.tr("Localizable", "screen_notification_settings_mode_all") }
+  /// Mentions
+  public static var screenNotificationSettingsModeMentions: String { return L10n.tr("Localizable", "screen_notification_settings_mode_mentions") }
+  /// Notify me for
+  public static var screenNotificationSettingsNotificationSectionTitle: String { return L10n.tr("Localizable", "screen_notification_settings_notification_section_title") }
+  /// Notify me on @room
+  public static var screenNotificationSettingsRoomMentionLabel: String { return L10n.tr("Localizable", "screen_notification_settings_room_mention_label") }
   /// To receive notifications, please change your %1$@.
   public static func screenNotificationSettingsSystemNotificationsActionRequired(_ p1: Any) -> String {
     return L10n.tr("Localizable", "screen_notification_settings_system_notifications_action_required", String(describing: p1))

--- a/ElementX/Sources/Mocks/NotificationSettingsProxyMock.swift
+++ b/ElementX/Sources/Mocks/NotificationSettingsProxyMock.swift
@@ -51,5 +51,19 @@ extension NotificationSettingsProxyMock {
                 self.callbacks.send(.settingsDidChange)
             }
         }
+        setRoomMentionEnabledEnabledClosure = { [weak self] enabled in
+            guard let self else { return }
+            self.isRoomMentionEnabledReturnValue = enabled
+            Task {
+                self.callbacks.send(.settingsDidChange)
+            }
+        }
+        setCallEnabledEnabledClosure = { [weak self] enabled in
+            guard let self else { return }
+            self.isCallEnabledReturnValue = enabled
+            Task {
+                self.callbacks.send(.settingsDidChange)
+            }
+        }
     }
 }

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenCoordinator.swift
@@ -19,6 +19,7 @@ import SwiftUI
 
 struct NotificationSettingsScreenCoordinatorParameters {
     let userNotificationCenter: UserNotificationCenterProtocol
+    let notificationSettings: NotificationSettingsProxyProtocol
 }
 
 enum NotificationSettingsScreenCoordinatorAction { }
@@ -37,10 +38,13 @@ final class NotificationSettingsScreenCoordinator: CoordinatorProtocol {
         self.parameters = parameters
         
         viewModel = NotificationSettingsScreenViewModel(appSettings: ServiceLocator.shared.settings,
-                                                        userNotificationCenter: parameters.userNotificationCenter)
+                                                        userNotificationCenter: parameters.userNotificationCenter,
+                                                        notificationSettingsProxy: parameters.notificationSettings)
     }
     
-    func start() { }
+    func start() {
+        viewModel.start()
+    }
         
     func toPresentable() -> AnyView {
         AnyView(NotificationSettingsScreen(context: viewModel.context))

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenCoordinator.swift
@@ -43,7 +43,7 @@ final class NotificationSettingsScreenCoordinator: CoordinatorProtocol {
     }
     
     func start() {
-        viewModel.start()
+        viewModel.fetchInitialContent()
     }
         
     func toPresentable() -> AnyView {

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
@@ -23,14 +23,24 @@ struct NotificationSettingsScreenViewState: BindableState {
     var bindings: NotificationSettingsScreenViewStateBindings
     var strings = NotificationSettingsScreenStrings()
     var isUserPermissionGranted: Bool?
+    var allowedNotificationModes: [RoomNotificationModeProxy] = [.allMessages, .mentionsAndKeywordsOnly]
     
     var showSystemNotificationsAlert: Bool {
         bindings.enableNotifications && isUserPermissionGranted == false
     }
+    
+    var groupChatNotificationSettingsState: NotificationSettingsScreenModeState = .loading
+    var directChatNotificationSettingsState: NotificationSettingsScreenModeState = .loading
+    var applyingChange = false
+    var inconsistentGroupChatsSettings = false
+    var inconsistentDirectChatsSettings = false
 }
 
 struct NotificationSettingsScreenViewStateBindings {
     var enableNotifications = false
+    var enableRoomMention = false
+    var enableCalls = false
+    var alertInfo: AlertInfo<NotificationSettingsScreenErrorType>?
 }
 
 struct NotificationSettingsScreenStrings {
@@ -45,9 +55,58 @@ struct NotificationSettingsScreenStrings {
         
         return text
     }()
+    
+    func string(for mode: RoomNotificationModeProxy) -> String {
+        switch mode {
+        case .allMessages:
+            return L10n.screenNotificationSettingsModeAll
+        case .mentionsAndKeywordsOnly:
+            return L10n.screenNotificationSettingsModeMentions
+        case .mute:
+            return L10n.commonMute
+        }
+    }
 }
 
 enum NotificationSettingsScreenViewAction {
     case linkClicked(url: URL)
     case changedEnableNotifications
+    case processTapGroupChats
+    case processTapDirectChats
+    case processToggleRoomMention
+    case processToggleCalls
+}
+
+enum NotificationSettingsScreenModeState {
+    case loading
+    case loaded(mode: RoomNotificationModeProxy)
+    case error
+}
+
+extension NotificationSettingsScreenModeState {
+    var isLoading: Bool {
+        if case .loading = self {
+            return true
+        }
+        return false
+    }
+    
+    var isLoaded: Bool {
+        if case .loaded = self {
+            return true
+        }
+        return false
+    }
+    
+    var isError: Bool {
+        if case .error = self {
+            return true
+        }
+        return false
+    }
+}
+
+enum NotificationSettingsScreenErrorType: Hashable {
+    /// A specific error message shown in an alert.
+    case alert
 }

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
@@ -28,19 +28,26 @@ struct NotificationSettingsScreenViewState: BindableState {
     var showSystemNotificationsAlert: Bool {
         bindings.enableNotifications && isUserPermissionGranted == false
     }
-    
-    var groupChatNotificationSettingsState: NotificationSettingsScreenModeState = .loading
-    var directChatNotificationSettingsState: NotificationSettingsScreenModeState = .loading
+
+    var settings: NotificationSettingsScreenSettings?
     var applyingChange = false
-    var inconsistentGroupChatsSettings = false
-    var inconsistentDirectChatsSettings = false
 }
 
 struct NotificationSettingsScreenViewStateBindings {
     var enableNotifications = false
-    var enableRoomMention = false
-    var enableCalls = false
+    var roomMentionsEnabled = false
+    var callsEnabled = false
     var alertInfo: AlertInfo<NotificationSettingsScreenErrorType>?
+}
+
+struct NotificationSettingsScreenSettings {
+    let groupChatsMode: RoomNotificationModeProxy
+    let directChatsMode: RoomNotificationModeProxy
+    let roomMentionsEnabled: Bool?
+    let callsEnabled: Bool?
+    // Old clients were having specific settings for encrypted and unencrypted rooms,
+    // so it's possible for `group chats` and `direct chats` settings to be inconsistent (e.g. encrypted `direct chats` can have a different mode that unencrypted `direct chats`)
+    let inconsistentSettings: Bool
 }
 
 struct NotificationSettingsScreenStrings {
@@ -71,39 +78,10 @@ struct NotificationSettingsScreenStrings {
 enum NotificationSettingsScreenViewAction {
     case linkClicked(url: URL)
     case changedEnableNotifications
-    case processTapGroupChats
-    case processTapDirectChats
-    case processToggleRoomMention
-    case processToggleCalls
-}
-
-enum NotificationSettingsScreenModeState {
-    case loading
-    case loaded(mode: RoomNotificationModeProxy)
-    case error
-}
-
-extension NotificationSettingsScreenModeState {
-    var isLoading: Bool {
-        if case .loading = self {
-            return true
-        }
-        return false
-    }
-    
-    var isLoaded: Bool {
-        if case .loaded = self {
-            return true
-        }
-        return false
-    }
-    
-    var isError: Bool {
-        if case .error = self {
-            return true
-        }
-        return false
-    }
+    case groupChatsTapped
+    case directChatsTapped
+    case roomMentionChanged
+    case callsChanged
 }
 
 enum NotificationSettingsScreenErrorType: Hashable {

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
@@ -23,14 +23,18 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
     private var actionsSubject: PassthroughSubject<NotificationSettingsScreenViewModelAction, Never> = .init()
     private let appSettings: AppSettings
     private let userNotificationCenter: UserNotificationCenterProtocol
+    private let notificationSettingsProxy: NotificationSettingsProxyProtocol
+    @CancellableTask private var fetchSettingsTask: Task<Void, Error>?
     
     var actions: AnyPublisher<NotificationSettingsScreenViewModelAction, Never> {
         actionsSubject.eraseToAnyPublisher()
     }
 
-    init(appSettings: AppSettings, userNotificationCenter: UserNotificationCenterProtocol) {
+    init(appSettings: AppSettings, userNotificationCenter: UserNotificationCenterProtocol, notificationSettingsProxy: NotificationSettingsProxyProtocol) {
         self.appSettings = appSettings
         self.userNotificationCenter = userNotificationCenter
+        self.notificationSettingsProxy = notificationSettingsProxy
+        
         let bindings = NotificationSettingsScreenViewStateBindings(enableNotifications: appSettings.enableNotifications)
         super.init(initialViewState: NotificationSettingsScreenViewState(bindings: bindings))
                 
@@ -39,6 +43,44 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
             .weakAssign(to: \.state.bindings.enableNotifications, on: self)
             .store(in: &cancellables)
         
+        setupDidBecomeActiveSubscription()
+        setupNotificationSettingsSubscription()
+    }
+    
+    func start() {
+        fetchSettings()
+    }
+        
+    // MARK: - Public
+    
+    override func process(viewAction: NotificationSettingsScreenViewAction) {
+        switch viewAction {
+        case .linkClicked(let url):
+            MXLog.warning("Link clicked: \(url)")
+        case .changedEnableNotifications:
+            toggleNotifications()
+        case .processTapGroupChats:
+            break
+        case .processTapDirectChats:
+            break
+        case .processToggleRoomMention:
+            toggleRoomMention()
+        case .processToggleCalls:
+            toggleCalls()
+        }
+    }
+    
+    // MARK: - Private
+        
+    func readSystemAuthorizationStatus() async {
+        state.isUserPermissionGranted = await userNotificationCenter.authorizationStatus() == .authorized
+    }
+
+    func toggleNotifications() {
+        appSettings.enableNotifications.toggle()
+    }
+    
+    private func setupDidBecomeActiveSubscription() {
         // Refresh authorization status uppon UIApplication.didBecomeActiveNotification notification
         NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in
@@ -52,25 +94,119 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
             await readSystemAuthorizationStatus()
         }
     }
-        
-    // MARK: - Public
     
-    override func process(viewAction: NotificationSettingsScreenViewAction) {
-        switch viewAction {
-        case .linkClicked(let url):
-            MXLog.warning("Link clicked: \(url)")
-        case .changedEnableNotifications:
-            toggleNotifications()
+    private func setupNotificationSettingsSubscription() {
+        notificationSettingsProxy.callbacks
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] callback in
+                guard let self else { return }
+                
+                switch callback {
+                case .settingsDidChange:
+                    self.fetchSettings()
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private struct Settings {
+        var groupChatsMode: RoomNotificationModeProxy = .allMessages
+        var encryptedGroupChatsMode: RoomNotificationModeProxy = .allMessages
+        var directChatsMode: RoomNotificationModeProxy = .allMessages
+        var encryptedDirectChatsMode: RoomNotificationModeProxy = .allMessages
+        var roomMentionState: Result<Bool, Error> = .success(false)
+        var callState: Result<Bool, Error> = .success(false)
+    }
+
+    private func fetchSettings() {
+        fetchSettingsTask = Task {
+            var settings = Settings()
+            
+            // Group chats
+            settings.groupChatsMode = await notificationSettingsProxy.getDefaultNotificationRoomMode(isEncrypted: false, activeMembersCount: 3)
+            settings.encryptedGroupChatsMode = await notificationSettingsProxy.getDefaultNotificationRoomMode(isEncrypted: true, activeMembersCount: 3)
+
+            // Direct chats
+            settings.directChatsMode = await notificationSettingsProxy.getDefaultNotificationRoomMode(isEncrypted: false, activeMembersCount: 2)
+            settings.encryptedDirectChatsMode = await notificationSettingsProxy.getDefaultNotificationRoomMode(isEncrypted: true, activeMembersCount: 2)
+
+            // Room mentions
+            do {
+                settings.roomMentionState = try await .success(notificationSettingsProxy.isRoomMentionEnabled())
+            } catch {
+                settings.roomMentionState = .failure(error)
+            }
+            
+            // Calls
+            do {
+                settings.callState = try await .success(notificationSettingsProxy.isCallEnabled())
+            } catch {
+                settings.callState = .failure(error)
+            }
+            
+            guard !Task.isCancelled else { return }
+            
+            applySettings(settings)
         }
     }
     
-    // MARK: - Private
-    
-    func readSystemAuthorizationStatus() async {
-        state.isUserPermissionGranted = await userNotificationCenter.authorizationStatus() == .authorized
+    private func applySettings(_ settings: Settings) {
+        if settings.groupChatsMode == settings.encryptedGroupChatsMode {
+            state.groupChatNotificationSettingsState = .loaded(mode: settings.groupChatsMode)
+            state.inconsistentGroupChatsSettings = false
+        } else {
+            state.groupChatNotificationSettingsState = .loaded(mode: .allMessages)
+            state.inconsistentGroupChatsSettings = true
+        }
+        
+        if settings.directChatsMode == settings.encryptedDirectChatsMode {
+            state.directChatNotificationSettingsState = .loaded(mode: settings.directChatsMode)
+            state.inconsistentDirectChatsSettings = false
+        } else {
+            state.directChatNotificationSettingsState = .loaded(mode: .allMessages)
+            state.inconsistentDirectChatsSettings = true
+        }
+        
+        if case .success(let enabled) = settings.roomMentionState {
+            state.bindings.enableRoomMention = enabled
+        } else {
+            state.bindings.enableRoomMention = false
+        }
+        
+        if case .success(let enabled) = settings.callState {
+            state.bindings.enableCalls = enabled
+        } else {
+            state.bindings.enableCalls = false
+        }
     }
-
-    func toggleNotifications() {
-        appSettings.enableNotifications.toggle()
+    
+    private func toggleRoomMention() {
+        Task {
+            do {
+                let currentValue = try await notificationSettingsProxy.isRoomMentionEnabled()
+                let newValue = state.bindings.enableRoomMention
+                guard currentValue != newValue else { return }
+                state.applyingChange = true
+                try await notificationSettingsProxy.setRoomMentionEnabled(enabled: newValue)
+            } catch {
+                state.bindings.alertInfo = AlertInfo(id: .alert)
+            }
+            state.applyingChange = false
+        }
+    }
+        
+    func toggleCalls() {
+        Task {
+            do {
+                let currentValue = try await notificationSettingsProxy.isCallEnabled()
+                let newValue = state.bindings.enableCalls
+                guard currentValue != newValue else { return }
+                state.applyingChange = true
+                try await notificationSettingsProxy.setCallEnabled(enabled: newValue)
+            } catch {
+                state.bindings.alertInfo = AlertInfo(id: .alert)
+            }
+            state.applyingChange = false
+        }
     }
 }

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModelProtocol.swift
@@ -21,5 +21,5 @@ protocol NotificationSettingsScreenViewModelProtocol {
     var actions: AnyPublisher<NotificationSettingsScreenViewModelAction, Never> { get }
     var context: NotificationSettingsScreenViewModelType.Context { get }
     
-    func start()
+    func fetchInitialContent()
 }

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModelProtocol.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModelProtocol.swift
@@ -20,4 +20,6 @@ import Combine
 protocol NotificationSettingsScreenViewModelProtocol {
     var actions: AnyPublisher<NotificationSettingsScreenViewModelAction, Never> { get }
     var context: NotificationSettingsScreenViewModelType.Context { get }
+    
+    func start()
 }

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenCoordinator.swift
@@ -21,6 +21,7 @@ struct SettingsScreenCoordinatorParameters {
     weak var userIndicatorController: UserIndicatorControllerProtocol?
     let userSession: UserSessionProtocol
     let bugReportService: BugReportServiceProtocol
+    let notificationSettings: NotificationSettingsProxyProtocol
 }
 
 enum SettingsScreenCoordinatorAction {
@@ -140,9 +141,8 @@ final class SettingsScreenCoordinator: CoordinatorProtocol {
     }
     
     private func presentNotificationSettings() {
-        let notificationParameters = NotificationSettingsScreenCoordinatorParameters(
-            userNotificationCenter: UNUserNotificationCenter.current()
-        )
+        let notificationParameters = NotificationSettingsScreenCoordinatorParameters(userNotificationCenter: UNUserNotificationCenter.current(),
+                                                                                     notificationSettings: parameters.notificationSettings)
         let coordinator = NotificationSettingsScreenCoordinator(parameters: notificationParameters)
         parameters.navigationStackCoordinator?.push(coordinator)
     }

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -169,7 +169,8 @@ class MockScreen: Identifiable {
                                                                           userIndicatorController: nil,
                                                                           userSession: MockUserSession(clientProxy: MockClientProxy(userID: "@mock:client.com"),
                                                                                                        mediaProvider: MockMediaProvider()),
-                                                                          bugReportService: BugReportServiceMock()))
+                                                                          bugReportService: BugReportServiceMock(),
+                                                                          notificationSettings: NotificationSettingsProxyMock(with: .init())))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator
         case .bugReport:
@@ -195,7 +196,8 @@ class MockScreen: Identifiable {
         case .notificationSettingsScreen:
             let userNotificationCenter = UserNotificationCenterMock()
             userNotificationCenter.authorizationStatusReturnValue = .denied
-            let parameters = NotificationSettingsScreenCoordinatorParameters(userNotificationCenter: userNotificationCenter)
+            let parameters = NotificationSettingsScreenCoordinatorParameters(userNotificationCenter: userNotificationCenter,
+                                                                             notificationSettings: NotificationSettingsProxyMock(with: .init()))
             return NotificationSettingsScreenCoordinator(parameters: parameters)
         case .onboarding:
             return OnboardingCoordinator()

--- a/UnitTests/Sources/NotificationManager/NotificationManagerTests.swift
+++ b/UnitTests/Sources/NotificationManager/NotificationManagerTests.swift
@@ -95,6 +95,7 @@ final class NotificationManagerTests: XCTestCase {
     }
     
     func test_whenRegisteredAndPusherTagIsSetInSettings_tagNotGenerated() async throws {
+        notificationCenter.requestAuthorizationOptionsReturnValue = true
         appSettings.pusherProfileTag = "12345"
         _ = await notificationManager.register(with: Data())
         XCTAssertEqual(appSettings.pusherProfileTag, "12345")

--- a/UnitTests/Sources/NotificationSettingsScreenViewModelTests.swift
+++ b/UnitTests/Sources/NotificationSettingsScreenViewModelTests.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import MatrixRustSDK
 import XCTest
 
 @testable import ElementX
@@ -24,6 +25,7 @@ class NotificationSettingsScreenViewModelTests: XCTestCase {
     private var context: NotificationSettingsScreenViewModelType.Context!
     private var appSettings: AppSettings!
     private var userNotificationCenter: UserNotificationCenterMock!
+    private var notificationSettingsProxy: NotificationSettingsProxyMock!
     
     @MainActor override func setUpWithError() throws {
         AppSettings.reset()
@@ -31,8 +33,14 @@ class NotificationSettingsScreenViewModelTests: XCTestCase {
         userNotificationCenter = UserNotificationCenterMock()
         userNotificationCenter.authorizationStatusReturnValue = .authorized
         appSettings = AppSettings()
+        notificationSettingsProxy = NotificationSettingsProxyMock(with: NotificationSettingsProxyMockConfiguration())
+        notificationSettingsProxy.getDefaultNotificationRoomModeIsEncryptedActiveMembersCountReturnValue = .allMessages
+        notificationSettingsProxy.isRoomMentionEnabledReturnValue = true
+        notificationSettingsProxy.isCallEnabledReturnValue = true
+        
         viewModel = NotificationSettingsScreenViewModel(appSettings: appSettings,
-                                                        userNotificationCenter: userNotificationCenter)
+                                                        userNotificationCenter: userNotificationCenter,
+                                                        notificationSettingsProxy: notificationSettingsProxy)
         context = viewModel.context
     }
     
@@ -42,9 +50,172 @@ class NotificationSettingsScreenViewModelTests: XCTestCase {
         XCTAssertTrue(appSettings.enableNotifications)
     }
     
-    func testOptOut() {
+    func testDisableNotifications() {
         appSettings.enableNotifications = true
         context.send(viewAction: .changedEnableNotifications)
         XCTAssertFalse(appSettings.enableNotifications)
+    }
+    
+    func testFetchSettings() async throws {
+        notificationSettingsProxy.getDefaultNotificationRoomModeIsEncryptedActiveMembersCountClosure = { isEncrypted, activeMembersCount in
+            switch (isEncrypted, activeMembersCount) {
+            case (_, 2):
+                return .allMessages
+            case (_, _):
+                return .mentionsAndKeywordsOnly
+            }
+        }
+        let deferredDirectChatsSettings = deferFulfillment(viewModel.context.$viewState
+            .collect(6)
+            .first())
+        notificationSettingsProxy.callbacks.send(.settingsDidChange)
+        try await deferredDirectChatsSettings.fulfill()
+        
+        XCTAssertEqual(notificationSettingsProxy.getDefaultNotificationRoomModeIsEncryptedActiveMembersCountCallsCount, 4)
+        XCTAssert(notificationSettingsProxy.isRoomMentionEnabledCalled)
+        XCTAssert(notificationSettingsProxy.isCallEnabledCalled)
+        
+        XCTAssert(isState(context.viewState.groupChatNotificationSettingsState, loadedWithValue: .mentionsAndKeywordsOnly))
+        XCTAssert(isState(context.viewState.directChatNotificationSettingsState, loadedWithValue: .allMessages))
+        XCTAssertFalse(context.viewState.inconsistentGroupChatsSettings)
+        XCTAssertFalse(context.viewState.inconsistentDirectChatsSettings)
+        XCTAssertNil(context.viewState.bindings.alertInfo)
+    }
+    
+    func isState(_ state: NotificationSettingsScreenModeState, loadedWithValue value: RoomNotificationModeProxy) -> Bool {
+        switch state {
+        case .loaded(let mode):
+            return mode == value
+        default:
+            return false
+        }
+    }
+    
+    func testInconsistentGroupChatsSettings() async throws {
+        notificationSettingsProxy.getDefaultNotificationRoomModeIsEncryptedActiveMembersCountClosure = { isEncrypted, activeMembersCount in
+            switch (isEncrypted, activeMembersCount) {
+            case (true, 3):
+                return .allMessages
+            case (false, 3):
+                return .mentionsAndKeywordsOnly
+            default:
+                return .allMessages
+            }
+        }
+                
+        let deferred = deferFulfillment(viewModel.context.$viewState.map(\.inconsistentGroupChatsSettings)
+            .removeDuplicates()
+            .collect(2)
+            .first())
+        notificationSettingsProxy.callbacks.send(.settingsDidChange)
+        let states = try await deferred.fulfill()
+        
+        XCTAssertEqual(states, [false, true])
+        XCTAssert(isState(context.viewState.groupChatNotificationSettingsState, loadedWithValue: .allMessages))
+        XCTAssert(context.viewState.inconsistentGroupChatsSettings)
+        XCTAssertFalse(context.viewState.inconsistentDirectChatsSettings)
+    }
+    
+    func testInconsistentDirectChatsSettings() async throws {
+        notificationSettingsProxy.getDefaultNotificationRoomModeIsEncryptedActiveMembersCountClosure = { isEncrypted, activeMembersCount in
+            switch (isEncrypted, activeMembersCount) {
+            case (true, 2):
+                return .allMessages
+            case (false, 2):
+                return .mentionsAndKeywordsOnly
+            default:
+                return .allMessages
+            }
+        }
+                
+        let deferred = deferFulfillment(viewModel.context.$viewState.map(\.inconsistentDirectChatsSettings)
+            .removeDuplicates()
+            .collect(2)
+            .first())
+        notificationSettingsProxy.callbacks.send(.settingsDidChange)
+        let states = try await deferred.fulfill()
+        
+        XCTAssertEqual(states, [false, true])
+        XCTAssert(isState(context.viewState.directChatNotificationSettingsState, loadedWithValue: .allMessages))
+        XCTAssertFalse(context.viewState.inconsistentGroupChatsSettings)
+        XCTAssert(context.viewState.inconsistentDirectChatsSettings)
+    }
+    
+    func testToggleRoomMentionOff() async throws {
+        notificationSettingsProxy.isRoomMentionEnabledReturnValue = true
+        context.enableRoomMention = false
+        let deferred = deferFulfillment(notificationSettingsProxy.callbacks
+            .first(where: { $0 == .settingsDidChange }))
+        context.send(viewAction: .processToggleRoomMention)
+        try await deferred.fulfill()
+        
+        XCTAssert(notificationSettingsProxy.setRoomMentionEnabledEnabledCalled)
+        XCTAssertEqual(notificationSettingsProxy.setRoomMentionEnabledEnabledReceivedEnabled, false)
+    }
+    
+    func testToggleRoomMentionOn() async throws {
+        notificationSettingsProxy.isRoomMentionEnabledReturnValue = false
+        context.enableRoomMention = true
+        let deferred = deferFulfillment(notificationSettingsProxy.callbacks
+            .first(where: { $0 == .settingsDidChange }))
+        context.send(viewAction: .processToggleRoomMention)
+        try await deferred.fulfill()
+        
+        XCTAssert(notificationSettingsProxy.setRoomMentionEnabledEnabledCalled)
+        XCTAssertEqual(notificationSettingsProxy.setRoomMentionEnabledEnabledReceivedEnabled, true)
+    }
+    
+    func testToggleRoomMentionFailure() async throws {
+        notificationSettingsProxy.setRoomMentionEnabledEnabledThrowableError = NotificationSettingsError.Generic(message: "error")
+        notificationSettingsProxy.isRoomMentionEnabledReturnValue = false
+        context.enableRoomMention = true
+        let deferred = deferFulfillment(context.$viewState.map(\.applyingChange)
+            .removeDuplicates()
+            .collect(3)
+            .first())
+        context.send(viewAction: .processToggleRoomMention)
+        let states = try await deferred.fulfill()
+        
+        XCTAssertEqual(states, [false, true, false])
+        XCTAssertNotNil(context.alertInfo)
+    }
+    
+    func testToggleCallsOff() async throws {
+        notificationSettingsProxy.isCallEnabledReturnValue = true
+        context.enableCalls = false
+        let deferred = deferFulfillment(notificationSettingsProxy.callbacks
+            .first(where: { $0 == .settingsDidChange }))
+        context.send(viewAction: .processToggleCalls)
+        try await deferred.fulfill()
+        
+        XCTAssert(notificationSettingsProxy.setCallEnabledEnabledCalled)
+        XCTAssertEqual(notificationSettingsProxy.setCallEnabledEnabledReceivedEnabled, false)
+    }
+    
+    func testToggleCallsOn() async throws {
+        notificationSettingsProxy.isCallEnabledReturnValue = false
+        context.enableCalls = true
+        let deferred = deferFulfillment(notificationSettingsProxy.callbacks
+            .first(where: { $0 == .settingsDidChange }))
+        context.send(viewAction: .processToggleCalls)
+        try await deferred.fulfill()
+
+        XCTAssert(notificationSettingsProxy.setCallEnabledEnabledCalled)
+        XCTAssertEqual(notificationSettingsProxy.setCallEnabledEnabledReceivedEnabled, true)
+    }
+    
+    func testToggleCallsFailure() async throws {
+        notificationSettingsProxy.setCallEnabledEnabledThrowableError = NotificationSettingsError.Generic(message: "error")
+        notificationSettingsProxy.isCallEnabledReturnValue = false
+        context.enableCalls = true
+        let deferred = deferFulfillment(context.$viewState.map(\.applyingChange)
+            .removeDuplicates()
+            .collect(3)
+            .first())
+        context.send(viewAction: .processToggleCalls)
+        let states = try await deferred.fulfill()
+        
+        XCTAssertEqual(states, [false, true, false])
+        XCTAssertNotNil(context.alertInfo)
     }
 }


### PR DESCRIPTION
This PR implements #1024 and #1025 

Notes: 
- Notification settings are linked to the `notificationSettingsEnabled` feature flag
- The banner described in #1024 will be implemented in a later PR
- A fix will be submitted later on MatrixRustSDK to fix an issue when enabling `@room` mentions

<img src="https://github.com/vector-im/element-x-ios/assets/4334885/63b10c2d-fb8d-41ba-8e7c-b77e159c0b5c" width=25% height=25%>

<img src="https://github.com/vector-im/element-x-ios/assets/4334885/34628973-65e1-4e79-b426-18ec696d36ff" width=25% height=25%>
