### PR TITLE
Add an empty state on the home screen.

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 		76BA28216FBAF83B2D86A027 /* InvitesScreenCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2A71915C1F075E403F559C /* InvitesScreenCell.swift */; };
 		7756C4E90CABE6F14F7920A0 /* BugReportUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6FEA87EA3752203065ECE27 /* BugReportUITests.swift */; };
 		77920AFA8091AC6B9F190C90 /* Signposter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752A0EB49BF5BCEA37EDF7A3 /* Signposter.swift */; };
+		77BB228AEA861E50FFD6A228 /* HomeScreenEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FEA560929DD73FFEF8C3DF /* HomeScreenEmptyStateView.swift */; };
 		77C1A2F49CD90D3EFDF376E5 /* MapTilerURLBuildersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376D941BF8BB294389C0DE24 /* MapTilerURLBuildersTests.swift */; };
 		77D7DAA41AAB36800C1F2E2D /* RoomTimelineProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095AED4CF56DFF3EB7BB84C8 /* RoomTimelineProviderProtocol.swift */; };
 		77FACC29F98FE2E65BBB6A5F /* ServerSelectionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054F469E433864CC6FE6EE8E /* ServerSelectionUITests.swift */; };
@@ -1335,6 +1336,7 @@
 		C070FD43DC6BF4E50217965A /* LocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationTests.swift; sourceTree = "<group>"; };
 		C08E9043618AE5B0BF7B07E1 /* TemplateScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateScreenViewModelTests.swift; sourceTree = "<group>"; };
 		C0900BBF0A5D5D775E917C70 /* EventBasedMessageTimelineItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventBasedMessageTimelineItemProtocol.swift; sourceTree = "<group>"; };
+		C0FEA560929DD73FFEF8C3DF /* HomeScreenEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenEmptyStateView.swift; sourceTree = "<group>"; };
 		C1198B925F4A88DA74083662 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		C14D83B2B7CD5501A0089EFC /* LayoutDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutDirection.swift; sourceTree = "<group>"; };
 		C1511766C534367700C8DD75 /* RoomNotificationModeProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomNotificationModeProxy.swift; sourceTree = "<group>"; };
@@ -2209,6 +2211,7 @@
 			isa = PBXGroup;
 			children = (
 				B902EA6CD3296B0E10EE432B /* HomeScreen.swift */,
+				C0FEA560929DD73FFEF8C3DF /* HomeScreenEmptyStateView.swift */,
 				24227FF9A2797F6EA7F69CDD /* HomeScreenInvitesButton.swift */,
 				ED044D00F2176681CC02CD54 /* HomeScreenRoomCell.swift */,
 				C7661EFFCAA307A97D71132A /* HomeScreenRoomList.swift */,
@@ -3670,7 +3673,7 @@
 			path = Timeline;
 			sourceTree = "<group>";
 		};
-		"TEMP_F85F8A84-6E1F-4213-A180-41C5B49354D2" /* element-x-ios */ = {
+		"TEMP_9E86D325-D1C7-441E-B1F2-A3D93615813E" /* element-x-ios */ = {
 			isa = PBXGroup;
 			children = (
 				41553551C55AD59885840F0E /* secrets.xcconfig */,
@@ -4364,6 +4367,7 @@
 				4295E5F850897710A51AE114 /* GeoURI.swift in Sources */,
 				964B9D2EC38C488C360CE0C9 /* HomeScreen.swift in Sources */,
 				8CC12086CBF91A7E10CDC205 /* HomeScreenCoordinator.swift in Sources */,
+				77BB228AEA861E50FFD6A228 /* HomeScreenEmptyStateView.swift in Sources */,
 				64C373ACCFA26D42BA45CFAD /* HomeScreenInvitesButton.swift in Sources */,
 				8810A2A30A68252EBB54EE05 /* HomeScreenModels.swift in Sources */,
 				0AE0AB1952F186EB86719B4F /* HomeScreenRoomCell.swift in Sources */,

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -338,6 +338,8 @@
 "screen_room_timeline_add_reaction" = "Add emoji";
 "screen_room_timeline_less_reactions" = "Show less";
 "screen_roomlist_a11y_create_message" = "Create a new conversation or room";
+"screen_roomlist_empty_message" = "Get started by messaging someone.";
+"screen_roomlist_empty_title" = "No chats yet.";
 "screen_roomlist_main_space_title" = "All Chats";
 "screen_server_confirmation_change_server" = "Change account provider";
 "screen_server_confirmation_message_login_element_dot_io" = "A private server for Element employees.";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -856,6 +856,10 @@ public enum L10n {
   }
   /// Create a new conversation or room
   public static var screenRoomlistA11yCreateMessage: String { return L10n.tr("Localizable", "screen_roomlist_a11y_create_message") }
+  /// Get started by messaging someone.
+  public static var screenRoomlistEmptyMessage: String { return L10n.tr("Localizable", "screen_roomlist_empty_message") }
+  /// No chats yet.
+  public static var screenRoomlistEmptyTitle: String { return L10n.tr("Localizable", "screen_roomlist_empty_title") }
   /// All Chats
   public static var screenRoomlistMainSpaceTitle: String { return L10n.tr("Localizable", "screen_roomlist_main_space_title") }
   /// Change account provider

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -51,14 +51,17 @@ enum HomeScreenViewAction {
 
 enum HomeScreenRoomListMode: CustomStringConvertible {
     case skeletons
+    case empty
     case rooms
     
     var description: String {
         switch self {
-        case .rooms:
-            return "Showing rooms"
         case .skeletons:
             return "Showing placeholders"
+        case .empty:
+            return "Showing empty state"
+        case .rooms:
+            return "Showing rooms"
         }
     }
 }

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -92,7 +92,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 if isLoadingData {
                     roomListMode = .skeletons
                 } else if hasNoRooms {
-                    roomListMode = .skeletons
+                    roomListMode = .empty
                 } else {
                     roomListMode = .rooms
                 }

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenEmptyStateView.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenEmptyStateView.swift
@@ -1,0 +1,163 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Combine
+import Compound
+import SwiftUI
+
+/// The view shown when the user isn't part of any rooms.
+struct HomeScreenEmptyStateView: View {
+    let context: HomeScreenViewModel.Context
+    
+    var body: some View {
+        VStack(spacing: 6) {
+            Text(L10n.screenRoomlistEmptyTitle)
+                .font(.compound.bodyLG)
+                .foregroundColor(.compound.textSecondary)
+                .multilineTextAlignment(.center)
+            
+            Text(L10n.screenRoomlistEmptyMessage)
+                .font(.compound.bodyLG)
+                .foregroundColor(.compound.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 12)
+            
+            Button { context.send(viewAction: .startChat) } label: {
+                Label(L10n.actionStartChat, systemImage: "square.and.pencil")
+                    .font(.compound.bodyLGSemibold)
+                    .foregroundColor(.compound.textOnSolidPrimary)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 22)
+            }
+            .buttonStyle(.borderedProminent)
+            .buttonBorderShape(.capsule)
+        }
+        .padding(16)
+    }
+}
+
+/// A custom layout for the empty state which will show it centrally with the
+/// session verification banner and invites button stacked at the top.
+struct HomeScreenEmptyStateLayout: Layout {
+    /// The vertical spacing between views in the layout.
+    var spacing: CGFloat = 8
+    /// The minimum height of the layout. This should be the height of the scroll view.
+    var minHeight: CGFloat = 0
+    
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        // We keep the proposed width and replace the height with the minimum specified,
+        // or the total height of the subviews if it exceeds the minimum height.
+        let width = proposal.width ?? .greatestFiniteMagnitude
+        var height: CGFloat = spacing * CGFloat(max(0, subviews.count - 1))
+        
+        for subview in subviews {
+            let size = subview.sizeThatFits(proposal)
+            height += size.height
+        }
+        
+        return CGSize(width: width, height: max(minHeight, height))
+    }
+    
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let mainView = subviews.first(where: { $0.priority > 0 })
+        let topViews = subviews.filter { $0 != mainView }
+        
+        var y: CGFloat = bounds.minY
+        
+        // Place all the top views in a vertical stack, centering horizontally.
+        for view in topViews {
+            let size = view.sizeThatFits(proposal)
+            let x = (bounds.width - size.width) / 2
+            view.place(at: CGPoint(x: x, y: y), proposal: proposal)
+            y += size.height + spacing
+        }
+        
+        // Place the main view in the center if there is space, otherwise add it to the stack.
+        guard let mainView else { return }
+
+        let mainViewSize = mainView.sizeThatFits(proposal)
+        if (y + mainViewSize.height / 2) < bounds.height / 2 {
+            let center = CGPoint(x: bounds.midX, y: bounds.midY)
+            mainView.place(at: center, anchor: .center, proposal: proposal)
+        } else {
+            let x = (bounds.width - mainViewSize.width) / 2
+            mainView.place(at: CGPoint(x: x, y: y), proposal: proposal)
+        }
+    }
+}
+
+// MARK: - Previews
+
+struct HomeScreenEmptyStateView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeScreenEmptyStateView(context: viewModel.context)
+            .previewDisplayName("View")
+        
+        GeometryReader { geometry in
+            ScrollView {
+                HomeScreenEmptyStateLayout(minHeight: geometry.size.height) {
+                    banner
+                    
+                    HomeScreenEmptyStateView(context: viewModel.context)
+                        .layoutPriority(1)
+                }
+            }
+        }
+        .previewDisplayName("Normal Layout")
+        
+        GeometryReader { geometry in
+            ScrollView {
+                HomeScreenEmptyStateLayout(minHeight: geometry.size.height) {
+                    banner
+                    banner
+                    banner
+                    
+                    HomeScreenEmptyStateView(context: viewModel.context)
+                        .layoutPriority(1)
+                }
+            }
+        }
+        .previewDisplayName("Constrained layout")
+    }
+    
+    // MARK: -
+    
+    static var banner: some View {
+        Text("This is a title that is very long")
+            .font(.compound.headingXLBold)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background {
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(Color.compound.bgSubtleSecondary)
+            }
+            .padding()
+    }
+    
+    static let viewModel = {
+        let userSession = MockUserSession(clientProxy: MockClientProxy(userID: "@user:example.com",
+                                                                       roomSummaryProvider: MockRoomSummaryProvider(state: .loaded([]))),
+                                          mediaProvider: MockMediaProvider())
+        
+        return HomeScreenViewModel(userSession: userSession,
+                                   attributedStringBuilder: AttributedStringBuilder(permalinkBaseURL: ServiceLocator.shared.settings.permalinkBaseURL),
+                                   selectedRoomPublisher: CurrentValueSubject<String?, Never>(nil).asCurrentValuePublisher(),
+                                   appSettings: ServiceLocator.shared.settings,
+                                   analytics: ServiceLocator.shared.analytics,
+                                   userIndicatorController: ServiceLocator.shared.userIndicatorController)
+    }()
+}


### PR DESCRIPTION
This PR adds an empty state on the home screen. It includes a custom layout so that the instructions are central unless the banner and invites button push it downwards (say on a small device or with large dynamic type).

| With banner | With out banner | Dark mode with large type |
| - | - | - |
| ![Simulator Screenshot - iPhone 14 - 2023-08-04 at 19 04 35](https://github.com/vector-im/element-x-ios/assets/6060466/59370090-77a7-430a-b53b-56b6fcc90144) | ![Simulator Screenshot - iPhone 14 - 2023-08-04 at 19 04 37](https://github.com/vector-im/element-x-ios/assets/6060466/4a4b0847-fcfc-4764-84c7-7db1d66fca6c) | ![Simulator Screenshot - iPhone 14 - 2023-08-04 at 19 11 28](https://github.com/vector-im/element-x-ios/assets/6060466/bfa86834-5f0e-43cb-a877-e5939d3f182a) |
