### PR TITLE
Timeline item long press tweaks

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,7 +24,7 @@ line_length:
   error: 1000
 
 file_length:
-  warning: 800
+  warning: 1000
   error: 1000
 
 type_name:
@@ -38,8 +38,11 @@ type_body_length:
   error: 1000
 
 function_body_length:
-  warning: 50
+  warning: 100
   error: 100
+
+cyclomatic_complexity:
+  ignores_case_statements: true
 
 nesting:
   type_level:

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -241,7 +241,6 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
         userSessionStore.reset()
     }
     
-    // swiftlint:disable:next cyclomatic_complexity
     private func setupStateMachine() {
         stateMachine.addTransitionHandler { [weak self] context in
             guard let self else { return }

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -95,7 +95,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     
     // MARK: - Private
     
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    // swiftlint:disable:next function_body_length
     private func setupStateMachine() {
         stateMachine.addRouteMapping { event, fromState, _ in
             switch (event, fromState) {
@@ -258,7 +258,6 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
         }
     }
     
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func asyncPresentRoom(_ roomID: String, animated: Bool, destinationRoomProxy: RoomProxyProtocol? = nil) async {
         if let roomProxy, roomProxy.id == roomID {
             navigationStackCoordinator.popToRoot()

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -135,7 +135,6 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
 
     // MARK: - Private
     
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func setupStateMachine() {
         stateMachine.addTransitionHandler { [weak self] context in
             guard let self else { return }
@@ -241,7 +240,6 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         }
     }
     
-    // swiftlint:disable:next cyclomatic_complexity
     private func presentHomeScreen() {
         let parameters = HomeScreenCoordinatorParameters(userSession: userSession,
                                                          attributedStringBuilder: AttributedStringBuilder(permalinkBaseURL: ServiceLocator.shared.settings.permalinkBaseURL),

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
@@ -114,7 +114,6 @@ class UserSessionFlowCoordinatorStateMachine {
         configure()
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     private func configure() {
         stateMachine.addRoutes(event: .start, transitions: [.initial => .roomList(selectedRoomID: nil)])
         stateMachine.addRoutes(event: .startWithMigration, transitions: [.initial => .migration])

--- a/ElementX/Sources/Other/Extensions/Array.swift
+++ b/ElementX/Sources/Other/Extensions/Array.swift
@@ -67,3 +67,9 @@ extension Array {
         return newItems
     }
 }
+
+extension Array where Element == RoomTimelineItemProtocol {
+    func firstUsingStableID(_ id: TimelineItemIdentifier) -> Element? {
+        first { $0.id.timelineID == id.timelineID }
+    }
+}

--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -101,7 +101,6 @@ extension UNMutableNotificationContent {
         return self
     }
 
-    // swiftlint:disable:next function_body_length
     func addSenderIcon(using mediaProvider: MediaProviderProtocol?,
                        senderID: String,
                        senderName: String,

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -34,7 +34,6 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
     
     var callback: ((HomeScreenViewModelAction) -> Void)?
     
-    // swiftlint:disable:next function_body_length cyclomatic_complexity
     init(userSession: UserSessionProtocol,
          attributedStringBuilder: AttributedStringBuilderProtocol,
          selectedRoomPublisher: CurrentValuePublisher<String?, Never>,
@@ -156,7 +155,6 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
     
     // MARK: - Public
     
-    // swiftlint:disable:next cyclomatic_complexity
     override func process(viewAction: HomeScreenViewAction) {
         switch viewAction {
         case .selectRoom(let roomIdentifier):

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -69,7 +69,6 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
     
     // MARK: - Public
     
-    // swiftlint:disable:next cyclomatic_complexity
     override func process(viewAction: RoomDetailsScreenViewAction) {
         switch viewAction {
         case .processTapPeople:

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenCoordinator.swift
@@ -59,7 +59,6 @@ final class RoomScreenCoordinator: CoordinatorProtocol {
     
     // MARK: - Public
     
-    // swiftlint:disable:next cyclomatic_complexity
     func start() {
         viewModel.callback = { [weak self] action in
             guard let self else { return }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -81,7 +81,6 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
 
     var callback: ((RoomScreenViewModelAction) -> Void)?
     
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     override func process(viewAction: RoomScreenViewAction) {
         switch viewAction {
         case .displayRoomDetails:
@@ -539,7 +538,6 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         item.isOutgoing || (canCurrentUserRedact && !roomProxy.isDirect)
     }
     
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func processTimelineItemMenuAction(_ action: TimelineItemMenuAction, itemID: TimelineItemIdentifier) {
         guard let timelineItem = timelineController.timelineItems.firstUsingStableID(itemID),
               let eventTimelineItem = timelineItem as? EventBasedTimelineItemProtocol else {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -469,7 +469,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     // MARK: TimelineItemActionMenu
     
     private func showTimelineItemActionMenu(for itemID: TimelineItemIdentifier) {
-        guard let timelineItem = timelineController.timelineItems.first(where: { $0.id == itemID }),
+        guard let timelineItem = timelineController.timelineItems.firstUsingStableID(itemID),
               let eventTimelineItem = timelineItem as? EventBasedTimelineItemProtocol else {
             // Don't show a menu for non-event based items.
             return
@@ -479,7 +479,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     }
     
     private func timelineItemMenuActionsForItemId(_ itemID: TimelineItemIdentifier) -> TimelineItemMenuActions? {
-        guard let timelineItem = timelineController.timelineItems.first(where: { $0.id == itemID }),
+        guard let timelineItem = timelineController.timelineItems.firstUsingStableID(itemID),
               let item = timelineItem as? EventBasedTimelineItemProtocol else {
             // Don't show a context menu for non-event based items.
             return nil
@@ -541,7 +541,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func processTimelineItemMenuAction(_ action: TimelineItemMenuAction, itemID: TimelineItemIdentifier) {
-        guard let timelineItem = timelineController.timelineItems.first(where: { $0.id == itemID }),
+        guard let timelineItem = timelineController.timelineItems.firstUsingStableID(itemID),
               let eventTimelineItem = timelineItem as? EventBasedTimelineItemProtocol else {
             return
         }
@@ -766,7 +766,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     // MARK: - Reactions
     
     private func showEmojiPicker(for itemID: TimelineItemIdentifier) {
-        guard let timelineItem = timelineController.timelineItems.first(where: { $0.id == itemID }),
+        guard let timelineItem = timelineController.timelineItems.firstUsingStableID(itemID),
               timelineItem.isReactable,
               let eventTimelineItem = timelineItem as? EventBasedTimelineItemProtocol else {
             return
@@ -776,7 +776,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     }
     
     private func showReactionSummary(for itemID: TimelineItemIdentifier, selectedKey: String) {
-        guard let timelineItem = timelineController.timelineItems.first(where: { $0.id == itemID }),
+        guard let timelineItem = timelineController.timelineItems.firstUsingStableID(itemID),
               let eventTimelineItem = timelineItem as? EventBasedTimelineItemProtocol else {
             return
         }

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/LongPressWithFeedback.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/LongPressWithFeedback.swift
@@ -33,7 +33,7 @@ struct LongPressWithFeedback: ViewModifier {
             .animation(isLongPressing ? .spring(response: 0.5).delay(0.1) : .spring(response: 0.5),
                        value: isLongPressing)
             // The minimum duration here doesn't actually invoke the perform block when elapsed (thus
-            // the implementation bellow) but it does cancel other system gestures e.g. swipe to reply
+            // the implementation below) but it does cancel other system gestures e.g. swipe to reply
             .onLongPressGesture(minimumDuration: 0.25) { } onPressingChanged: { isPressing in
                 isLongPressing = isPressing
                 

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/LongPressWithFeedback.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/LongPressWithFeedback.swift
@@ -19,6 +19,7 @@ import SwiftUI
 struct LongPressWithFeedback: ViewModifier {
     let action: () -> Void
     
+    @State private var triggerTask: Task<Void, Never>?
     @State private var isLongPressing = false
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .heavy)
     
@@ -29,15 +30,27 @@ struct LongPressWithFeedback: ViewModifier {
             .shadow(color: .black.opacity(isLongPressing ? 0.1 : 0.0), radius: isLongPressing ? 3 : 0)
             .scaleEffect(x: isLongPressing ? 1.05 : 1,
                          y: isLongPressing ? 1.05 : 1)
-            .animation(isLongPressing ? .spring(response: 1.5).delay(0.2) : .spring(response: 0.5),
+            .animation(isLongPressing ? .spring(response: 0.5).delay(0.1) : .spring(response: 0.5),
                        value: isLongPressing)
-            .onLongPressGesture(minimumDuration: 0.25) {
-                action()
-                feedbackGenerator.impactOccurred()
-            } onPressingChanged: { isPressing in
+            // The minimum duration here doesn't actually invoke the perform block when elapsed (thus
+            // the implementation bellow) but it does cancel other system gestures e.g. swipe to reply
+            .onLongPressGesture(minimumDuration: 0.25) { } onPressingChanged: { isPressing in
                 isLongPressing = isPressing
-                if isPressing {
-                    feedbackGenerator.prepare()
+                
+                guard isPressing else {
+                    triggerTask?.cancel()
+                    return
+                }
+                
+                feedbackGenerator.prepare()
+                
+                triggerTask = Task {
+                    try? await Task.sleep(for: .seconds(0.35))
+                    
+                    if Task.isCancelled { return }
+                    
+                    action()
+                    feedbackGenerator.impactOccurred()
                 }
             }
     }

--- a/ElementX/Sources/Screens/SessionVerificationScreen/SessionVerificationScreenStateMachine.swift
+++ b/ElementX/Sources/Screens/SessionVerificationScreen/SessionVerificationScreenStateMachine.swift
@@ -83,7 +83,6 @@ class SessionVerificationScreenStateMachine {
         configure()
     }
     
-    // swiftlint:disable:next cyclomatic_complexity
     private func configure() {
         stateMachine.addRoutes(event: .requestVerification, transitions: [.initial => .requestingVerification])
         stateMachine.addRoutes(event: .didAcceptVerificationRequest, transitions: [.requestingVerification => .verificationRequestAccepted])

--- a/ElementX/Sources/Services/BugReport/BugReportService.swift
+++ b/ElementX/Sources/Services/BugReport/BugReportService.swift
@@ -101,7 +101,6 @@ class BugReportService: NSObject, BugReportServiceProtocol {
         SentrySDK.crash()
     }
 
-    // swiftlint:disable:next function_body_length cyclomatic_complexity
     func submitBugReport(_ bugReport: BugReport,
                          progressListener: CurrentValueSubject<Double, Never>) async -> Result<SubmitBugReportResponse, BugReportServiceError> {
         var params = [

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
@@ -23,7 +23,6 @@ struct RoomEventStringBuilder {
         self.stateEventStringBuilder = stateEventStringBuilder
     }
     
-    // swiftlint:disable:next cyclomatic_complexity
     func buildAttributedString(for eventItemProxy: EventTimelineItemProxy) -> AttributedString? {
         let sender = eventItemProxy.sender
         let isOutgoing = eventItemProxy.isOwn

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -206,7 +206,6 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         }
     }
     
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func buildDiff(from diff: RoomListEntriesUpdate, on rooms: [RoomSummary]) -> CollectionDifference<RoomSummary>? {
         var changes = [CollectionDifference<RoomSummary>.Change]()
         

--- a/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
+++ b/ElementX/Sources/Services/Timeline/RoomTimelineProvider.swift
@@ -89,7 +89,7 @@ class RoomTimelineProvider: RoomTimelineProviderProtocol {
         MXLog.verbose("Finished applying diffs, current items (\(itemProxies.count)) : \(itemProxies.map(\.debugIdentifier))")
     }
     
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    // swiftlint:disable:next cyclomatic_complexity
     private func buildDiff(from diff: TimelineDiff, on itemProxies: [TimelineItemProxy]) -> CollectionDifference<TimelineItemProxy>? {
         var changes = [CollectionDifference<TimelineItemProxy>.Change]()
         

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
@@ -96,7 +96,7 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
     }
     
     func processItemAppearance(_ itemID: TimelineItemIdentifier) async {
-        guard let timelineItem = timelineItems.first(where: { $0.id == itemID }) else {
+        guard let timelineItem = timelineItems.firstUsingStableID(itemID) else {
             return
         }
         
@@ -108,7 +108,7 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
     func processItemDisappearance(_ itemID: TimelineItemIdentifier) { }
 
     func processItemTap(_ itemID: TimelineItemIdentifier) async -> RoomTimelineControllerAction {
-        guard let timelineItem = timelineItems.first(where: { $0.id == itemID }) else {
+        guard let timelineItem = timelineItems.firstUsingStableID(itemID) else {
             return .none
         }
         
@@ -158,7 +158,7 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
     
     func editMessage(_ newMessage: String, original itemID: TimelineItemIdentifier) async {
         MXLog.info("Edit message in \(roomID)")
-        if let timelineItem = timelineItems.first(where: { $0.id == itemID }),
+        if let timelineItem = timelineItems.firstUsingStableID(itemID),
            let item = timelineItem as? EventBasedTimelineItemProtocol,
            item.hasFailedToSend {
             MXLog.info("Editing a failed echo, will cancel and resend it as a new message")

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomStateEventStringBuilder.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomStateEventStringBuilder.swift
@@ -20,7 +20,6 @@ import UIKit
 struct RoomStateEventStringBuilder {
     let userID: String
     
-    // swiftlint:disable:next cyclomatic_complexity
     func buildString(for change: MembershipChange?, member: String, sender: TimelineItemSender, isOutgoing: Bool) -> String? {
         guard let change else {
             MXLog.verbose("Filtering timeline item for membership change that is nil")
@@ -76,7 +75,7 @@ struct RoomStateEventStringBuilder {
         }
     }
     
-    // swiftlint:disable:next cyclomatic_complexity function_parameter_count
+    // swiftlint:disable:next function_parameter_count
     func buildProfileChangeString(displayName: String?, previousDisplayName: String?,
                                   avatarURLString: String?, previousAvatarURLString: String?,
                                   member: String, memberIsYou: Bool) -> String? {
@@ -122,7 +121,6 @@ struct RoomStateEventStringBuilder {
         }
     }
     
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     func buildString(for state: OtherState, stateKey: String?, sender: TimelineItemSender, isOutgoing: Bool) -> String? {
         let senderName = sender.displayName ?? sender.id
         

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -36,7 +36,6 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
         self.stateEventStringBuilder = stateEventStringBuilder
     }
     
-    // swiftlint:disable:next cyclomatic_complexity
     func buildTimelineItem(for eventItemProxy: EventTimelineItemProxy) -> RoomTimelineItemProtocol? {
         let isOutgoing = eventItemProxy.isOwn
         
@@ -543,7 +542,6 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
     
     // MARK: - Reply details
     
-    // swiftlint:disable:next cyclomatic_complexity
     private func buildReplyToDetailsFrom(details: InReplyToDetails?) -> TimelineItemReplyDetails? {
         guard let details else { return nil }
         

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemViewState.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemViewState.swift
@@ -70,7 +70,6 @@ enum RoomTimelineItemType: Equatable {
     case location(LocationRoomTimelineItem)
     case poll(PollRoomTimelineItem)
 
-    // swiftlint:disable:next cyclomatic_complexity
     init(item: RoomTimelineItemProtocol) {
         switch item {
         case let item as TextRoomTimelineItem:

--- a/UnitTests/Sources/LoggingTests.swift
+++ b/UnitTests/Sources/LoggingTests.swift
@@ -248,7 +248,6 @@ class LoggingTests: XCTestCase {
         XCTAssertFalse(content.contains(lastMessage))
     }
     
-    // swiftlint:disable:next function_body_length
     func testTimelineContentIsRedacted() throws {
         // Given timeline items that contain text
         let textAttributedString = "TextAttributed"


### PR DESCRIPTION
* reduces the time it takes for the timeline item long press gesture to trigger
* correctly identifies timeline items based on their stable timelineID so that actions are always correctly computed (fixes #1455)
* tweaks swiftlint to remove various warnings