### PR TITLE
Send read receipts as messages are displayed.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -91,10 +91,6 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
         }
     }
     
-    func stop() {
-        viewModel.context.send(viewAction: .markRoomAsRead)
-    }
-    
     func toPresentable() -> AnyView {
         AnyView(RoomScreen(context: viewModel.context))
     }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -59,8 +59,7 @@ enum RoomScreenViewAction {
     case toggleReaction(key: String, itemID: TimelineItemIdentifier)
     case cancelReply
     case cancelEdit
-    /// Mark the entire room as read - this is heavy handed as a starting point for now.
-    case markRoomAsRead
+    case sendReadReceiptIfNeeded(TimelineItemIdentifier)
     case paginateBackwards
     
     case timelineItemMenu(itemID: TimelineItemIdentifier)
@@ -85,7 +84,7 @@ enum RoomScreenViewAction {
 }
 
 struct RoomScreenViewState: BindableState {
-    var roomId: String
+    var roomID: String
     var roomTitle = ""
     var roomAvatarURL: URL?
     var members: [String: RoomMemberState] = [:]

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomHeaderView.swift
@@ -40,7 +40,7 @@ struct RoomHeaderView: View {
     @ViewBuilder private var roomAvatar: some View {
         LoadableAvatarImage(url: context.viewState.roomAvatarURL,
                             name: context.viewState.roomTitle,
-                            contentID: context.viewState.roomId,
+                            contentID: context.viewState.roomID,
                             avatarSize: .room(on: .timeline),
                             imageProvider: context.imageProvider)
             .accessibilityIdentifier(A11yIdentifiers.roomScreen.avatar)

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -56,13 +56,6 @@ struct RoomScreen: View {
             }
             .interactiveQuickLook(item: $context.mediaPreviewItem)
             .track(screen: .room)
-            .task(id: context.viewState.roomId) {
-                // Give a couple of seconds for items to load and to see them.
-                try? await Task.sleep(for: .seconds(2))
-                
-                guard !Task.isCancelled else { return }
-                context.send(viewAction: .markRoomAsRead)
-            }
             .onDrop(of: ["public.item"], isTargeted: $dragOver) { providers -> Bool in
                 guard let provider = providers.first,
                       provider.isSupportedForPasteOrDrop else {
@@ -89,7 +82,7 @@ struct RoomScreen: View {
 
     private var timeline: some View {
         timelineSwitch
-            .id(context.viewState.roomId)
+            .id(context.viewState.roomID)
             .environmentObject(context)
             .environment(\.timelineStyle, context.viewState.timelineStyle)
             .environment(\.readReceiptsEnabled, context.viewState.readReceiptsEnabled)

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/TimelineTableViewController.swift
@@ -48,6 +48,8 @@ class TimelineTableViewController: UIViewController {
             if timelineItemsDictionary.isEmpty {
                 paginateBackwardsPublisher.send()
             }
+            
+            sendReadReceiptIfNeeded()
         }
     }
 
@@ -241,6 +243,15 @@ class TimelineTableViewController: UIViewController {
         
         coordinator.send(viewAction: .paginateBackwards)
     }
+    
+    private func sendReadReceiptIfNeeded() {
+        guard let lastVisibleItemIndexPath = tableView.indexPathsForVisibleRows?.first,
+              let lastVisibleItemTimelineID = dataSource?.itemIdentifier(for: lastVisibleItemIndexPath),
+              let lastVisibleItemID = timelineItemsDictionary[lastVisibleItemTimelineID]?.identifier
+        else { return }
+        
+        coordinator.send(viewAction: .sendReadReceiptIfNeeded(lastVisibleItemID))
+    }
 }
 
 // MARK: - UITableViewDelegate
@@ -270,6 +281,18 @@ extension TimelineTableViewController: UITableViewDelegate {
     func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
         scrollToTop(animated: true)
         return false
+    }
+    
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        sendReadReceiptIfNeeded()
+    }
+    
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        sendReadReceiptIfNeeded()
+    }
+    
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        sendReadReceiptIfNeeded()
     }
 }
 

--- a/ElementX/Sources/Services/Timeline/TimelineController/MockRoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/MockRoomTimelineController.swift
@@ -26,7 +26,8 @@ class MockRoomTimelineController: RoomTimelineControllerProtocol {
     /// An array of timeline items that will be appended in order when ``simulateIncomingItems()`` is called.
     var incomingItems: [RoomTimelineItemProtocol] = []
     
-    let roomID = "MockRoomIdentifier"
+    var roomProxy: RoomProxyProtocol?
+    var roomID: String { roomProxy?.id ?? "MockRoomIdentifier" }
     
     let callbacks = PassthroughSubject<RoomTimelineControllerCallback, Never>()
     
@@ -49,7 +50,15 @@ class MockRoomTimelineController: RoomTimelineControllerProtocol {
         return .success(())
     }
     
-    func markRoomAsRead() async -> Result<Void, RoomTimelineControllerError> { .success(()) }
+    func sendReadReceipt(for itemID: TimelineItemIdentifier) async -> Result<Void, RoomTimelineControllerError> {
+        guard let roomProxy, let eventID = itemID.eventID else { return .failure(.generic) }
+        switch await roomProxy.sendReadReceipt(for: eventID) {
+        case .success:
+            return .success(())
+        case .failure:
+            return .failure(.generic)
+        }
+    }
     
     func processItemAppearance(_ itemID: TimelineItemIdentifier) async { }
     

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
@@ -82,9 +82,9 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
         }
     }
     
-    func markRoomAsRead() async -> Result<Void, RoomTimelineControllerError> {
+    func sendReadReceipt(for itemID: TimelineItemIdentifier) async -> Result<Void, RoomTimelineControllerError> {
         guard roomProxy.hasUnreadNotifications,
-              let eventID = timelineItems.last?.id.eventID
+              let eventID = itemID.eventID
         else { return .success(()) }
         
         switch await roomProxy.sendReadReceipt(for: eventID) {

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineControllerProtocol.swift
@@ -49,7 +49,7 @@ protocol RoomTimelineControllerProtocol {
     
     func paginateBackwards(requestSize: UInt, untilNumberOfItems: UInt) async -> Result<Void, RoomTimelineControllerError>
     
-    func markRoomAsRead() async -> Result<Void, RoomTimelineControllerError>
+    func sendReadReceipt(for itemID: TimelineItemIdentifier) async -> Result<Void, RoomTimelineControllerError>
     
     func sendMessage(_ message: String, inReplyTo itemID: TimelineItemIdentifier?) async
 

--- a/changelog.d/639.bugfix
+++ b/changelog.d/639.bugfix
@@ -1,0 +1,1 @@
+Send read receipts as messages are displayed instead of on opening/closing rooms.


### PR DESCRIPTION
This PR changes read receipt sending to match Android, tracking the ID of the last sent read receipt, and sending if needed as items are added and the timeline is scrolled.

Note: This isn't plummed into the SwiftUI timeline as we really need iOS 17's `scrollPosition(id:anchor:)` to determine visible items given we can't use the hacks from the home screen due to cells having unique sizes.

Fixes #639.