### PR TITLE
Fix missing DM URLs.

### DIFF
--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -195,7 +195,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         let details = RoomSummaryDetails(id: roomInfo.id,
                                          name: roomInfo.name ?? roomInfo.id,
                                          isDirect: roomInfo.isDirect,
-                                         avatarURL: roomInfo.avatarUrl.flatMap(URL.init(string:)),
+                                         avatarURL: roomListItem.avatarUrl().flatMap(URL.init(string:)),
                                          lastMessage: attributedLastMessage,
                                          lastMessageFormattedTimestamp: lastMessageFormattedTimestamp,
                                          unreadNotificationCount: UInt(roomInfo.notificationCount),


### PR DESCRIPTION
The new roomInfo struct is reading the avatarURL from the `Room` and not the `RoomListItem` so we've lost DM avatars on the home screen. This PR fixes that.
