### PR TITLE
Fix DM avatars not showing up in room headers. Use the roomListItem a…

### DIFF
--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -148,7 +148,7 @@ class RoomProxy: RoomProxyProtocol {
     }
     
     var avatarURL: URL? {
-        room.avatarUrl().flatMap(URL.init(string:))
+        roomListItem.avatarUrl().flatMap(URL.init(string:))
     }
 
     var encryptionBadgeImage: UIImage? {


### PR DESCRIPTION
…vatar instead of the fullRoom one.