### PR TITLE
Switch entirely to dynamic room list entries (normalizedMatchRoomName…

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -38,7 +38,6 @@ final class AppSettings {
         case notificationSettingsEnabled
         case swiftUITimelineEnabled
         case pollsInTimeline
-        case dynamicEntriesEnabled
     }
     
     private static var suiteName: String = InfoPlistReader.main.appGroupIdentifier
@@ -224,7 +223,4 @@ final class AppSettings {
 
     @UserPreference(key: UserDefaultsKeys.pollsInTimeline, defaultValue: false, storageType: .userDefaults(store))
     var pollsInTimelineEnabled
-    
-    @UserPreference(key: UserDefaultsKeys.dynamicEntriesEnabled, defaultValue: true, storageType: .userDefaults(store))
-    var dynamicEntriesEnabled
 }

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -79,18 +79,12 @@ struct HomeScreenViewState: BindableState {
     
     var selectedRoomID: String?
     
-    var dynamicEntriesEnabled: Bool
-    
     var visibleRooms: [HomeScreenRoom] {
         if roomListMode == .skeletons {
             return placeholderRooms
         }
         
-        if dynamicEntriesEnabled || bindings.searchQuery.isEmpty {
-            return rooms
-        }
-        
-        return rooms.filter { $0.name.localizedStandardContains(bindings.searchQuery) }
+        return rooms
     }
     
     var bindings = HomeScreenViewStateBindings()

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -49,7 +49,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
         roomSummaryProvider = userSession.clientProxy.roomSummaryProvider
         inviteSummaryProvider = userSession.clientProxy.inviteSummaryProvider
         
-        super.init(initialViewState: HomeScreenViewState(userID: userSession.userID, dynamicEntriesEnabled: appSettings.dynamicEntriesEnabled),
+        super.init(initialViewState: HomeScreenViewState(userID: userSession.userID),
                    imageProvider: userSession.mediaProvider)
         
         userSession.callbacks
@@ -74,12 +74,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             .weakAssign(to: \.state.selectedRoomID, on: self)
             .store(in: &cancellables)
         
-        appSettings.$dynamicEntriesEnabled
-            .weakAssign(to: \.state.dynamicEntriesEnabled, on: self)
-            .store(in: &cancellables)
-        
         context.$viewState
-            .filter { _ in appSettings.dynamicEntriesEnabled }
             .map(\.bindings.searchQuery)
             .debounceAndRemoveDuplicates()
             .sink { [weak self] searchQuery in

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -49,7 +49,6 @@ protocol DeveloperOptionsProtocol: AnyObject {
     var notificationSettingsEnabled: Bool { get set }
     var swiftUITimelineEnabled: Bool { get set }
     var pollsInTimelineEnabled: Bool { get set }
-    var dynamicEntriesEnabled: Bool { get set }
 }
 
 extension AppSettings: DeveloperOptionsProtocol { }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -38,13 +38,6 @@ struct DeveloperOptionsScreen: View {
                 }
             }
             
-            Section("Room list") {
-                Toggle(isOn: $context.dynamicEntriesEnabled) {
-                    Text("Dynamic entries")
-                    Text("Requires app reboot")
-                }
-            }
-
             Section("Notifications") {
                 Toggle(isOn: $context.notificationSettingsEnabled) {
                     Text("Show notification settings")


### PR DESCRIPTION
… brings the same behavior as the old implementation) and cleanup