### PR TITLE
Start using the new (faster) RoomInfo record to populate the room and…

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -1029,6 +1029,7 @@
 		47F29139BC2A804CE5E0757E /* MediaUploadPreviewScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUploadPreviewScreenViewModel.swift; sourceTree = "<group>"; };
 		4959CECEC984B3995616F427 /* DataProtectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProtectionManager.swift; sourceTree = "<group>"; };
 		49D2C8E66E83EA578A7F318A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		49E6066092ED45E36BB306F7 /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		49E751D7EDB6043238111D90 /* UNNotificationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UNNotificationRequest.swift; sourceTree = "<group>"; };
 		4A4AD793D50748F8997E5B15 /* TimelineItemMacContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItemMacContextMenu.swift; sourceTree = "<group>"; };
 		4AB7D7DAAAF662DED9D02379 /* MockMediaLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaLoader.swift; sourceTree = "<group>"; };
@@ -1217,6 +1218,7 @@
 		8FC803282F9268D49F4ABF14 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		90A55430639712CFACA34F43 /* TextRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRoomTimelineItem.swift; sourceTree = "<group>"; };
 		90F2F8998E5632668B0AD848 /* RoomTimelineItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemView.swift; sourceTree = "<group>"; };
+		91CF6F7D08228D16BA69B63B /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		923485F85E1D765EF9D20E88 /* UserProfileCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileCell.swift; sourceTree = "<group>"; };
 		92390F9FA98255440A6BF5F8 /* OIDCAuthenticationPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDCAuthenticationPresenter.swift; sourceTree = "<group>"; };
 		92FCD9116ADDE820E4E30F92 /* UIKitBackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitBackgroundTask.swift; sourceTree = "<group>"; };
@@ -3949,6 +3951,7 @@
 				ro,
 				ru,
 				sk,
+				"zh-Hant-TW",
 			);
 			mainGroup = 405B00F139AEE3994601B36A;
 			packageReferences = (
@@ -4906,6 +4909,7 @@
 				E9D059BFE329BE09B6D96A9F /* ro */,
 				E5F2B6443D1ED8602F328539 /* ru */,
 				667DD3A9D932D7D9EB380CAA /* sk */,
+				49E6066092ED45E36BB306F7 /* zh-Hant-TW */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";
@@ -4922,6 +4926,7 @@
 				33E49C5C6F802B4D94CA78D1 /* ro */,
 				E8294DB9E95C0C0630418466 /* ru */,
 				AD378D580A41E42560C60E9C /* sk */,
+				91CF6F7D08228D16BA69B63B /* zh-Hant-TW */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -5460,7 +5465,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "1.0.107-alpha";
+				version = "1.0.108-alpha";
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -129,8 +129,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "28211915a5a5ca926798d12bedc3bf1a352714fd",
-        "version" : "1.0.107-alpha"
+        "revision" : "3166b3e6d35779aa78025a0b9143def6a7ee1c51",
+        "version" : "1.0.108-alpha"
       }
     },
     {

--- a/ElementX/Sources/Screens/InvitesScreen/InvitesScreenModels.swift
+++ b/ElementX/Sources/Screens/InvitesScreen/InvitesScreenModels.swift
@@ -21,10 +21,6 @@ enum InvitesScreenViewModelAction {
 struct InvitesScreenViewState: BindableState {
     var invites: [InvitesScreenRoomDetails] = []
     var bindings: InvitesScreenViewStateBindings = .init()
-
-    // ideally we wanted to derive this state from `invites` being `Optional.none`.
-    // But we needed to make it a non optional array due to a strange crash in release builds (https://github.com/vector-im/element-x-ios/pull/1120)
-    var isLoading = true
 }
 
 struct InvitesScreenViewStateBindings {
@@ -33,7 +29,6 @@ struct InvitesScreenViewStateBindings {
 
 struct InvitesScreenRoomDetails: Identifiable {
     let roomDetails: RoomSummaryDetails
-    var inviter: RoomMemberProxyProtocol?
     var isUnread: Bool
     
     var isDirect: Bool {

--- a/ElementX/Sources/Screens/InvitesScreen/View/InvitesScreen.swift
+++ b/ElementX/Sources/Screens/InvitesScreen/View/InvitesScreen.swift
@@ -20,17 +20,11 @@ struct InvitesScreen: View {
     @ObservedObject var context: InvitesScreenViewModel.Context
     
     var body: some View {
-        Group {
-            if context.viewState.isLoading {
-                ProgressView()
-            } else {
-                mainContent
-            }
-        }
-        .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
-        .navigationTitle(L10n.actionInvitesList)
-        .alert(item: $context.alertInfo)
-        .track(screen: .invites)
+        mainContent
+            .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
+            .navigationTitle(L10n.actionInvitesList)
+            .alert(item: $context.alertInfo)
+            .track(screen: .invites)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/InvitesScreen/View/InvitesScreenCell.swift
+++ b/ElementX/Sources/Screens/InvitesScreen/View/InvitesScreenCell.swift
@@ -71,9 +71,9 @@ struct InvitesScreenCell: View {
 
     @ViewBuilder
     private var inviterView: some View {
-        if let invitedText = attributedInviteText, let name = invite.inviter?.displayName {
+        if let invitedText = attributedInviteText, let name = invite.roomDetails.inviter?.displayName {
             HStack(alignment: .firstTextBaseline) {
-                LoadableAvatarImage(url: invite.inviter?.avatarURL,
+                LoadableAvatarImage(url: invite.roomDetails.inviter?.avatarURL,
                                     name: name,
                                     contentID: name,
                                     avatarSize: .custom(16),
@@ -125,14 +125,14 @@ struct InvitesScreenCell: View {
     }
     
     private var subtitle: String? {
-        invite.isDirect ? invite.inviter?.userID : invite.roomDetails.canonicalAlias
+        invite.isDirect ? invite.roomDetails.inviter?.userID : invite.roomDetails.canonicalAlias
     }
     
     private var attributedInviteText: AttributedString? {
         guard
             invite.roomDetails.isDirect == false,
-            let inviterName = invite.inviter?.displayName,
-            let inviterID = invite.inviter?.userID
+            let inviterName = invite.roomDetails.inviter?.displayName,
+            let inviterID = invite.roomDetails.inviter?.userID
         else {
             return nil
         }
@@ -178,6 +178,10 @@ struct InvitesScreenCell_Previews: PreviewProvider {
 @MainActor
 private extension InvitesScreenRoomDetails {
     static var dm: InvitesScreenRoomDetails {
+        let inviter = RoomMemberProxyMock()
+        inviter.displayName = "Jack"
+        inviter.userID = "@jack:somewhere.com"
+        
         let dmRoom = RoomSummaryDetails(id: "@someone:somewhere.com",
                                         name: "Some Guy",
                                         isDirect: true,
@@ -185,15 +189,17 @@ private extension InvitesScreenRoomDetails {
                                         lastMessage: nil,
                                         lastMessageFormattedTimestamp: nil,
                                         unreadNotificationCount: 0,
-                                        canonicalAlias: "#footest:somewhere.org")
-        let inviter = RoomMemberProxyMock()
-        inviter.displayName = "Jack"
-        inviter.userID = "@jack:somewhere.com"
-        
-        return .init(roomDetails: dmRoom, inviter: inviter, isUnread: false)
+                                        canonicalAlias: "#footest:somewhere.org",
+                                        inviter: inviter)
+        return .init(roomDetails: dmRoom, isUnread: false)
     }
     
     static func room(alias: String? = nil, avatarURL: URL? = nil, isUnread: Bool = true) -> InvitesScreenRoomDetails {
+        let inviter = RoomMemberProxyMock()
+        inviter.displayName = "Luca"
+        inviter.userID = "@jack:somewhi.nl"
+        inviter.avatarURL = avatarURL
+        
         let dmRoom = RoomSummaryDetails(id: "@someone:somewhere.com",
                                         name: "Awesome Room",
                                         isDirect: false,
@@ -201,12 +207,8 @@ private extension InvitesScreenRoomDetails {
                                         lastMessage: nil,
                                         lastMessageFormattedTimestamp: nil,
                                         unreadNotificationCount: 0,
-                                        canonicalAlias: alias)
-        let inviter = RoomMemberProxyMock()
-        inviter.displayName = "Luca"
-        inviter.userID = "@jack:somewhi.nl"
-        inviter.avatarURL = avatarURL
-        
-        return .init(roomDetails: dmRoom, inviter: inviter, isUnread: isUnread)
+                                        canonicalAlias: alias,
+                                        inviter: inviter)
+        return .init(roomDetails: dmRoom, isUnread: isUnread)
     }
 }

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -399,12 +399,14 @@ class ClientProxy: ClientProxyProtocol {
             roomSummaryProvider = RoomSummaryProvider(roomListService: roomListService,
                                                       eventStringBuilder: eventStringBuilder,
                                                       name: "AllRooms",
-                                                      appSettings: appSettings)
+                                                      appSettings: appSettings,
+                                                      backgroundTaskService: backgroundTaskService)
             try await roomSummaryProvider?.setRoomList(roomListService.allRooms())
             inviteSummaryProvider = RoomSummaryProvider(roomListService: roomListService,
                                                         eventStringBuilder: eventStringBuilder,
                                                         name: "Invites",
-                                                        appSettings: appSettings)
+                                                        appSettings: appSettings,
+                                                        backgroundTaskService: backgroundTaskService)
 
             self.syncService = syncService
             self.roomListService = roomListService

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
@@ -57,7 +57,8 @@ extension Array where Element == RoomSummary {
                                             lastMessage: AttributedString("Prosciutto beef ribs pancetta filet mignon kevin hamburger, chuck ham venison picanha. Beef ribs chislic turkey biltong tenderloin."),
                                             lastMessageFormattedTimestamp: "Now",
                                             unreadNotificationCount: 4,
-                                            canonicalAlias: nil)),
+                                            canonicalAlias: nil,
+                                            inviter: nil)),
         .filled(details: RoomSummaryDetails(id: "2",
                                             name: "Second room",
                                             isDirect: true,
@@ -65,7 +66,8 @@ extension Array where Element == RoomSummary {
                                             lastMessage: nil,
                                             lastMessageFormattedTimestamp: nil,
                                             unreadNotificationCount: 1,
-                                            canonicalAlias: nil)),
+                                            canonicalAlias: nil,
+                                            inviter: nil)),
         .filled(details: RoomSummaryDetails(id: "3",
                                             name: "Third room",
                                             isDirect: true,
@@ -73,7 +75,8 @@ extension Array where Element == RoomSummary {
                                             lastMessage: try? AttributedString(markdown: "**@mock:client.com**: T-bone beef ribs bacon"),
                                             lastMessageFormattedTimestamp: "Later",
                                             unreadNotificationCount: 0,
-                                            canonicalAlias: nil)),
+                                            canonicalAlias: nil,
+                                            inviter: nil)),
         .empty
     ]
     
@@ -84,7 +87,8 @@ extension Array where Element == RoomSummary {
                                             lastMessage: nil,
                                             lastMessageFormattedTimestamp: nil,
                                             unreadNotificationCount: 0,
-                                            canonicalAlias: "#footest:somewhere.org")),
+                                            canonicalAlias: "#footest:somewhere.org",
+                                            inviter: nil)),
         .filled(details: RoomSummaryDetails(id: "someAwesomeRoomId2",
                                             name: "Second room",
                                             isDirect: true,
@@ -92,6 +96,7 @@ extension Array where Element == RoomSummary {
                                             lastMessage: nil,
                                             lastMessageFormattedTimestamp: nil,
                                             unreadNotificationCount: 0,
-                                            canonicalAlias: nil))
+                                            canonicalAlias: nil,
+                                            inviter: nil))
     ]
 }

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryDetails.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryDetails.swift
@@ -15,6 +15,7 @@
 //
 
 import Foundation
+import MatrixRustSDK
 
 struct RoomSummaryDetails {
     let id: String
@@ -25,6 +26,7 @@ struct RoomSummaryDetails {
     let lastMessageFormattedTimestamp: String?
     let unreadNotificationCount: UInt
     let canonicalAlias: String?
+    let inviter: RoomMemberProxyProtocol?
 }
 
 extension RoomSummaryDetails: CustomStringConvertible {

--- a/project.yml
+++ b/project.yml
@@ -45,7 +45,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.0.107-alpha
+    exactVersion: 1.0.108-alpha
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
… invite lists

This brings performance improvements as we no longer need to go over FFI for each of the room's properties. It also exposes the inviter so that we can directly populate the invites list without having to fetch them separately

Fixes https://github.com/vector-im/element-x-ios/issues/1434