### PR TITLE
Disable timeline in the middle test again.

### DIFF
--- a/UITests/Sources/RoomDetailsScreenUITests.swift
+++ b/UITests/Sources/RoomDetailsScreenUITests.swift
@@ -30,7 +30,7 @@ class RoomDetailsScreenUITests: XCTestCase {
     func testInitialStateComponentsWithRoomAvatar() async throws {
         let app = Application.launch(.roomDetailsScreenWithRoomAvatar)
 
-        XCTAssert(app.images[A11yIdentifiers.roomDetailsScreen.avatar].waitForExistence(timeout: 1))
+        XCTAssert(app.buttons[A11yIdentifiers.roomDetailsScreen.avatar].waitForExistence(timeout: 1))
         XCTAssert(app.buttons[A11yIdentifiers.roomDetailsScreen.people].waitForExistence(timeout: 1))
         try await app.assertScreenshot(.roomDetailsScreenWithRoomAvatar)
     }
@@ -52,7 +52,7 @@ class RoomDetailsScreenUITests: XCTestCase {
     func testInitialStateComponentsDmDetails() async throws {
         let app = Application.launch(.roomDetailsScreenDmDetails)
 
-        XCTAssert(app.images[A11yIdentifiers.roomDetailsScreen.dmAvatar].waitForExistence(timeout: 1))
+        XCTAssert(app.buttons[A11yIdentifiers.roomDetailsScreen.dmAvatar].waitForExistence(timeout: 1))
         XCTAssertFalse(app.buttons[A11yIdentifiers.roomDetailsScreen.people].exists)
         try await app.assertScreenshot(.roomDetailsScreenDmDetails)
     }

--- a/UITests/Sources/RoomScreenUITests.swift
+++ b/UITests/Sources/RoomScreenUITests.swift
@@ -75,7 +75,7 @@ class RoomScreenUITests: XCTestCase {
         try await app.assertScreenshot(.roomSmallTimelineLargePagination)
     }
 
-    func testTimelineLayoutInMiddle() async throws {
+    func disabled_testTimelineLayoutInMiddle() async throws {
         let client = try UITestsSignalling.Client(mode: .tests)
         
         let app = Application.launch(.roomLayoutMiddle)
@@ -100,8 +100,7 @@ class RoomScreenUITests: XCTestCase {
         
         // Then the UI should still remain unchanged.
 
-        // FIXME: the timeline scrolls a bit on new incoming messages
-        // try await app.assertScreenshot(.roomLayoutMiddle, step: 0)
+        try await app.assertScreenshot(.roomLayoutMiddle, step: 0)
         
         // When the keyboard appears for the message composer.
         try await tapMessageComposer(in: app)


### PR DESCRIPTION
After running happily for a few days, it has been failing for the last week, hiding signs of other tests failing.

Additionally fixes the room details avatar changing from an image to a button.

Run going on here: https://github.com/vector-im/element-x-ios/actions/runs/5823415696