### PR TITLE
Add a link to the global settings in the room notifications settings

### DIFF
--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenCoordinator.swift
@@ -189,7 +189,8 @@ final class RoomDetailsScreenCoordinator: CoordinatorProtocol {
     }
     
     private func presentNotificationSettings() {
-        let roomNotificationSettingsParameters = RoomNotificationSettingsScreenCoordinatorParameters(notificationSettingsProxy: parameters.notificationSettings,
+        let roomNotificationSettingsParameters = RoomNotificationSettingsScreenCoordinatorParameters(navigationStackCoordinator: parameters.navigationStackCoordinator,
+                                                                                                     notificationSettingsProxy: parameters.notificationSettings,
                                                                                                      roomProxy: parameters.roomProxy)
         let roomNotificationSettingsCoordinator = RoomNotificationSettingsScreenCoordinator(parameters: roomNotificationSettingsParameters)
         navigationStackCoordinator?.push(roomNotificationSettingsCoordinator)

--- a/ElementX/Sources/Screens/RoomNotificationSettingsScreen/RoomNotificationSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomNotificationSettingsScreen/RoomNotificationSettingsScreenModels.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-enum RoomNotificationSettingsScreenViewModelAction { }
+enum RoomNotificationSettingsScreenViewModelAction {
+    case openGlobalSettings
+}
 
 enum RoomNotificationSettingsState {
     case loading
@@ -66,6 +68,7 @@ struct RoomNotificationSettingsScreenViewStateBindings {
 enum RoomNotificationSettingsScreenViewAction {
     case changedAllowCustomSettings
     case setCustomMode(RoomNotificationModeProxy)
+    case globalSettingsTapped
 }
 
 struct RoomNotificationSettingsScreenStrings {

--- a/ElementX/Sources/Screens/RoomNotificationSettingsScreen/RoomNotificationSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomNotificationSettingsScreen/RoomNotificationSettingsScreenModels.swift
@@ -68,16 +68,20 @@ struct RoomNotificationSettingsScreenViewStateBindings {
 enum RoomNotificationSettingsScreenViewAction {
     case changedAllowCustomSettings
     case setCustomMode(RoomNotificationModeProxy)
-    case globalSettingsTapped
+    case customSettingFootnoteLinkTapped
 }
 
 struct RoomNotificationSettingsScreenStrings {
     let customSettingFootnote: AttributedString
+    let customSettingFootnoteLink: URL?
     
     init() {
+        customSettingFootnoteLink = URL(string: "element://openGlobalSettings")
+        
         let linkPlaceholder = "{link}"
         var customSettingFootnote = AttributedString(L10n.screenRoomNotificationSettingsDefaultSettingFootnote(linkPlaceholder))
         var linkString = AttributedString(L10n.screenRoomNotificationSettingsDefaultSettingFootnoteContentLink)
+        linkString.link = customSettingFootnoteLink
         linkString.bold()
         customSettingFootnote.replace(linkPlaceholder, with: linkString)
         

--- a/ElementX/Sources/Screens/RoomNotificationSettingsScreen/RoomNotificationSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomNotificationSettingsScreen/RoomNotificationSettingsScreenViewModel.swift
@@ -48,7 +48,7 @@ class RoomNotificationSettingsScreenViewModel: RoomNotificationSettingsScreenVie
             toogleCustomSetting()
         case .setCustomMode(let mode):
             setCustomMode(mode)
-        case .globalSettingsTapped:
+        case .customSettingFootnoteLinkTapped:
             actionsSubject.send(.openGlobalSettings)
         }
     }

--- a/ElementX/Sources/Screens/RoomNotificationSettingsScreen/RoomNotificationSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomNotificationSettingsScreen/RoomNotificationSettingsScreenViewModel.swift
@@ -48,6 +48,8 @@ class RoomNotificationSettingsScreenViewModel: RoomNotificationSettingsScreenVie
             toogleCustomSetting()
         case .setCustomMode(let mode):
             setCustomMode(mode)
+        case .globalSettingsTapped:
+            actionsSubject.send(.openGlobalSettings)
         }
     }
     

--- a/ElementX/Sources/Screens/RoomNotificationSettingsScreen/View/RoomNotificationSettingsScreen.swift
+++ b/ElementX/Sources/Screens/RoomNotificationSettingsScreen/View/RoomNotificationSettingsScreen.swift
@@ -71,6 +71,9 @@ struct RoomNotificationSettingsScreen: View {
                 .compoundFormSectionHeader()
         } footer: {
             Text(context.viewState.strings.customSettingFootnote)
+                .onTapGesture {
+                    context.send(viewAction: .globalSettingsTapped)
+                }
                 .compoundFormSectionFooter()
         }
         .compoundFormSection()

--- a/ElementX/Sources/Screens/RoomNotificationSettingsScreen/View/RoomNotificationSettingsScreen.swift
+++ b/ElementX/Sources/Screens/RoomNotificationSettingsScreen/View/RoomNotificationSettingsScreen.swift
@@ -71,9 +71,11 @@ struct RoomNotificationSettingsScreen: View {
                 .compoundFormSectionHeader()
         } footer: {
             Text(context.viewState.strings.customSettingFootnote)
-                .onTapGesture {
-                    context.send(viewAction: .globalSettingsTapped)
-                }
+                .environment(\.openURL, OpenURLAction { url in
+                    guard url == context.viewState.strings.customSettingFootnoteLink else { return .discarded }
+                    context.send(viewAction: .customSettingFootnoteLinkTapped)
+                    return .handled
+                })
                 .compoundFormSectionFooter()
         }
         .compoundFormSection()

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenCoordinator.swift
@@ -23,20 +23,16 @@ struct NotificationSettingsScreenCoordinatorParameters {
     let isModallyPresented: Bool
 }
 
-enum NotificationSettingsScreenCoordinatorResult {
+enum NotificationSettingsScreenCoordinatorAction {
     case close
 }
-
-enum NotificationSettingsScreenCoordinatorAction { }
 
 final class NotificationSettingsScreenCoordinator: CoordinatorProtocol {
     private let parameters: NotificationSettingsScreenCoordinatorParameters
     private var viewModel: NotificationSettingsScreenViewModelProtocol
     private let actionsSubject: PassthroughSubject<NotificationSettingsScreenCoordinatorAction, Never> = .init()
     private var cancellables: Set<AnyCancellable> = .init()
-    
-    var completion: ((NotificationSettingsScreenCoordinatorResult) -> Void)?
-    
+        
     var actions: AnyPublisher<NotificationSettingsScreenCoordinatorAction, Never> {
         actionsSubject.eraseToAnyPublisher()
     }
@@ -53,9 +49,13 @@ final class NotificationSettingsScreenCoordinator: CoordinatorProtocol {
     func start() {
         viewModel.fetchInitialContent()
         
-        viewModel.actions.sink { [weak self] _ in
-            self?.completion?(.close)
-        }.store(in: &cancellables)
+        viewModel.actions.sink { [weak self] action in
+            switch action {
+            case .close:
+                self?.actionsSubject.send(.close)
+            }
+        }
+        .store(in: &cancellables)
     }
         
     func toPresentable() -> AnyView {

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
@@ -17,6 +17,10 @@
 import Foundation
 import UIKit
 
+enum NotificationSettingsScreenViewModelAction {
+    case close
+}
+
 struct NotificationSettingsScreenViewState: BindableState {
     var bindings: NotificationSettingsScreenViewStateBindings
     var strings = NotificationSettingsScreenStrings()
@@ -81,10 +85,6 @@ enum NotificationSettingsScreenViewAction {
     case directChatsTapped
     case roomMentionChanged
     case callsChanged
-    case close
-}
-
-enum NotificationSettingsScreenViewModelAction {
     case close
 }
 

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
@@ -17,11 +17,10 @@
 import Foundation
 import UIKit
 
-enum NotificationSettingsScreenViewModelAction { }
-
 struct NotificationSettingsScreenViewState: BindableState {
     var bindings: NotificationSettingsScreenViewStateBindings
     var strings = NotificationSettingsScreenStrings()
+    let isModallyPresented: Bool
     var isUserPermissionGranted: Bool?
     var allowedNotificationModes: [RoomNotificationModeProxy] = [.allMessages, .mentionsAndKeywordsOnly]
     
@@ -82,6 +81,11 @@ enum NotificationSettingsScreenViewAction {
     case directChatsTapped
     case roomMentionChanged
     case callsChanged
+    case close
+}
+
+enum NotificationSettingsScreenViewModelAction {
+    case close
 }
 
 enum NotificationSettingsScreenErrorType: Hashable {

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenViewModel.swift
@@ -30,13 +30,13 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
         actionsSubject.eraseToAnyPublisher()
     }
 
-    init(appSettings: AppSettings, userNotificationCenter: UserNotificationCenterProtocol, notificationSettingsProxy: NotificationSettingsProxyProtocol) {
+    init(appSettings: AppSettings, userNotificationCenter: UserNotificationCenterProtocol, notificationSettingsProxy: NotificationSettingsProxyProtocol, isModallyPresented: Bool) {
         self.appSettings = appSettings
         self.userNotificationCenter = userNotificationCenter
         self.notificationSettingsProxy = notificationSettingsProxy
         
         let bindings = NotificationSettingsScreenViewStateBindings(enableNotifications: appSettings.enableNotifications)
-        super.init(initialViewState: NotificationSettingsScreenViewState(bindings: bindings))
+        super.init(initialViewState: NotificationSettingsScreenViewState(bindings: bindings, isModallyPresented: isModallyPresented))
                 
         // Listen for changes to AppSettings.enableNotifications
         appSettings.$enableNotifications
@@ -73,6 +73,8 @@ class NotificationSettingsScreenViewModel: NotificationSettingsScreenViewModelTy
                 return
             }
             Task { await enableCalls(state.bindings.callsEnabled) }
+        case .close:
+            actionsSubject.send(.close)
         }
     }
     

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
@@ -37,12 +37,25 @@ struct NotificationSettingsScreen: View {
         }
         .compoundForm()
         .navigationTitle(L10n.screenNotificationSettingsTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar { toolbar }
         .alert(item: $context.alertInfo)
         .track(screen: .settingsNotifications)
     }
     
     // MARK: - Private
-
+    
+    @ToolbarContentBuilder
+    private var toolbar: some ToolbarContent {
+        if context.viewState.isModallyPresented {
+            ToolbarItem(placement: .confirmationAction) {
+                Button(L10n.actionClose) {
+                    context.send(viewAction: .close)
+                }
+            }
+        }
+    }
+    
     private var userPermissionSection: some View {
         Section {
             HStack(alignment: .firstTextBaseline, spacing: 13) {
@@ -183,7 +196,8 @@ struct NotificationSettingsScreen_Previews: PreviewProvider {
 
         var viewModel = NotificationSettingsScreenViewModel(appSettings: appSettings,
                                                             userNotificationCenter: notificationCenter,
-                                                            notificationSettingsProxy: notificationSettingsProxy)
+                                                            notificationSettingsProxy: notificationSettingsProxy,
+                                                            isModallyPresented: true)
         viewModel.fetchInitialContent()
         return viewModel
     }()

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenCoordinator.swift
@@ -142,7 +142,8 @@ final class SettingsScreenCoordinator: CoordinatorProtocol {
     
     private func presentNotificationSettings() {
         let notificationParameters = NotificationSettingsScreenCoordinatorParameters(userNotificationCenter: UNUserNotificationCenter.current(),
-                                                                                     notificationSettings: parameters.notificationSettings)
+                                                                                     notificationSettings: parameters.notificationSettings,
+                                                                                     isModallyPresented: false)
         let coordinator = NotificationSettingsScreenCoordinator(parameters: notificationParameters)
         parameters.navigationStackCoordinator?.push(coordinator)
     }

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -195,7 +195,8 @@ class MockScreen: Identifiable {
             let userNotificationCenter = UserNotificationCenterMock()
             userNotificationCenter.authorizationStatusReturnValue = .denied
             let parameters = NotificationSettingsScreenCoordinatorParameters(userNotificationCenter: userNotificationCenter,
-                                                                             notificationSettings: NotificationSettingsProxyMock(with: .init()))
+                                                                             notificationSettings: NotificationSettingsProxyMock(with: .init()),
+                                                                             isModallyPresented: false)
             return NotificationSettingsScreenCoordinator(parameters: parameters)
         case .onboarding:
             return OnboardingCoordinator()
@@ -481,14 +482,16 @@ class MockScreen: Identifiable {
         case .roomNotificationSettingsDefaultSetting:
             let navigationStackCoordinator = NavigationStackCoordinator()
             let members: [RoomMemberProxyMock] = [.mockInvitedAlice, .mockBob, .mockCharlie]
-            let coordinator = RoomNotificationSettingsScreenCoordinator(parameters: .init(notificationSettingsProxy: NotificationSettingsProxyMock(with: .init(defaultRoomMode: .allMessages, roomMode: .allMessages)),
+            let coordinator = RoomNotificationSettingsScreenCoordinator(parameters: .init(navigationStackCoordinator: navigationStackCoordinator,
+                                                                                          notificationSettingsProxy: NotificationSettingsProxyMock(with: .init(defaultRoomMode: .allMessages, roomMode: .allMessages)),
                                                                                           roomProxy: RoomProxyMock(with: .init(displayName: "test", members: members))))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator
         case .roomNotificationSettingsCustomSetting:
             let navigationStackCoordinator = NavigationStackCoordinator()
             let members: [RoomMemberProxyMock] = [.mockInvitedAlice, .mockBob, .mockCharlie]
-            let coordinator = RoomNotificationSettingsScreenCoordinator(parameters: .init(notificationSettingsProxy: NotificationSettingsProxyMock(with: .init(defaultRoomMode: .allMessages, roomMode: .mentionsAndKeywordsOnly)),
+            let coordinator = RoomNotificationSettingsScreenCoordinator(parameters: .init(navigationStackCoordinator: navigationStackCoordinator,
+                                                                                          notificationSettingsProxy: NotificationSettingsProxyMock(with: .init(defaultRoomMode: .allMessages, roomMode: .mentionsAndKeywordsOnly)),
                                                                                           roomProxy: RoomProxyMock(with: .init(displayName: "test", members: members))))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator

--- a/UnitTests/Sources/NotificationSettingsScreenViewModelTests.swift
+++ b/UnitTests/Sources/NotificationSettingsScreenViewModelTests.swift
@@ -40,7 +40,8 @@ class NotificationSettingsScreenViewModelTests: XCTestCase {
         
         viewModel = NotificationSettingsScreenViewModel(appSettings: appSettings,
                                                         userNotificationCenter: userNotificationCenter,
-                                                        notificationSettingsProxy: notificationSettingsProxy)
+                                                        notificationSettingsProxy: notificationSettingsProxy,
+                                                        isModallyPresented: false)
         context = viewModel.context
     }
     


### PR DESCRIPTION
This PR implements #1045 

On the room notification screen, when the user taps on "You can change it in your global settings", the notification settings screen opens modally.
