### PR TITLE
Feature flag to OTLP tracing

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -889,7 +889,7 @@
 		127C8472672A5BA09EF1ACF8 /* CurrentValuePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValuePublisher.swift; sourceTree = "<group>"; };
 		12EDAFB64FA5F6812D54F39A /* MigrationScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationScreenViewModel.swift; sourceTree = "<group>"; };
 		12F1E7F9C2BE8BB751037826 /* WaitlistScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitlistScreenCoordinator.swift; sourceTree = "<group>"; };
-		1304D9191300873EADA52D6E /* IntegrationTests.xctestplan */ = {isa = PBXFileReference; path = IntegrationTests.xctestplan; sourceTree = "<group>"; };
+		1304D9191300873EADA52D6E /* IntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = IntegrationTests.xctestplan; sourceTree = "<group>"; };
 		130ED565A078F7E0B59D9D25 /* UNTextInputNotificationResponse+Creator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNTextInputNotificationResponse+Creator.swift"; sourceTree = "<group>"; };
 		13802897C7AFA360EA74C0B0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		1423AB065857FA546444DB15 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
@@ -1035,7 +1035,7 @@
 		47111410B6E659A697D472B5 /* RoomProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomProxyProtocol.swift; sourceTree = "<group>"; };
 		471EB7D96AFEA8D787659686 /* EmoteRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoteRoomTimelineView.swift; sourceTree = "<group>"; };
 		47873756E45B46683D97DC32 /* LegalInformationScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegalInformationScreenModels.swift; sourceTree = "<group>"; };
-		478BE8591BD13E908EF70C0C /* DesignKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = DesignKit; path = DesignKit; sourceTree = SOURCE_ROOT; };
+		478BE8591BD13E908EF70C0C /* DesignKit */ = {isa = PBXFileReference; lastKnownFileType = folder; path = DesignKit; sourceTree = SOURCE_ROOT; };
 		4798B3B7A1E8AE3901CEE8C6 /* FramePreferenceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FramePreferenceKey.swift; sourceTree = "<group>"; };
 		47EBB5D698CE9A25BB553A2D /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		47F29139BC2A804CE5E0757E /* MediaUploadPreviewScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUploadPreviewScreenViewModel.swift; sourceTree = "<group>"; };
@@ -1049,7 +1049,7 @@
 		4B41FABA2B0AEF4389986495 /* LoginMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginMode.swift; sourceTree = "<group>"; };
 		4B5046BB295AEAFA6FB81655 /* SessionVerificationScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionVerificationScreenModels.swift; sourceTree = "<group>"; };
 		4BD371B60E07A5324B9507EF /* AnalyticsSettingsScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsSettingsScreenCoordinator.swift; sourceTree = "<group>"; };
-		4CD6AC7546E8D7E5C73CEA48 /* ElementX.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = ElementX.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4CD6AC7546E8D7E5C73CEA48 /* ElementX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ElementX.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CDDDDD9FE1A699D23A5E096 /* LoginScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScreen.swift; sourceTree = "<group>"; };
 		4D6E4C37E9F0E53D3DF951AC /* HomeScreenUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenUITests.swift; sourceTree = "<group>"; };
 		4E2245243369B99216C7D84E /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
@@ -1222,7 +1222,7 @@
 		8D55702474F279D910D2D162 /* RoomStateEventStringBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStateEventStringBuilder.swift; sourceTree = "<group>"; };
 		8D8169443E5AC5FF71BFB3DB /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8DC2C9E0E15C79BBDA80F0A2 /* TimelineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStyle.swift; sourceTree = "<group>"; };
-		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; path = UITests.xctestplan; sourceTree = "<group>"; };
+		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
 		8E1BBA73B611EDEEA6E20E05 /* InvitesScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitesScreenModels.swift; sourceTree = "<group>"; };
 		8EC57A32ABC80D774CC663DB /* SettingsScreenUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreenUITests.swift; sourceTree = "<group>"; };
 		8F21ED7205048668BEB44A38 /* AppActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityView.swift; sourceTree = "<group>"; };
@@ -1333,7 +1333,7 @@
 		B4CFE236419E830E8946639C /* Analytics+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+SwiftUI.swift"; sourceTree = "<group>"; };
 		B590BD4507D4F0A377FDE01A /* LoadableAvatarImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableAvatarImage.swift; sourceTree = "<group>"; };
 		B5B243E7818E5E9F6A4EDC7A /* NoticeRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeRoomTimelineView.swift; sourceTree = "<group>"; };
-		B61C339A2FDDBD067FF6635C /* ConfettiScene.scn */ = {isa = PBXFileReference; path = ConfettiScene.scn; sourceTree = "<group>"; };
+		B61C339A2FDDBD067FF6635C /* ConfettiScene.scn */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = ConfettiScene.scn; sourceTree = "<group>"; };
 		B6311F21F911E23BE4DF51B4 /* ReadMarkerRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadMarkerRoomTimelineView.swift; sourceTree = "<group>"; };
 		B697816AF93DA06EC58C5D70 /* WaitlistScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitlistScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		B6E89E530A8E92EC44301CA1 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
@@ -1420,7 +1420,7 @@
 		CD95B3714F806AC9CF9A557B /* ComposerToolbarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerToolbarViewModel.swift; sourceTree = "<group>"; };
 		CDB3227C7A74B734924942E9 /* RoomSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSummaryProvider.swift; sourceTree = "<group>"; };
 		CEE0E6043EFCF6FD2A341861 /* TimelineReplyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineReplyView.swift; sourceTree = "<group>"; };
-		CEE41494C837AA403A06A5D9 /* UnitTests.xctestplan */ = {isa = PBXFileReference; path = UnitTests.xctestplan; sourceTree = "<group>"; };
+		CEE41494C837AA403A06A5D9 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		CF48AF076424DBC1615C74AD /* AuthenticationServiceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceProxy.swift; sourceTree = "<group>"; };
 		D0140615D2232612C813FD6C /* EncryptedHistoryRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedHistoryRoomTimelineItem.swift; sourceTree = "<group>"; };
 		D071F86CD47582B9196C9D16 /* UserDiscoverySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDiscoverySection.swift; sourceTree = "<group>"; };
@@ -1499,7 +1499,7 @@
 		ECF79FB25E2D4BD6F50CE7C9 /* RoomMembersListScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMembersListScreenViewModel.swift; sourceTree = "<group>"; };
 		ED044D00F2176681CC02CD54 /* HomeScreenRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenRoomCell.swift; sourceTree = "<group>"; };
 		ED1D792EB82506A19A72C8DE /* RoomTimelineItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemProtocol.swift; sourceTree = "<group>"; };
-		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; path = message.caf; sourceTree = "<group>"; };
+		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = message.caf; sourceTree = "<group>"; };
 		ED983D4DCA5AFA6E1ED96099 /* StateRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRoomTimelineView.swift; sourceTree = "<group>"; };
 		EDAA4472821985BF868CC21C /* ServerSelectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionViewModelTests.swift; sourceTree = "<group>"; };
 		EE378083653EF0C9B5E9D580 /* EmoteRoomTimelineItemContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoteRoomTimelineItemContent.swift; sourceTree = "<group>"; };
@@ -1513,7 +1513,7 @@
 		F174A5627CDB3CAF280D1880 /* EmojiPickerScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerScreenModels.swift; sourceTree = "<group>"; };
 		F17EFA1D3D09FC2F9C5E1CB2 /* MediaProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProvider.swift; sourceTree = "<group>"; };
 		F1B8500C152BC59445647DA8 /* UnsupportedRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedRoomTimelineItem.swift; sourceTree = "<group>"; };
-		F2D513D2477B57F90E98EEC0 /* portrait_test_video.mp4 */ = {isa = PBXFileReference; path = portrait_test_video.mp4; sourceTree = "<group>"; };
+		F2D513D2477B57F90E98EEC0 /* portrait_test_video.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = portrait_test_video.mp4; sourceTree = "<group>"; };
 		F31F59030205A6F65B057E1A /* MatrixEntityRegexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixEntityRegexTests.swift; sourceTree = "<group>"; };
 		F348B5F2C12F9D4F4B4D3884 /* VideoRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRoomTimelineItem.swift; sourceTree = "<group>"; };
 		F36C0A6D59717193F49EA986 /* UserSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionTests.swift; sourceTree = "<group>"; };

--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -58,7 +58,14 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
 
     init() {
         let appSettings = AppSettings()
-        MXLog.configure(logLevel: appSettings.logLevel)
+        
+        if appSettings.otlpTracingEnabled {
+            MXLog.configure(logLevel: appSettings.logLevel, otlpConfiguration: .init(url: appSettings.otlpTracingURL,
+                                                                                     username: appSettings.otlpTracingUsername,
+                                                                                     password: appSettings.otlpTracingPassword))
+        } else {
+            MXLog.configure(logLevel: appSettings.logLevel)
+        }
         
         if ProcessInfo.processInfo.environment["RESET_APP_SETTINGS"].map(Bool.init) == true {
             AppSettings.reset()

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -30,6 +30,7 @@ final class AppSettings {
         case enableInAppNotifications
         case pusherProfileTag
         case logLevel
+        case otlpTracingEnabled
         
         // Feature flags
         case shouldCollapseRoomStateEvents
@@ -197,8 +198,17 @@ final class AppSettings {
     
     let permalinkBaseURL: URL = "https://matrix.to"
     
+    // MARK: - Logging
+    
     @UserPreference(key: UserDefaultsKeys.logLevel, defaultValue: TracingConfiguration.LogLevel.info, storageType: .userDefaults(store))
     var logLevel
+    
+    @UserPreference(key: UserDefaultsKeys.otlpTracingEnabled, defaultValue: false, storageType: .userDefaults(store))
+    var otlpTracingEnabled
+    
+    let otlpTracingURL = InfoPlistReader.main.otlpTracingURL
+    let otlpTracingUsername = InfoPlistReader.main.otlpTracingUsername
+    let otlpTracingPassword = InfoPlistReader.main.otlpTracingPassword
     
     // MARK: - Maps
     

--- a/ElementX/Sources/Other/InfoPlistReader.swift
+++ b/ElementX/Sources/Other/InfoPlistReader.swift
@@ -27,6 +27,10 @@ struct InfoPlistReader {
         static let utExportedTypeDeclarationsKey = "UTExportedTypeDeclarations"
         static let utTypeIdentifierKey = "UTTypeIdentifier"
         static let utDescriptionKey = "UTTypeDescription"
+        
+        static let otlpTracingURL = "otlpTracingURL"
+        static let otlpTracingUsername = "otlpTracingUsername"
+        static let otlpTracingPassword = "otlpTracingPassword"
     }
     
     private enum Values {
@@ -87,10 +91,27 @@ struct InfoPlistReader {
         infoPlistValue(forKey: Keys.bundleDisplayName)
     }
 
-    /// Map Libre API Key
+    // MARK: - MapLibre
+    
     var mapLibreAPIKey: String {
         infoPlistValue(forKey: Keys.mapLibreAPIKey)
     }
+    
+    // MARK: - OTLP Tracing
+    
+    var otlpTracingURL: String {
+        infoPlistValue(forKey: Keys.otlpTracingURL)
+    }
+    
+    var otlpTracingUsername: String {
+        infoPlistValue(forKey: Keys.otlpTracingUsername)
+    }
+    
+    var otlpTracingPassword: String {
+        infoPlistValue(forKey: Keys.otlpTracingPassword)
+    }
+    
+    // MARK: - Mention Pills
 
     /// Mention Pills UTType
     var pillsUTType: String {
@@ -101,6 +122,8 @@ struct InfoPlistReader {
         }
         return utType
     }
+    
+    // MARK: - Private
 
     private func infoPlistValue<T>(forKey key: String) -> T {
         guard let result = bundle.object(forInfoDictionaryKey: key) as? T else {

--- a/ElementX/Sources/Other/Logging/MXLog.swift
+++ b/ElementX/Sources/Other/Logging/MXLog.swift
@@ -43,6 +43,7 @@ enum MXLog {
     
     static func configure(target: String? = nil,
                           logLevel: TracingConfiguration.LogLevel,
+                          otlpConfiguration: OTLPConfiguration? = nil,
                           redirectToFiles: Bool = Constants.redirectToFiles,
                           maxLogFileCount: UInt = Constants.maxLogFileCount,
                           logFileSizeLimit: UInt = Constants.logFilesSizeLimit) {
@@ -58,7 +59,7 @@ enum MXLog {
             return
         }
         
-        setupTracing(configuration: .custom(logLevel: logLevel))
+        setupTracing(configuration: .custom(logLevel: logLevel), otlpConfiguration: otlpConfiguration)
         
         if let target {
             self.target = target

--- a/ElementX/Sources/Other/Logging/RustTracing.swift
+++ b/ElementX/Sources/Other/Logging/RustTracing.swift
@@ -17,6 +17,12 @@
 import Collections
 import MatrixRustSDK
 
+struct OTLPConfiguration {
+    let url: String
+    let username: String
+    let password: String
+}
+
 // This exposes the full Rust side tracing subscriber filter for more flexibility.
 // We can filter by level, crate and even file. See more details here:
 // https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/filter/struct.EnvFilter.html#examples
@@ -83,6 +89,18 @@ struct TracingConfiguration {
     }
 }
 
-func setupTracing(configuration: TracingConfiguration) {
-    setupTracing(config: .init(filter: configuration.filter, writeToStdoutOrSystem: true, writeToFiles: nil))
+func setupTracing(configuration: TracingConfiguration, otlpConfiguration: OTLPConfiguration?) {
+    if let otlpConfiguration {
+        setupOtlpTracing(config: .init(clientName: "ElementX-iOS",
+                                       user: otlpConfiguration.username,
+                                       password: otlpConfiguration.password,
+                                       otlpEndpoint: otlpConfiguration.url,
+                                       filter: configuration.filter,
+                                       writeToStdoutOrSystem: true,
+                                       writeToFiles: nil))
+    } else {
+        setupTracing(config: .init(filter: configuration.filter,
+                                   writeToStdoutOrSystem: true,
+                                   writeToFiles: nil))
+    }
 }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/DeveloperOptionsScreenModels.swift
@@ -44,6 +44,7 @@ enum DeveloperOptionsScreenViewAction {
 
 protocol DeveloperOptionsProtocol: AnyObject {
     var logLevel: TracingConfiguration.LogLevel { get set }
+    var otlpTracingEnabled: Bool { get set }
     var shouldCollapseRoomStateEvents: Bool { get set }
     var userSuggestionsEnabled: Bool { get set }
     var readReceiptsEnabled: Bool { get set }

--- a/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/DeveloperOptionsScreen/View/DeveloperOptionsScreen.swift
@@ -22,13 +22,20 @@ struct DeveloperOptionsScreen: View {
 
     var body: some View {
         Form {
-            Picker(selection: $context.logLevel) {
-                ForEach(TracingConfiguration.LogLevel.allCases, id: \.self) { logLevel in
-                    Text(logLevel.rawValue.capitalized)
+            Section("Logging") {
+                Picker(selection: $context.logLevel) {
+                    ForEach(TracingConfiguration.LogLevel.allCases, id: \.self) { logLevel in
+                        Text(logLevel.rawValue.capitalized)
+                    }
+                } label: {
+                    Text("Log level")
+                    Text("Requires app reboot")
                 }
-            } label: {
-                Text("Log level")
-                Text("Requires app reboot")
+                
+                Toggle(isOn: $context.otlpTracingEnabled) {
+                    Text("OTLP tracing")
+                    Text("Requires app reboot")
+                }
             }
             
             Section("Timeline") {

--- a/ElementX/SupportingFiles/Info.plist
+++ b/ElementX/SupportingFiles/Info.plist
@@ -90,5 +90,11 @@
 	<string>$(KEYCHAIN_ACCESS_GROUP_IDENTIFIER)</string>
 	<key>mapLibreAPIKey</key>
 	<string>$(MAPLIBRE_API_KEY)</string>
+	<key>otlpTracingPassword</key>
+	<string>${OTLP_TRACING_PASSWORD}</string>
+	<key>otlpTracingURL</key>
+	<string>${OTLP_TRACING_URL}</string>
+	<key>otlpTracingUsername</key>
+	<string>${OTLP_TRACING_USERNAME}</string>
 </dict>
 </plist>

--- a/ElementX/SupportingFiles/secrets.xcconfig
+++ b/ElementX/SupportingFiles/secrets.xcconfig
@@ -17,4 +17,16 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
+// MARK: - MapLibre
 MAPLIBRE_API_KEY = your_key
+
+// MARK: - OTLP Tracing
+
+// URLs need special treatment to work properly in xcconfig files
+// https://stackoverflow.com/a/36297483/730924
+// i.e. make sure to use https:/$()/ in the scheme in the stored secret
+OTLP_TRACING_URL = otlp_endpoint
+
+OTLP_TRACING_USERNAME = otlp_username
+OTLP_TRACING_PASSWORD = otlp_password
+

--- a/ElementX/SupportingFiles/target.yml
+++ b/ElementX/SupportingFiles/target.yml
@@ -80,7 +80,6 @@ targets:
         BGTaskSchedulerPermittedIdentifiers: [
           io.element.elementx.background.refresh
         ]
-        mapLibreAPIKey: $(MAPLIBRE_API_KEY)
         UTExportedTypeDeclarations:
         - UTTypeConformsTo: [public.text]
           UTTypeDescription: Mention Pills
@@ -91,6 +90,10 @@ targets:
           LSHandlerRank: Owner
           LSItemContentTypes: $(PILLS_UT_TYPE_IDENTIFIER)
         LSSupportsOpeningDocumentsInPlace: false
+        mapLibreAPIKey: $(MAPLIBRE_API_KEY)
+        otlpTracingURL: ${OTLP_TRACING_URL}
+        otlpTracingUsername: ${OTLP_TRACING_USERNAME}
+        otlpTracingPassword: ${OTLP_TRACING_PASSWORD}
 
 
     settings:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -164,7 +164,7 @@ lane :config_nightly do
   data["settings"]["BASE_APP_GROUP_IDENTIFIER"] = "io.element.nightly"
   data["settings"]["BASE_BUNDLE_IDENTIFIER"] = "io.element.elementx.nightly"
 
-  config_maplibre()
+  config_secrets()
   
   File.open(target_file_path, 'w') { |f| YAML.dump(data, f) }
 
@@ -180,7 +180,7 @@ lane :config_nightly do
 end
 
 lane :config_production do
-  config_maplibre()
+  config_secrets()
   xcodegen(spec: "project.yml")
 end
 
@@ -414,13 +414,43 @@ private_lane :create_simulator_if_necessary do |options|
   end
 end
 
-private_lane :config_maplibre do
-  api_key = ENV["MAPLIBRE_API_KEY"]
-  UI.user_error!("Invalid Map Libre API key.") unless !api_key.to_s.empty?
+private_lane :config_secrets do
+  maplibre_api_key = ENV["MAPLIBRE_API_KEY"]
+  UI.user_error!("Invalid Map Libre API key.") unless !maplibre_api_key.to_s.empty?
+
+  otlp_tracing_url = ENV["OTLP_TRACING_URL"]
+  UI.user_error!("Invalid OTLP tracing URL.") unless !otlp_tracing_url.to_s.empty?
+
+  otlp_tracing_username = ENV["OTLP_TRACING_USERNAME"]
+  UI.user_error!("Invalid OTLP tracing username.") unless !otlp_tracing_username.to_s.empty?
+
+  otlp_tracing_password = ENV["OTLP_TRACING_PASSWORD"]
+  UI.user_error!("Invalid OTLP tracing URL.") unless !otlp_tracing_password.to_s.empty?
 
   set_xcconfig_value(
     path: './ElementX/SupportingFiles/secrets.xcconfig',
     name: 'MAPLIBRE_API_KEY',
-    value: api_key
+    value: maplibre_api_key
+  )
+
+  # URLs need special treatment to work properly in xcconfig files
+  # https://stackoverflow.com/a/36297483/730924
+  # i.e. make sure to use https:/$()/ in the scheme in the stored secret
+  set_xcconfig_value(
+    path: './ElementX/SupportingFiles/secrets.xcconfig',
+    name: 'OTLP_TRACING_URL',
+    value: otlp_tracing_url
+  )
+
+  set_xcconfig_value(
+    path: './ElementX/SupportingFiles/secrets.xcconfig',
+    name: 'OTLP_TRACING_USERNAME',
+    value: otlp_tracing_username
+  )
+
+  set_xcconfig_value(
+    path: './ElementX/SupportingFiles/secrets.xcconfig',
+    name: 'OTLP_TRACING_PASSWORD',
+    value: otlp_tracing_password
   )
 end


### PR DESCRIPTION
This allows nightly users to enable OTLP tracing from the developer options menu. Configuration and credentials are read from the `secrets.xcconfig` and have been added as envars to all Xcode Cloud workflows.