### PR TITLE
feat: Replace `markdown` by manually font configuration

### DIFF
--- a/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
@@ -109,7 +109,8 @@ struct RoomEventStringBuilder {
     private func prefix(_ eventSummary: String, with sender: TimelineItemSender) -> AttributedString {
         let attributedEventSummary = AttributedString(eventSummary.trimmingCharacters(in: .whitespacesAndNewlines))
         if let senderDisplayName = sender.displayName,
-           let attributedSenderDisplayName = try? AttributedString(markdown: "**\(senderDisplayName)**") {
+           let attributedSenderDisplayName = try? AttributedString(senderDisplayName) {
+            attributedSenderDisplayName.font = UIFont.systemFont(weight: .bold)
             // Don't include the message body in the markdown otherwise it makes tappable links.
             return attributedSenderDisplayName + ": " + attributedEventSummary
         } else {


### PR DESCRIPTION
Before all, sorry for trying to write Swift :-].

This patch isn't tested, nor written from inside Xcode. Maybe it's totally broken.

The idea of this patch is to raise a concern about running a Markdown parser just to make the full content of as tring with a bold weight. It can impact the performance.