### PR TITLE
Run SwiftFormat 0.52.0

### DIFF
--- a/ElementX/Sources/Mocks/SessionVerificationControllerProxyMock.swift
+++ b/ElementX/Sources/Mocks/SessionVerificationControllerProxyMock.swift
@@ -48,7 +48,7 @@ extension SessionVerificationControllerProxyMock {
 
                 Task.detached {
                     try await Task.sleep(for: requestDelay)
-                    mock.callbacks.send(.receivedVerificationData(Self.emojis))
+                    mock.callbacks.send(.receivedVerificationData(emojis))
                 }
             }
 

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreenSelectedItem.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreenSelectedItem.swift
@@ -60,7 +60,7 @@ struct InviteUsersScreenSelectedItem_Previews: PreviewProvider {
     static var previews: some View {
         ScrollView(.horizontal) {
             HStack(spacing: 28) {
-                ForEach(Self.people, id: \.userID) { user in
+                ForEach(people, id: \.userID) { user in
                     InviteUsersScreenSelectedItem(user: user, imageProvider: MockMediaProvider(), dismissAction: { })
                         .frame(width: 72)
                 }

--- a/ElementX/Sources/Services/Background/UIKitBackgroundTaskService.swift
+++ b/ElementX/Sources/Services/Background/UIKitBackgroundTaskService.swift
@@ -112,8 +112,8 @@ private extension UIApplication {
     /// Application instance extension-safe. Will be `nil` on app extensions.
     static var extensionSafeShared: UIApplication? {
         let selector = NSSelectorFromString("sharedApplication")
-        guard Self.responds(to: selector) else { return nil }
-        return Self.perform(selector).takeUnretainedValue() as? UIApplication
+        guard responds(to: selector) else { return nil }
+        return perform(selector).takeUnretainedValue() as? UIApplication
     }
 }
 

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -34,7 +34,7 @@ class MockClientProxy: ClientProxyProtocol {
 
     var isSyncing: Bool { false }
     
-    internal init(userID: String, deviceID: String? = nil, roomSummaryProvider: RoomSummaryProviderProtocol? = MockRoomSummaryProvider()) {
+    init(userID: String, deviceID: String? = nil, roomSummaryProvider: RoomSummaryProviderProtocol? = MockRoomSummaryProvider()) {
         self.userID = userID
         self.deviceID = deviceID
         self.roomSummaryProvider = roomSummaryProvider


### PR DESCRIPTION
SwiftFormat 0.52.0 introduced  some new rules, amongst which `redundantInternal` and `redundantStaticSelf` have some failures in our codebase. This PR runs the command to fix them.