### PR TITLE
SwiftUI timeline tweaks

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -80,6 +80,8 @@ enum RoomScreenViewAction {
 
     case retrySend(itemID: TimelineItemIdentifier)
     case cancelSend(itemID: TimelineItemIdentifier)
+    
+    case scrolledToBottom
 }
 
 struct RoomScreenViewState: BindableState {
@@ -94,7 +96,7 @@ struct RoomScreenViewState: BindableState {
     var timelineViewState = TimelineViewState() // check the doc before changing this
     var composerMode: RoomScreenComposerMode = .default
     var swiftUITimelineEnabled = false
-
+    
     var bindings: RoomScreenViewStateBindings
     
     /// A closure providing the actions to show when long pressing on an item in the timeline.
@@ -109,7 +111,7 @@ struct RoomScreenViewStateBindings {
     var composerText: String
     var composerFocused: Bool
     
-    var scrollToBottomButtonVisible = false
+    var isScrolledToBottom = true
     var showAttachmentPopover = false {
         didSet {
             composerFocused = false
@@ -184,12 +186,15 @@ struct TimelineViewState {
     var scrollToBottomPublisher = PassthroughSubject<Void, Never>()
 
     var itemsDictionary = OrderedDictionary<String, RoomTimelineItemViewState>()
+    
+    var renderedTimelineIDs = [String]()
+    var pendingTimelineIDs = [String]()
 
     var timelineIDs: [String] {
         itemsDictionary.keys.elements
     }
 
     var itemViewStates: [RoomTimelineItemViewState] {
-        itemsDictionary.values.elements
+        renderedTimelineIDs.compactMap { itemsDictionary[$0] }
     }
 }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -299,7 +299,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             }
         }
         
-        // The SwiftUI scroll view needs special handling, see `selectivellyUpdateTimelineItems`
+        // The SwiftUI scroll view needs special handling, see `selectivelyUpdateTimelineItems`
         if state.swiftUITimelineEnabled {
             selectivelyUpdateTimelineItems(timelineItemsDictionary: timelineItemsDictionary)
         } else {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -304,6 +304,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             selectivelyUpdateTimelineItems(timelineItemsDictionary: timelineItemsDictionary)
         } else {
             state.timelineViewState.itemsDictionary = timelineItemsDictionary
+            state.timelineViewState.renderedTimelineIDs = Array(timelineItemsDictionary.keys)
         }
     }
 

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -80,6 +80,11 @@ struct RoomScreen: View {
                     context.send(viewAction: .cancelSend(itemID: info.itemID))
                 }
             }
+            .onChange(of: context.isScrolledToBottom) { isScrolledToBottom in
+                if isScrolledToBottom {
+                    context.send(viewAction: .scrolledToBottom)
+                }
+            }
     }
 
     private var timeline: some View {
@@ -94,7 +99,7 @@ struct RoomScreen: View {
     private var timelineSwitch: some View {
         if context.viewState.swiftUITimelineEnabled {
             TimelineView(viewState: context.viewState.timelineViewState,
-                         scrollToBottomButtonVisible: $context.scrollToBottomButtonVisible) {
+                         isScrolledToBottom: $context.isScrolledToBottom) {
                 context.send(viewAction: .paginateBackwards)
             }
         } else {
@@ -121,9 +126,9 @@ struct RoomScreen: View {
                 }
                 .padding()
         }
-        .opacity(context.scrollToBottomButtonVisible ? 1.0 : 0.0)
-        .accessibilityHidden(!context.scrollToBottomButtonVisible)
-        .animation(.elementDefault, value: context.scrollToBottomButtonVisible)
+        .opacity(context.isScrolledToBottom ? 0.0 : 1.0)
+        .accessibilityHidden(context.isScrolledToBottom)
+        .animation(.elementDefault, value: context.isScrolledToBottom)
     }
     
     private var messageComposer: some View {

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
@@ -56,8 +56,7 @@ struct TimelineItemPlainStylerView<Content: View>: View {
                     Rectangle()
                         .foregroundColor(.global.melon)
                         .frame(width: 4.0)
-                    TimelineReplyView(placement: .timeline,
-                                      timelineItemReplyDetails: replyDetails)
+                    TimelineReplyView(placement: .timeline, timelineItemReplyDetails: replyDetails)
                 }
             }
             

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/TimelineTableViewController.swift
@@ -68,7 +68,7 @@ class TimelineTableViewController: UIViewController {
         
     var contextMenuActionProvider: (@MainActor (_ itemID: TimelineItemIdentifier) -> TimelineItemMenuActions?)?
     
-    @Binding private var scrollToBottomButtonVisible: Bool
+    @Binding private var isScrolledToBottom: Bool
 
     private var timelineItemsIDs: [String] {
         timelineItemsDictionary.keys.elements.reversed()
@@ -90,11 +90,11 @@ class TimelineTableViewController: UIViewController {
     
     init(coordinator: UITimelineView.Coordinator,
          timelineStyle: TimelineStyle,
-         scrollToBottomButtonVisible: Binding<Bool>,
+         isScrolledToBottom: Binding<Bool>,
          scrollToBottomPublisher: PassthroughSubject<Void, Never>) {
         self.coordinator = coordinator
         self.timelineStyle = timelineStyle
-        _scrollToBottomButtonVisible = scrollToBottomButtonVisible
+        _isScrolledToBottom = isScrolledToBottom
         
         super.init(nibName: nil, bundle: nil)
         
@@ -253,11 +253,11 @@ extension TimelineTableViewController: UITableViewDelegate {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             
-            let scrollToBottomButtonVisible = scrollView.contentOffset.y > 0
+            let isScrolledToBottom = scrollView.contentOffset.y <= 0
             
             // Only update the binding on changes to avoid needlessly recomputing the hierarchy when scrolling.
-            if self.scrollToBottomButtonVisible != scrollToBottomButtonVisible {
-                self.scrollToBottomButtonVisible = scrollToBottomButtonVisible
+            if self.isScrolledToBottom != isScrolledToBottom {
+                self.isScrolledToBottom = isScrolledToBottom
             }
         }
 

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/UITimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/UITimelineView.swift
@@ -24,7 +24,7 @@ struct UITimelineView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> TimelineTableViewController {
         let tableViewController = TimelineTableViewController(coordinator: context.coordinator,
                                                               timelineStyle: timelineStyle,
-                                                              scrollToBottomButtonVisible: $viewModelContext.scrollToBottomButtonVisible,
+                                                              isScrolledToBottom: $viewModelContext.isScrolledToBottom,
                                                               scrollToBottomPublisher: viewModelContext.viewState.timelineViewState.scrollToBottomPublisher)
         return tableViewController
     }

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineView.swift
@@ -21,7 +21,7 @@ import SwiftUIIntrospect
 
 struct TimelineView: View {
     let viewState: TimelineViewState
-    @Binding var scrollToBottomButtonVisible: Bool
+    @Binding var isScrolledToBottom: Bool
     let paginationAction: () -> Void
 
     @Environment(\.timelineStyle) private var timelineStyle
@@ -61,17 +61,17 @@ struct TimelineView: View {
                 .scrollDismissesKeyboard(.immediately)
         }
         .overlay(scrollToBottomButton, alignment: .bottomTrailing)
-        .animation(.elementDefault, value: viewState.timelineIDs)
         .onReceive(scrollViewAdapter.didScroll) { _ in
             guard let scrollView = scrollViewAdapter.scrollView else {
                 return
             }
             let offset = scrollView.contentOffset.y + scrollView.contentInset.top
 
-            // We give it a bit of tollerance which solves the issue when of it being displayed when the keyboard appears
-            let scrollToBottomButtonVisibleValue = offset > 5
-            if scrollToBottomButtonVisibleValue != scrollToBottomButtonVisible {
-                scrollToBottomButtonVisible = scrollToBottomButtonVisibleValue
+            let isScrolledToBottom = offset <= 0
+            
+            // Only update the binding on changes to avoid needlessly recomputing the hierarchy when scrolling.
+            if self.isScrolledToBottom != isScrolledToBottom {
+                self.isScrolledToBottom = isScrolledToBottom
             }
 
             // Allows the scroll to top to work properly
@@ -100,6 +100,7 @@ struct TimelineView: View {
                         .scaleEffect(x: 1, y: -1)
                 }
             }
+            .animation(.elementDefault, value: viewState.itemViewStates)
             topPin
         }
     }
@@ -138,9 +139,9 @@ struct TimelineView: View {
                 }
                 .padding()
         }
-        .opacity(scrollToBottomButtonVisible ? 1.0 : 0.0)
-        .accessibilityHidden(!scrollToBottomButtonVisible)
-        .animation(.elementDefault, value: scrollToBottomButtonVisible)
+        .opacity(isScrolledToBottom ? 0.0 : 1.0)
+        .accessibilityHidden(isScrolledToBottom)
+        .animation(.elementDefault, value: isScrolledToBottom)
     }
 
     private func paginateBackwardsIfNeeded() {

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
@@ -23,7 +23,7 @@ struct RoomEventStringBuilder {
         self.stateEventStringBuilder = stateEventStringBuilder
     }
     
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    // swiftlint:disable:next cyclomatic_complexity
     func buildAttributedString(for eventItemProxy: EventTimelineItemProxy) -> AttributedString? {
         let sender = eventItemProxy.sender
         let isOutgoing = eventItemProxy.isOwn

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -75,7 +75,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         do {
             let listUpdatesSubscriptionResult = try roomList.entries(listener: RoomListEntriesListenerProxy { [weak self] updates in
                 guard let self else { return }
-                MXLog.verbose("\(name): Received list update")
+                MXLog.info("\(name): Received list update")
                 diffsPublisher.send(updates)
             })
 
@@ -119,7 +119,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
             span.exit()
         }
         
-        MXLog.verbose("\(name): Received \(diffs.count) diffs, current room list \(rooms.compactMap { $0.id ?? "Empty" })")
+        MXLog.info("\(name): Received \(diffs.count) diffs, current room list \(rooms.compactMap { $0.id ?? "Empty" })")
         
         rooms = diffs
             .reduce(rooms) { currentItems, diff in
@@ -138,7 +138,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         
         detectDuplicatesInRoomList(rooms)
         
-        MXLog.verbose("\(name): Finished applying \(diffs.count) diffs, new room list \(rooms.compactMap { $0.id ?? "Empty" })")
+        MXLog.info("\(name): Finished applying \(diffs.count) diffs, new room list \(rooms.compactMap { $0.id ?? "Empty" })")
     }
 
     private func fetchLastMessage(roomListItem: RoomListItemProtocol) -> EventTimelineItem? {
@@ -212,36 +212,36 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         
         switch diff {
         case .pushFront(let value):
-            MXLog.verbose("\(name): Push Front \(value.debugIdentifier)")
+            MXLog.info("\(name): Push Front \(value.debugIdentifier)")
             let summary = buildSummaryForRoomListEntry(value)
             changes.append(.insert(offset: 0, element: summary, associatedWith: nil))
         case .pushBack(let value):
-            MXLog.verbose("\(name): Push Back \(value.debugIdentifier)")
+            MXLog.info("\(name): Push Back \(value.debugIdentifier)")
             let summary = buildSummaryForRoomListEntry(value)
             changes.append(.insert(offset: rooms.count, element: summary, associatedWith: nil))
         case .append(values: let values):
             let debugIdentifiers = values.map(\.debugIdentifier)
-            MXLog.verbose("\(name): Append \(debugIdentifiers)")
+            MXLog.info("\(name): Append \(debugIdentifiers)")
             for (index, value) in values.enumerated() {
                 let summary = buildSummaryForRoomListEntry(value)
                 changes.append(.insert(offset: rooms.count + index, element: summary, associatedWith: nil))
             }
         case .set(let index, let value):
-            MXLog.verbose("\(name): Update \(value.debugIdentifier) at \(index)")
+            MXLog.info("\(name): Update \(value.debugIdentifier) at \(index)")
             let summary = buildSummaryForRoomListEntry(value)
             changes.append(.remove(offset: Int(index), element: summary, associatedWith: nil))
             changes.append(.insert(offset: Int(index), element: summary, associatedWith: nil))
         case .insert(let index, let value):
-            MXLog.verbose("\(name): Insert at \(value.debugIdentifier) at \(index)")
+            MXLog.info("\(name): Insert at \(value.debugIdentifier) at \(index)")
             let summary = buildSummaryForRoomListEntry(value)
             changes.append(.insert(offset: Int(index), element: summary, associatedWith: nil))
         case .remove(let index):
             let summary = rooms[Int(index)]
-            MXLog.verbose("\(name): Remove \(summary.id ?? "") from \(index)")
+            MXLog.info("\(name): Remove \(summary.id ?? "") from \(index)")
             changes.append(.remove(offset: Int(index), element: summary, associatedWith: nil))
         case .reset(let values):
             let debugIdentifiers = values.map(\.debugIdentifier)
-            MXLog.verbose("\(name): Replace all items with \(debugIdentifiers)")
+            MXLog.info("\(name): Replace all items with \(debugIdentifiers)")
             for (index, summary) in rooms.enumerated() {
                 changes.append(.remove(offset: index, element: summary, associatedWith: nil))
             }
@@ -250,16 +250,16 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
                 changes.append(.insert(offset: index, element: buildSummaryForRoomListEntry(value), associatedWith: nil))
             }
         case .clear:
-            MXLog.verbose("\(name): Clear all items")
+            MXLog.info("\(name): Clear all items")
             for (index, value) in rooms.enumerated() {
                 changes.append(.remove(offset: index, element: value, associatedWith: nil))
             }
         case .popFront:
-            MXLog.verbose("\(name): Pop Front")
+            MXLog.info("\(name): Pop Front")
             let summary = rooms[0]
             changes.append(.remove(offset: 0, element: summary, associatedWith: nil))
         case .popBack:
-            MXLog.verbose("\(name): Pop Back")
+            MXLog.info("\(name): Pop Back")
             guard let value = rooms.last else {
                 fatalError()
             }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 struct RoomTimelineItemView: View {
     @EnvironmentObject private var context: RoomScreenViewModel.Context
     @ObservedObject var viewState: RoomTimelineItemViewState
-
+    
     var body: some View {
         timelineView
             .animation(.elementDefault, value: viewState.groupStyle)

--- a/UnitTests/Sources/RoomNotificationSettingsScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomNotificationSettingsScreenViewModelTests.swift
@@ -122,7 +122,7 @@ class RoomNotificationSettingsScreenViewModelTests: XCTestCase {
         try await deferredState.fulfill()
 
         do {
-            var deferredViewState = deferFulfillment(context.$viewState.collect(2).first())
+            let deferredViewState = deferFulfillment(context.$viewState.collect(2).first())
             context.send(viewAction: .setCustomMode(.allMessages))
             try await deferredViewState.fulfill()
             
@@ -132,7 +132,7 @@ class RoomNotificationSettingsScreenViewModelTests: XCTestCase {
         }
         
         do {
-            var deferredViewState = deferFulfillment(context.$viewState.collect(2).first())
+            let deferredViewState = deferFulfillment(context.$viewState.collect(2).first())
             context.send(viewAction: .setCustomMode(.mute))
             try await deferredViewState.fulfill()
             
@@ -142,7 +142,7 @@ class RoomNotificationSettingsScreenViewModelTests: XCTestCase {
         }
         
         do {
-            var deferredViewState = deferFulfillment(context.$viewState.collect(2).first())
+            let deferredViewState = deferFulfillment(context.$viewState.collect(2).first())
             context.send(viewAction: .setCustomMode(.mentionsAndKeywordsOnly))
             try await deferredViewState.fulfill()
             


### PR DESCRIPTION
Delay rendering bottom timeline items when scrolled up and avoid content shifts
- builds on top of langleyd/timeline_defer_new_items
- improve animations