### PR TITLE
Subscription fix

### DIFF
--- a/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
+++ b/ElementX.xcodeproj/xcshareddata/xcschemes/ElementX.xcscheme
@@ -89,7 +89,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "HTTPS_PROXY"
-            value = "192.168.0.111:9090"
+            value = "localhost:9090"
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -282,6 +282,8 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
             roomProxy = proxy
         }
         
+        await roomProxy.subscribeForUpdates()
+        
         actionsSubject.send(.presentedRoom(roomID))
         
         self.roomProxy = roomProxy
@@ -369,6 +371,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     private func asyncPresentRoomDetails(roomID: String, isRoot: Bool, animated: Bool) async {
         if isRoot {
             roomProxy = await userSession.clientProxy.roomForIdentifier(roomID)
+            await roomProxy?.subscribeForUpdates()
         } else {
             await asyncPresentRoom(roomID, animated: animated)
         }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -778,6 +778,18 @@ class RoomProxyMock: RoomProxyProtocol {
     }
     var underlyingTimelineProvider: RoomTimelineProviderProtocol!
 
+    //MARK: - subscribeForUpdates
+
+    var subscribeForUpdatesCallsCount = 0
+    var subscribeForUpdatesCalled: Bool {
+        return subscribeForUpdatesCallsCount > 0
+    }
+    var subscribeForUpdatesClosure: (() async -> Void)?
+
+    func subscribeForUpdates() async {
+        subscribeForUpdatesCallsCount += 1
+        await subscribeForUpdatesClosure?()
+    }
     //MARK: - loadAvatarURLForUserId
 
     var loadAvatarURLForUserIdCallsCount = 0

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -77,6 +77,8 @@ protocol RoomProxyProtocol {
     var updatesPublisher: AnyPublisher<[TimelineDiff], Never> { get }
     
     var timelineProvider: RoomTimelineProviderProtocol { get }
+    
+    func subscribeForUpdates() async
 
     func loadAvatarURLForUserId(_ userId: String) async -> Result<URL?, RoomProxyError>
     

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -23,7 +23,7 @@ schemes:
           value: full
           isEnabled: false
         - variable: HTTPS_PROXY
-          value: 192.168.0.111:9090
+          value: localhost:9090
           isEnabled: false
         - variable: UI_TESTS_SCREEN
           value: ""


### PR DESCRIPTION
The `InvitesScreenViewModel` fetches inviters through RoomProxies which has the side effect of adding subscriptions for all of them. This PR move subscriptions to a different call in order to prevent this from happening in the future