### PR TITLE
Fix for voice over reading the braille dot

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
@@ -69,6 +69,13 @@ struct FormattedBodyText: View {
     }
     
     var body: some View {
+        mainContent
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text(attributedString))
+    }
+    
+    @ViewBuilder
+    var mainContent: some View {
         if timelineStyle == .bubbles {
             bubbleLayout
                 .tint(.compound.textLinkExternal)

--- a/changelog.d/pr-1538.bugfix
+++ b/changelog.d/pr-1538.bugfix
@@ -1,0 +1,1 @@
+Fix for voice over reading braille dot at the end of a message.


### PR DESCRIPTION
We use a braille dot in app to get some extra spacing for the timestamp, however I just discovered that the voice over reads it.

This small fix solves the problem by overriding the accessibility with the original attributed string instead of the adjusted one.