### PR TITLE
Fix OIDC support for iOS 17

### DIFF
--- a/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/View/ServerConfirmationScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/ServerConfirmationScreen/View/ServerConfirmationScreen.swift
@@ -27,7 +27,7 @@ struct ServerConfirmationScreen: View {
         }
         .background()
         .environment(\.backgroundStyle, AnyShapeStyle(Color.compound.bgCanvasDefault))
-        .introspect(.window, on: .iOS(.v16)) { window in
+        .introspect(.window, on: .iOS(.v16, .v17)) { window in
             context.send(viewAction: .updateWindow(window))
         }
     }

--- a/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/View/SoftLogoutScreen.swift
+++ b/ElementX/Sources/Screens/Authentication/SoftLogoutScreen/View/SoftLogoutScreen.swift
@@ -49,7 +49,7 @@ struct SoftLogoutScreen: View {
         }
         .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
         .alert(item: $context.alertInfo)
-        .introspect(.window, on: .iOS(.v16)) { window in
+        .introspect(.window, on: .iOS(.v16, .v17)) { window in
             context.send(viewAction: .updateWindow(window))
         }
     }

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
@@ -46,7 +46,7 @@ struct SettingsScreen: View {
                 doneButton
             }
         }
-        .introspect(.window, on: .iOS(.v16)) { window in
+        .introspect(.window, on: .iOS(.v16, .v17)) { window in
             context.send(viewAction: .updateWindow(window))
         }
     }


### PR DESCRIPTION
This PR allows to use OIDC login on iOS 17.

I've only added iOS 17 support in the `introspect()` calls to fix the OIDC login.