### PR TITLE
Fix reply to media crash caused by missing room context (and implicit…

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -33,6 +33,7 @@ struct RoomScreen: View {
                     .padding(.top, 8)
                     .padding(.bottom)
                     .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
+                    .environmentObject(context)
             }
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { toolbar }

--- a/changelog.d/pr-1472.bugfix
+++ b/changelog.d/pr-1472.bugfix
@@ -1,0 +1,1 @@
+Fixed crash when trying to reply to media files


### PR DESCRIPTION
…ly image provider) on the new composer toolbar