### PR TITLE
Fix a bug when dismissing a media preview.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -256,6 +256,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
 
         switch action {
         case .displayMediaFile(let file, let title):
+            state.bindings.composerFocused = false // Hide the keyboard otherwise a big white space is sometimes shown when dismissing the preview.
             state.bindings.mediaPreviewItem = MediaPreviewItem(file: file, title: title)
         case .displayLocation(let body, let geoURI, let description):
             callback?(.displayLocation(body: body, geoURI: geoURI, description: description))

--- a/changelog.d/pr-1428.bugfix
+++ b/changelog.d/pr-1428.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where media previews would sometimes dismiss to show the timeline with a big empty space at the bottom.


### PR DESCRIPTION
Currently if you tap on a media item when the keyboard is visible, dismissing the item sometimes returns you to a view where the composer is pushed up by a big white empty space where the keyboard would normally be. This PR makes sure the composer resigns focus before displaying the preview.