### PR TITLE
Send the SDK's short git SHA to rageshakes

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -206,6 +206,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
         ServiceLocator.shared.register(bugReportService: BugReportService(withBaseURL: ServiceLocator.shared.settings.bugReportServiceBaseURL,
                                                                           sentryURL: ServiceLocator.shared.settings.bugReportSentryURL,
                                                                           applicationId: ServiceLocator.shared.settings.bugReportApplicationId,
+                                                                          sdkGitSHA: sdkGitSha(),
                                                                           maxUploadSize: ServiceLocator.shared.settings.bugReportMaxUploadSize))
         ServiceLocator.shared.register(analytics: AnalyticsService(client: PostHogAnalyticsClient(),
                                                                    appSettings: ServiceLocator.shared.settings,

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -24,6 +24,7 @@ class BugReportService: NSObject, BugReportServiceProtocol {
     private let baseURL: URL
     private let sentryURL: URL
     private let applicationId: String
+    private let sdkGitSHA: String
     private let maxUploadSize: Int
     private let session: URLSession
     private var lastCrashEventId: String?
@@ -33,11 +34,13 @@ class BugReportService: NSObject, BugReportServiceProtocol {
     init(withBaseURL baseURL: URL,
          sentryURL: URL,
          applicationId: String,
+         sdkGitSHA: String,
          maxUploadSize: Int,
          session: URLSession = .shared) {
         self.baseURL = baseURL
         self.sentryURL = sentryURL
         self.applicationId = applicationId
+        self.sdkGitSHA = sdkGitSHA
         self.maxUploadSize = maxUploadSize
         self.session = session
         super.init()
@@ -198,6 +201,7 @@ class BugReportService: NSObject, BugReportServiceProtocol {
             MultipartFormData(key: "app", type: .text(value: applicationId)),
             MultipartFormData(key: "version", type: .text(value: InfoPlistReader.main.bundleShortVersionString)),
             MultipartFormData(key: "build", type: .text(value: InfoPlistReader.main.bundleVersion)),
+            MultipartFormData(key: "sdk_sha", type: .text(value: sdkGitSHA)),
             MultipartFormData(key: "os", type: .text(value: os)),
             MultipartFormData(key: "resolved_languages", type: .text(value: Bundle.app.preferredLocalizations.joined(separator: ", "))),
             MultipartFormData(key: "user_languages", type: .text(value: Locale.preferredLanguages.joined(separator: ", "))),

--- a/UnitTests/Sources/BugReportServiceTests.swift
+++ b/UnitTests/Sources/BugReportServiceTests.swift
@@ -51,6 +51,7 @@ class BugReportServiceTests: XCTestCase {
         let service = BugReportService(withBaseURL: "https://www.example.com",
                                        sentryURL: "https://1234@sentry.com/1234",
                                        applicationId: "mock_app_id",
+                                       sdkGitSHA: "1234",
                                        maxUploadSize: ServiceLocator.shared.settings.bugReportMaxUploadSize,
                                        session: .mock)
         XCTAssertFalse(service.crashedLastRun)
@@ -60,6 +61,7 @@ class BugReportServiceTests: XCTestCase {
         let service = BugReportService(withBaseURL: "https://www.example.com",
                                        sentryURL: "https://1234@sentry.com/1234",
                                        applicationId: "mock_app_id",
+                                       sdkGitSHA: "1234",
                                        maxUploadSize: ServiceLocator.shared.settings.bugReportMaxUploadSize,
                                        session: .mock)
 


### PR DESCRIPTION
Implemented this Rust side a long time ago but forgot to actually use it anywhere