### PR TITLE
Fix timestamp not rendering properly when RTL and LTR are mixed together

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
@@ -31,9 +31,9 @@ struct FormattedBodyText: View {
         container.foregroundColor = UIColor.compound.textPrimary
         return container
     }()
-    
+        
     private var attributedComponents: [AttributedStringBuilderComponent] {
-        var adjustedAttributedString = attributedString + AttributedString(additionalWhitespacesSuffix)
+        var adjustedAttributedString = AttributedString(layoutDirection.isolateLayoutUnicodeString) + attributedString + AttributedString(additionalWhitespacesSuffix)
         
         // Required to allow the underlying TextView to use  body font when no font is specifie in the AttributedString.
         adjustedAttributedString.mergeAttributes(defaultAttributesContainer, mergePolicy: .keepCurrent)
@@ -89,7 +89,10 @@ struct FormattedBodyText: View {
     var bubbleLayout: some View {
         TimelineBubbleLayout(spacing: 8) {
             ForEach(attributedComponents, id: \.self) { component in
-                if component.isBlockquote {
+                // Ignore if the string contains only the layout correction
+                if String(component.attributedString.characters) == layoutDirection.isolateLayoutUnicodeString {
+                    EmptyView()
+                } else if component.isBlockquote {
                     // The rendered blockquote with a greedy width. The custom layout prevents the
                     // infinite width from increasing the overall width of the view.
                     MessageText(attributedString: component.attributedString.mergingAttributes(blockquoteAttributes))

--- a/changelog.d/pr-1539.bugfix
+++ b/changelog.d/pr-1539.bugfix
@@ -1,0 +1,1 @@
+Improve timestamp rendering when mixed LTR and RTL languages are present in the message.


### PR DESCRIPTION
<img width="477" alt="Screenshot 2023-08-22 at 15 08 50" src="https://github.com/vector-im/element-x-ios/assets/34335419/cb28566d-eeac-412e-8f66-d5e97bb4be94">
