### PR TITLE
Alert the user about configuration mismatch in notification settings

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -264,6 +264,8 @@
 "screen_migration_title" = "Setting up your account.";
 "screen_notification_settings_additional_settings_section_title" = "Additional settings";
 "screen_notification_settings_calls_label" = "Audio and video calls";
+"screen_notification_settings_configuration_mismatch" = "Configuration mismatch";
+"screen_notification_settings_configuration_mismatch_description" = "We’ve simplified Notifications Settings to make options easier to find. \n\nSome custom settings you’ve chosen in the past are not shown here, but they’re still active. \n\nIf you proceed, some of your settings may change.";
 "screen_notification_settings_direct_chats" = "Direct chats";
 "screen_notification_settings_edit_custom_settings_section_title" = "Custom setting per chat";
 "screen_notification_settings_edit_failed_updating_default_mode" = "An error occurred while updating the notification setting.";
@@ -272,6 +274,7 @@
 "screen_notification_settings_edit_screen_direct_section_header" = "On direct chats, notify me for";
 "screen_notification_settings_edit_screen_group_section_header" = "On group chats, notify me for";
 "screen_notification_settings_enable_notifications" = "Enable notifications on this device";
+"screen_notification_settings_failed_fixing_configuration" = "The configuration has not been corrected, please try again.";
 "screen_notification_settings_group_chats" = "Group chats";
 "screen_notification_settings_mentions_section_title" = "Mentions";
 "screen_notification_settings_mode_all" = "All";

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -265,7 +265,7 @@
 "screen_notification_settings_additional_settings_section_title" = "Additional settings";
 "screen_notification_settings_calls_label" = "Audio and video calls";
 "screen_notification_settings_configuration_mismatch" = "Configuration mismatch";
-"screen_notification_settings_configuration_mismatch_description" = "We’ve simplified Notifications Settings to make options easier to find. \n\nSome custom settings you’ve chosen in the past are not shown here, but they’re still active. \n\nIf you proceed, some of your settings may change.";
+"screen_notification_settings_configuration_mismatch_description" = "We’ve simplified Notifications Settings to make options easier to find.\n\nSome custom settings you’ve chosen in the past are not shown here, but they’re still active.\n\nIf you proceed, some of your settings may change.";
 "screen_notification_settings_direct_chats" = "Direct chats";
 "screen_notification_settings_edit_custom_settings_section_title" = "Custom setting per chat";
 "screen_notification_settings_edit_failed_updating_default_mode" = "An error occurred while updating the notification setting.";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -686,6 +686,14 @@ public enum L10n {
   public static var screenNotificationSettingsAdditionalSettingsSectionTitle: String { return L10n.tr("Localizable", "screen_notification_settings_additional_settings_section_title") }
   /// Audio and video calls
   public static var screenNotificationSettingsCallsLabel: String { return L10n.tr("Localizable", "screen_notification_settings_calls_label") }
+  /// Configuration mismatch
+  public static var screenNotificationSettingsConfigurationMismatch: String { return L10n.tr("Localizable", "screen_notification_settings_configuration_mismatch") }
+  /// We’ve simplified Notifications Settings to make options easier to find. 
+  /// 
+  /// Some custom settings you’ve chosen in the past are not shown here, but they’re still active. 
+  /// 
+  /// If you proceed, some of your settings may change.
+  public static var screenNotificationSettingsConfigurationMismatchDescription: String { return L10n.tr("Localizable", "screen_notification_settings_configuration_mismatch_description") }
   /// Direct chats
   public static var screenNotificationSettingsDirectChats: String { return L10n.tr("Localizable", "screen_notification_settings_direct_chats") }
   /// Custom setting per chat
@@ -702,6 +710,8 @@ public enum L10n {
   public static var screenNotificationSettingsEditScreenGroupSectionHeader: String { return L10n.tr("Localizable", "screen_notification_settings_edit_screen_group_section_header") }
   /// Enable notifications on this device
   public static var screenNotificationSettingsEnableNotifications: String { return L10n.tr("Localizable", "screen_notification_settings_enable_notifications") }
+  /// The configuration has not been corrected, please try again.
+  public static var screenNotificationSettingsFailedFixingConfiguration: String { return L10n.tr("Localizable", "screen_notification_settings_failed_fixing_configuration") }
   /// Group chats
   public static var screenNotificationSettingsGroupChats: String { return L10n.tr("Localizable", "screen_notification_settings_group_chats") }
   /// Mentions

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -688,9 +688,9 @@ public enum L10n {
   public static var screenNotificationSettingsCallsLabel: String { return L10n.tr("Localizable", "screen_notification_settings_calls_label") }
   /// Configuration mismatch
   public static var screenNotificationSettingsConfigurationMismatch: String { return L10n.tr("Localizable", "screen_notification_settings_configuration_mismatch") }
-  /// We’ve simplified Notifications Settings to make options easier to find. 
+  /// We’ve simplified Notifications Settings to make options easier to find.
   /// 
-  /// Some custom settings you’ve chosen in the past are not shown here, but they’re still active. 
+  /// Some custom settings you’ve chosen in the past are not shown here, but they’re still active.
   /// 
   /// If you proceed, some of your settings may change.
   public static var screenNotificationSettingsConfigurationMismatchDescription: String { return L10n.tr("Localizable", "screen_notification_settings_configuration_mismatch_description") }

--- a/ElementX/Sources/Mocks/NotificationSettingsProxyMock.swift
+++ b/ElementX/Sources/Mocks/NotificationSettingsProxyMock.swift
@@ -38,6 +38,8 @@ extension NotificationSettingsProxyMock {
         getDefaultRoomNotificationModeIsEncryptedIsOneToOneReturnValue = configuration.defaultRoomMode
         getUserDefinedRoomNotificationModeRoomIdReturnValue = configuration.roomMode.isDefault ? nil : configuration.roomMode.mode
         getRoomsWithUserDefinedRulesReturnValue = []
+        isRoomMentionEnabledReturnValue = true
+        isCallEnabledReturnValue = true
         
         setNotificationModeRoomIdModeClosure = { [weak self] _, mode in
             guard let self else { return }

--- a/ElementX/Sources/Other/AccessibilityIdentifiers.swift
+++ b/ElementX/Sources/Other/AccessibilityIdentifiers.swift
@@ -36,6 +36,7 @@ struct A11yIdentifiers {
     static let invitesScreen = InvitesScreen()
     static let welcomeScreen = WelcomeScreen()
     static let migrationScreen = MigrationScreen()
+    static let notificationSettingsScreen = NotificationSettingsScreen()
     static let notificationSettingsEditScreen = NotificationSettingsEditScreen()
 
     struct AnalyticsPromptScreen {
@@ -161,6 +162,10 @@ struct A11yIdentifiers {
 
     struct MigrationScreen {
         let message = "migration_screen-message"
+    }
+    
+    struct NotificationSettingsScreen {
+        let fixMismatchConfiguration = "notification_settings_screen-fix_mismatch_configuration"
     }
     
     struct NotificationSettingsEditScreen {

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
@@ -28,6 +28,7 @@ struct NotificationSettingsScreenViewState: BindableState {
     let isModallyPresented: Bool
     var isUserPermissionGranted: Bool?
     var allowedNotificationModes: [RoomNotificationModeProxy] = [.allMessages, .mentionsAndKeywordsOnly]
+    var fixingConfigurationMismatch = false
     
     var showSystemNotificationsAlert: Bool {
         bindings.enableNotifications && isUserPermissionGranted == false
@@ -51,7 +52,12 @@ struct NotificationSettingsScreenSettings {
     let callsEnabled: Bool?
     // Old clients were having specific settings for encrypted and unencrypted rooms,
     // so it's possible for `group chats` and `direct chats` settings to be inconsistent (e.g. encrypted `direct chats` can have a different mode that unencrypted `direct chats`)
-    let inconsistentSettings: Bool
+    let inconsistentSettings: [NotificationSettingsScreenSettingsChatMismatchConfiguration]
+}
+
+struct NotificationSettingsScreenSettingsChatMismatchConfiguration: Equatable {
+    let type: NotificationSettingsChatType
+    let isEncrypted: Bool
 }
 
 struct NotificationSettingsScreenStrings {
@@ -87,9 +93,11 @@ enum NotificationSettingsScreenViewAction {
     case roomMentionChanged
     case callsChanged
     case close
+    case fixConfigurationMismatchTapped
 }
 
 enum NotificationSettingsScreenErrorType: Hashable {
     /// A specific error message shown in an alert.
     case alert
+    case fixMismatchConfigurationFailed
 }

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/NotificationSettingsScreenModels.swift
@@ -52,11 +52,11 @@ struct NotificationSettingsScreenSettings {
     let callsEnabled: Bool?
     // Old clients were having specific settings for encrypted and unencrypted rooms,
     // so it's possible for `group chats` and `direct chats` settings to be inconsistent (e.g. encrypted `direct chats` can have a different mode that unencrypted `direct chats`)
-    let inconsistentSettings: [NotificationSettingsScreenSettingsChatMismatchConfiguration]
+    let inconsistentSettings: [NotificationSettingsScreenInvalidSetting]
 }
 
-struct NotificationSettingsScreenSettingsChatMismatchConfiguration: Equatable {
-    let type: NotificationSettingsChatType
+struct NotificationSettingsScreenInvalidSetting: Equatable {
+    let chatType: NotificationSettingsChatType
     let isEncrypted: Bool
 }
 

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
@@ -159,25 +159,28 @@ struct NotificationSettingsScreen: View {
     
     private var configurationMismatchSection: some View {
         Section {
-            VStack(alignment: .leading, spacing: 12) {
-                Image(systemName: "gearshape")
-                    .font(.compound.headingSMSemibold)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(L10n.screenNotificationSettingsConfigurationMismatch)
+            ListRow(kind: .custom {
+                VStack(alignment: .leading, spacing: 12) {
+                    Image(systemName: "gearshape")
                         .font(.compound.headingSMSemibold)
-                    Text(L10n.screenNotificationSettingsConfigurationMismatchDescription)
-                        .foregroundColor(.compound.textSecondary)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(L10n.screenNotificationSettingsConfigurationMismatch)
+                            .font(.compound.headingSMSemibold)
+                        Text(L10n.screenNotificationSettingsConfigurationMismatchDescription)
+                            .foregroundColor(.compound.textSecondary)
+                    }
+                    Button {
+                        context.send(viewAction: .fixConfigurationMismatchTapped)
+                    } label: {
+                        Text(L10n.actionContinue)
+                    }
+                    .buttonStyle(.elementCapsuleProminent)
+                    .disabled(context.viewState.fixingConfigurationMismatch)
+                    .accessibilityIdentifier(A11yIdentifiers.notificationSettingsScreen.fixMismatchConfiguration)
                 }
-                Button {
-                    context.send(viewAction: .fixConfigurationMismatchTapped)
-                } label: {
-                    Text(L10n.actionContinue)
-                }
-                .buttonStyle(.elementCapsuleProminent)
-                .disabled(context.viewState.fixingConfigurationMismatch)
-                .accessibilityIdentifier(A11yIdentifiers.notificationSettingsScreen.fixMismatchConfiguration)
-            }
-            .padding(.vertical, 4)
+                .padding(.horizontal, ListRowPadding.horizontal)
+                .padding(.vertical, ListRowPadding.vertical)
+            })
         }
     }
 }

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -204,6 +204,25 @@ class MockScreen: Identifiable {
                                                                              notificationSettings: NotificationSettingsProxyMock(with: .init()),
                                                                              isModallyPresented: false)
             return NotificationSettingsScreenCoordinator(parameters: parameters)
+        case .notificationSettingsScreenMismatchConfiguration:
+            let userNotificationCenter = UserNotificationCenterMock()
+            userNotificationCenter.authorizationStatusReturnValue = .denied
+            let session = MockUserSession(clientProxy: MockClientProxy(userID: "@mock:matrix.org"),
+                                          mediaProvider: MockMediaProvider())
+            let notificationSettings = NotificationSettingsProxyMock(with: .init())
+            notificationSettings.getDefaultRoomNotificationModeIsEncryptedIsOneToOneClosure = { isEncrypted, isOneToOne in
+                switch (isEncrypted, isOneToOne) {
+                case (true, _):
+                    return .allMessages
+                case (false, _):
+                    return .mentionsAndKeywordsOnly
+                }
+            }
+            let parameters = NotificationSettingsScreenCoordinatorParameters(userSession: session,
+                                                                             userNotificationCenter: userNotificationCenter,
+                                                                             notificationSettings: notificationSettings,
+                                                                             isModallyPresented: false)
+            return NotificationSettingsScreenCoordinator(parameters: parameters)
         case .onboarding:
             return OnboardingCoordinator()
         case .roomPlainNoAvatar:

--- a/ElementX/Sources/UITests/UITestsScreenIdentifier.swift
+++ b/ElementX/Sources/UITests/UITestsScreenIdentifier.swift
@@ -34,6 +34,7 @@ enum UITestsScreenIdentifier: String {
     case bugReport
     case bugReportWithScreenshot
     case notificationSettingsScreen
+    case notificationSettingsScreenMismatchConfiguration
     case onboarding
     case roomPlainNoAvatar
     case roomEncryptedWithAvatar

--- a/UITests/Sources/NotificationSettingsScreenUITests.swift
+++ b/UITests/Sources/NotificationSettingsScreenUITests.swift
@@ -18,4 +18,14 @@ import ElementX
 import XCTest
 
 @MainActor
-class NotificationSettingsScreenUITests: XCTestCase { }
+class NotificationSettingsScreenUITests: XCTestCase {
+    func testRegularScreen() async throws {
+        let app = Application.launch(.notificationSettingsScreen)
+        try await app.assertScreenshot(.notificationSettingsScreen)
+    }
+    
+    func testMismatchConfigurationScreen() async throws {
+        let app = Application.launch(.notificationSettingsScreenMismatchConfiguration)
+        try await app.assertScreenshot(.notificationSettingsScreenMismatchConfiguration)
+    }
+}

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.notificationSettingsScreen.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.notificationSettingsScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba5e1710d50a76d3581f946c77e0736ca8274e2198e28b69794a3b4851fdc2c3
+size 115177

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.notificationSettingsScreenMismatchConfiguration.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.notificationSettingsScreenMismatchConfiguration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc8c6cdd11f4bf35b28b3041aaa1672bc2c71d250396cb852b1db22e83108606
+size 95551

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.notificationSettingsScreenMismatchConfiguration.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.notificationSettingsScreenMismatchConfiguration.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc8c6cdd11f4bf35b28b3041aaa1672bc2c71d250396cb852b1db22e83108606
-size 95551
+oid sha256:12aa24cb445649e4b6520e960667a92c8166bf84418e24306380d63aee6c03a7
+size 95563

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.notificationSettingsScreen.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.notificationSettingsScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79c131aa3127ebfa5737ef286e550925c601f493368083ba3c034763d3cd4ab7
+size 145299

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.notificationSettingsScreenMismatchConfiguration.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.notificationSettingsScreenMismatchConfiguration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:555240c2fcbbce4a4b28dc454799171f3d80ca1fdb83f3a5c99f1d6d14c76a0d
+size 129125

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.notificationSettingsScreenMismatchConfiguration.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.notificationSettingsScreenMismatchConfiguration.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:555240c2fcbbce4a4b28dc454799171f3d80ca1fdb83f3a5c99f1d6d14c76a0d
-size 129125
+oid sha256:9319b24a7b129121d5e6bf8a14fae1b9700df5b44ddea3e0be03872602480578
+size 129165

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.notificationSettingsScreen.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.notificationSettingsScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c92c4baf77cb2ad25f07aeea790075400dc2ecd57a6e44b523193bd616f6190b
+size 134108

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.notificationSettingsScreenMismatchConfiguration.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.notificationSettingsScreenMismatchConfiguration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2030dee5078f9db06e29d89e820eb902ebfac0d8277a8f045cdc07a99395dce
+size 124162

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.notificationSettingsScreenMismatchConfiguration.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.notificationSettingsScreenMismatchConfiguration.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2030dee5078f9db06e29d89e820eb902ebfac0d8277a8f045cdc07a99395dce
-size 124162
+oid sha256:a339016cc249bc0f2014b7f65d084213115a2ceac30c7b7df65379ab47ea1512
+size 124169

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.notificationSettingsScreen.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.notificationSettingsScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:570373515f3a642836661d2f549d3f93c914245f333114640339402ae42ef9bb
+size 189090

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.notificationSettingsScreenMismatchConfiguration.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.notificationSettingsScreenMismatchConfiguration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:959fcdbcf52bf5f5d6b5c7678b484e7a12c6c82f9925c5e6d236dfe76be30eb6
+size 197241

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.notificationSettingsScreenMismatchConfiguration.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.notificationSettingsScreenMismatchConfiguration.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:959fcdbcf52bf5f5d6b5c7678b484e7a12c6c82f9925c5e6d236dfe76be30eb6
-size 197241
+oid sha256:69fc8921f9bd24b07eeb042da2b6b4dc85861dda6a62f94133fa136c5bfb498a
+size 197579

--- a/UnitTests/Sources/NotificationSettingsScreenViewModelTests.swift
+++ b/UnitTests/Sources/NotificationSettingsScreenViewModelTests.swift
@@ -104,7 +104,7 @@ class NotificationSettingsScreenViewModelTests: XCTestCase {
         try await deferred.fulfill()
         
         XCTAssertEqual(context.viewState.settings?.groupChatsMode, .allMessages)
-        XCTAssertEqual(context.viewState.settings?.inconsistentSettings, [.init(type: .groupChat, isEncrypted: false)])
+        XCTAssertEqual(context.viewState.settings?.inconsistentSettings, [.init(chatType: .groupChat, isEncrypted: false)])
     }
     
     func testInconsistentDirectChatsSettings() async throws {
@@ -125,7 +125,7 @@ class NotificationSettingsScreenViewModelTests: XCTestCase {
         try await deferred.fulfill()
         
         XCTAssertEqual(context.viewState.settings?.directChatsMode, .allMessages)
-        XCTAssertEqual(context.viewState.settings?.inconsistentSettings, [.init(type: .oneToOneChat, isEncrypted: false)])
+        XCTAssertEqual(context.viewState.settings?.inconsistentSettings, [.init(chatType: .oneToOneChat, isEncrypted: false)])
     }
     
     func testFixInconsistentSettings() async throws {
@@ -147,7 +147,7 @@ class NotificationSettingsScreenViewModelTests: XCTestCase {
         try await deferred.fulfill()
         
         XCTAssertEqual(context.viewState.settings?.directChatsMode, .allMessages)
-        XCTAssertEqual(context.viewState.settings?.inconsistentSettings, [.init(type: .oneToOneChat, isEncrypted: false)])
+        XCTAssertEqual(context.viewState.settings?.inconsistentSettings, [.init(chatType: .oneToOneChat, isEncrypted: false)])
         
         let deferredState = deferFulfillment(viewModel.context.$viewState
             .map(\.fixingConfigurationMismatch)
@@ -186,7 +186,7 @@ class NotificationSettingsScreenViewModelTests: XCTestCase {
         try await deferred.fulfill()
         
         XCTAssertEqual(context.viewState.settings?.directChatsMode, .allMessages)
-        XCTAssertEqual(context.viewState.settings?.inconsistentSettings, [.init(type: .groupChat, isEncrypted: false), .init(type: .oneToOneChat, isEncrypted: false)])
+        XCTAssertEqual(context.viewState.settings?.inconsistentSettings, [.init(chatType: .groupChat, isEncrypted: false), .init(chatType: .oneToOneChat, isEncrypted: false)])
         
         let deferredState = deferFulfillment(viewModel.context.$viewState
             .map(\.fixingConfigurationMismatch)


### PR DESCRIPTION
This PR implements the last part of #1024 to alert the user of a misconfiguration in their default notification settings.

In ElX, we no longer distinguish between encrypted and non-encrypted chats for notification settings, so it's possible to have different settings for encrypted and non-encrypted direct chats.

<img src="https://github.com/vector-im/element-x-ios/assets/4334885/69f86bfb-47b5-4bec-994a-4d51800b94a6" width="25%" height="25%">

If the user chooses to continue, the settings will be updated so that the same mode is defined for both encrypted and non-encrypted chats.