### PR TITLE
Fix refresh of location events

### DIFF
--- a/ElementX/Sources/Other/MapLibre/MapLibreStaticMapView.swift
+++ b/ElementX/Sources/Other/MapLibre/MapLibreStaticMapView.swift
@@ -22,7 +22,9 @@ struct MapLibreStaticMapView<PinAnnotation: View>: View {
     private let zoomLevel: Double
     private let mapTilerStatic: MapTilerStaticMapProtocol
     private let mapTilerAttributionPlacement: MapTilerAttributionPlacement
+    private let mapSize: CGSize
     private let pinAnnotationView: PinAnnotation
+
     @Environment(\.colorScheme) private var colorScheme
     @State private var fetchAttempt = 0
     
@@ -30,11 +32,13 @@ struct MapLibreStaticMapView<PinAnnotation: View>: View {
          zoomLevel: Double,
          attributionPlacement: MapTilerAttributionPlacement,
          mapTilerStatic: MapTilerStaticMapProtocol,
+         mapSize: CGSize,
          @ViewBuilder pinAnnotationView: () -> PinAnnotation) {
         self.coordinates = coordinates
         self.zoomLevel = zoomLevel
         self.mapTilerStatic = mapTilerStatic
         mapTilerAttributionPlacement = attributionPlacement
+        self.mapSize = mapSize
         self.pinAnnotationView = pinAnnotationView()
     }
     
@@ -43,7 +47,7 @@ struct MapLibreStaticMapView<PinAnnotation: View>: View {
             if let url = mapTilerStatic.staticMapURL(for: colorScheme.mapStyle,
                                                      coordinates: coordinates,
                                                      zoomLevel: zoomLevel,
-                                                     size: geometry.size,
+                                                     size: mapSize, // temporary using a fixed size since the refresh doesn't work properly on the UITableView based timeline
                                                      attribution: mapTilerAttributionPlacement) {
                 AsyncImage(url: url) { phase in
                     switch phase {
@@ -109,7 +113,7 @@ struct MapLibreStaticMapView_Previews: PreviewProvider {
         MapLibreStaticMapView(coordinates: CLLocationCoordinate2D(),
                               zoomLevel: 15,
                               attributionPlacement: .bottomLeft,
-                              mapTilerStatic: MapTilerStaticMapMock()) {
+                              mapTilerStatic: MapTilerStaticMapMock(), mapSize: .init(width: 300, height: 200)) {
             Image(systemName: "mappin.circle.fill")
                 .padding(.bottom, 35)
         }

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/LocationRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/LocationRoomTimelineView.swift
@@ -27,7 +27,7 @@ struct LocationRoomTimelineView: View {
                     descriptionView
                         .frame(maxWidth: mapAspectRatio * mapMaxHeight, alignment: .leading)
 
-                    MapLibreStaticMapView(geoURI: geoURI) {
+                    MapLibreStaticMapView(geoURI: geoURI, mapSize: .init(width: mapAspectRatio * mapMaxHeight, height: mapMaxHeight)) {
                         LocationMarkerView()
                     }
                     .frame(maxHeight: mapMaxHeight)
@@ -56,12 +56,13 @@ struct LocationRoomTimelineView: View {
 }
 
 private extension MapLibreStaticMapView {
-    init(geoURI: GeoURI, @ViewBuilder pinAnnotationView: () -> PinAnnotation) {
+    init(geoURI: GeoURI, mapSize: CGSize, @ViewBuilder pinAnnotationView: () -> PinAnnotation) {
         self.init(coordinates: .init(latitude: geoURI.latitude, longitude: geoURI.longitude),
                   zoomLevel: 15,
                   attributionPlacement: .bottomLeft,
                   mapTilerStatic: MapTilerStaticMap(baseURL: ServiceLocator.shared.settings.mapTilerBaseURL,
                                                     key: ServiceLocator.shared.settings.mapTilerApiKey),
+                  mapSize: mapSize,
                   pinAnnotationView: pinAnnotationView)
     }
 }


### PR DESCRIPTION
Fix https://github.com/vector-im/element-x-ios/issues/1372
ATM bubbles in the timeline change size (in general, also for other event types) on the UITableView based timeline.
This cause a problems on the location view since the url we fetch is related with the bubble size.
This PR is a workaround for the problem until we switch to the SwiftUI timeline where the problem seems not happening.