### PR TITLE
Add missing document configuration as per ITMS-90737

### DIFF
--- a/ElementX/SupportingFiles/Info.plist
+++ b/ElementX/SupportingFiles/Info.plist
@@ -39,6 +39,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>To take pictures or videos and send them as a message $(APP_DISPLAY_NAME) needs access to the camera.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -90,6 +90,7 @@ targets:
           CFBundleTypeRole: Viewer
           LSHandlerRank: Owner
           LSItemContentTypes: $(PILLS_UT_TYPE_IDENTIFIER)
+        LSSupportsOpeningDocumentsInPlace: false
 
 
     settings:


### PR DESCRIPTION
```
By declaring the CFBundleDocumentTypes key in your app, you've indicated that your app is able to open documents. Please set the UISupportsDocumentBrowser key to 'YES' if your app uses a UIDocumentBrowserViewController. Otherwise, set the LSSupportsOpeningDocumentsInPlace key in the Info.plist to 'YES' (recommended) or 'NO' to specify whether the app can open files in place. All document-based apps must include one of these configurations. For more information, visit https://developer.apple.com/document-based-apps/
```