### PR TITLE
Diffing performance fix

### DIFF
--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -133,24 +133,35 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         
         MXLog.verbose("\(name): Received \(diffs.count) diffs, current room list \(rooms.compactMap { $0.id ?? "Empty" })")
         
-        rooms = diffs
-            .reduce(rooms) { currentItems, diff in
-                guard let collectionDiff = buildDiff(from: diff, on: currentItems) else {
-                    MXLog.error("\(name): Failed building CollectionDifference from \(diff)")
-                    return currentItems
-                }
-                
-                guard let updatedItems = currentItems.applying(collectionDiff) else {
-                    MXLog.error("\(name): Failed applying diff: \(collectionDiff)")
-                    return currentItems
-                }
-                
-                return updatedItems
+        for diff in diffs {
+            // Special case resets in order to prevent large updates from blocking the UI
+            // Render the first resetDiffChunkingThreshhold as a reset and then append the rest to give the UI time to update
+            let resetDiffChunkingThreshhold = 50
+            if case .reset(let values) = diff, values.count > resetDiffChunkingThreshhold {
+                processDiff(RoomListEntriesUpdate.reset(values: Array(values[..<resetDiffChunkingThreshhold])))
+                processDiff(RoomListEntriesUpdate.append(values: Array(values.dropFirst(resetDiffChunkingThreshhold))))
+            } else {
+                processDiff(diff)
             }
+        }
         
         detectDuplicatesInRoomList(rooms)
         
         MXLog.verbose("\(name): Finished applying \(diffs.count) diffs, new room list \(rooms.compactMap { $0.id ?? "Empty" })")
+    }
+    
+    private func processDiff(_ diff: RoomListEntriesUpdate) {
+        guard let collectionDiff = buildDiff(from: diff, on: rooms) else {
+            MXLog.error("\(name): Failed building CollectionDifference from \(diff)")
+            return
+        }
+        
+        guard let updatedItems = rooms.applying(collectionDiff) else {
+            MXLog.error("\(name): Failed applying diff: \(collectionDiff)")
+            return
+        }
+        
+        rooms = updatedItems
     }
 
     private func fetchRoomInfo(roomListItem: RoomListItemProtocol) -> RoomInfo? {

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -133,35 +133,41 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         
         MXLog.verbose("\(name): Received \(diffs.count) diffs, current room list \(rooms.compactMap { $0.id ?? "Empty" })")
         
+        var updatedItems = rooms
         for diff in diffs {
-            // Special case resets in order to prevent large updates from blocking the UI
-            // Render the first resetDiffChunkingThreshhold as a reset and then append the rest to give the UI time to update
             let resetDiffChunkingThreshhold = 50
             if case .reset(let values) = diff, values.count > resetDiffChunkingThreshhold {
-                processDiff(RoomListEntriesUpdate.reset(values: Array(values[..<resetDiffChunkingThreshhold])))
-                processDiff(RoomListEntriesUpdate.append(values: Array(values.dropFirst(resetDiffChunkingThreshhold))))
+                // Special case resets in order to prevent large updates from blocking the UI
+                // Render the first resetDiffChunkingThreshhold as a reset and then append the rest to give the UI time to update
+                updatedItems = processDiff(.reset(values: Array(values[..<resetDiffChunkingThreshhold])), on: updatedItems)
+
+                // Once a reset is chunked dispatch the first part to the UI for rendering
+                rooms = updatedItems
+
+                updatedItems = processDiff(.append(values: Array(values.dropFirst(resetDiffChunkingThreshhold))), on: updatedItems)
             } else {
-                processDiff(diff)
+                updatedItems = processDiff(diff, on: updatedItems)
             }
         }
+        rooms = updatedItems
         
         detectDuplicatesInRoomList(rooms)
         
         MXLog.verbose("\(name): Finished applying \(diffs.count) diffs, new room list \(rooms.compactMap { $0.id ?? "Empty" })")
     }
     
-    private func processDiff(_ diff: RoomListEntriesUpdate) {
-        guard let collectionDiff = buildDiff(from: diff, on: rooms) else {
+    private func processDiff(_ diff: RoomListEntriesUpdate, on currentItems: [RoomSummary]) -> [RoomSummary] {
+        guard let collectionDiff = buildDiff(from: diff, on: currentItems) else {
             MXLog.error("\(name): Failed building CollectionDifference from \(diff)")
-            return
+            return currentItems
         }
         
-        guard let updatedItems = rooms.applying(collectionDiff) else {
+        guard let updatedItems = currentItems.applying(collectionDiff) else {
             MXLog.error("\(name): Failed applying diff: \(collectionDiff)")
-            return
+            return currentItems
         }
         
-        rooms = updatedItems
+        return updatedItems
     }
 
     private func fetchRoomInfo(roomListItem: RoomListItemProtocol) -> RoomInfo? {

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -60,7 +60,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
          appSettings: AppSettings,
          backgroundTaskService: BackgroundTaskServiceProtocol) {
         self.roomListService = roomListService
-        serialDispatchQueue = DispatchQueue(label: "io.element.elementx.roomsummaryprovider", qos: .utility)
+        serialDispatchQueue = DispatchQueue(label: "io.element.elementx.roomsummaryprovider", qos: .default)
         self.eventStringBuilder = eventStringBuilder
         self.name = name
         self.appSettings = appSettings


### PR DESCRIPTION
Fixed the problems we've been seeing with room list hangs
* on the previous `Split incoming large .resets into a reset + append` we introduced a behavioral change which would make the room summary provider inform the UI layer about room changes after every single processed diff
* now we go through the diffs one by one, collecting them, and **if** we encounter a large release we chunk it, process it and then directly inform the UI. The rest of the diffs will continue being collected and the UI will be informed once more at the end