### PR TITLE
Fixes #1418 - Preserve new lines when parsing html strings

### DIFF
--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -56,13 +56,19 @@ struct AttributedStringBuilder: AttributedStringBuilderProtocol {
     // that could happen with the default HTML renderer of NSAttributedString which is a
     // webview.
     func fromHTML(_ htmlString: String?) -> AttributedString? {
-        guard let htmlString,
-              let data = htmlString.data(using: .utf8) else {
+        guard let htmlString else {
             return nil
         }
         
         if let cached = Self.cache.value(forKey: htmlString) {
             return cached
+        }
+        
+        // Trick DTCoreText into preserving newlines
+        let adjustedHTMLString = htmlString.replacingOccurrences(of: "\n", with: "<br>")
+        
+        guard let data = adjustedHTMLString.data(using: .utf8) else {
+            return nil
         }
         
         let defaultFont = UIFont.preferredFont(forTextStyle: .body)

--- a/UnitTests/Sources/AttributedStringBuilderTests.swift
+++ b/UnitTests/Sources/AttributedStringBuilderTests.swift
@@ -396,6 +396,17 @@ class AttributedStringBuilderTests: XCTestCase {
         XCTAssertEqual(numberOfBlockquotes, 3, "Couldn't find all the blockquotes")
     }
     
+    func testNewLinesArePreserved() {
+        let htmlString = "Bob's\nyour\nuncle\nand\nFanny's\nyour\naunt"
+    
+        guard let attributedString = attributedStringBuilder.fromHTML(htmlString) else {
+            XCTFail("Could not build the attributed string")
+            return
+        }
+        
+        XCTAssertEqual(String(attributedString.characters), htmlString.replacingOccurrences(of: "\n", with: "\u{2028}"))
+    }
+    
     // MARK: - Private
     
     private func checkLinkIn(attributedString: AttributedString?, expectedLink: String, expectedRuns: Int) {


### PR DESCRIPTION
Trick DTCoreText into preserving `\n`s by replacing them with `<br>` tags before processing.