### PR TITLE
fix: Do not transform `\n` into `<br />` in the app

### DIFF
--- a/UnitTests/Sources/AttributedStringBuilderTests.swift
+++ b/UnitTests/Sources/AttributedStringBuilderTests.swift
@@ -395,7 +395,7 @@ class AttributedStringBuilderTests: XCTestCase {
         
         XCTAssertEqual(numberOfBlockquotes, 3, "Couldn't find all the blockquotes")
     }
-    
+
     // MARK: - Private
     
     private func checkLinkIn(attributedString: AttributedString?, expectedLink: String, expectedRuns: Int) {


### PR DESCRIPTION
https://github.com/vector-im/element-x-ios/pull/1463 tried to fix https://github.com/vector-im/element-x-ios/issues/1418. However, the solution wasn't working properly as Markdown is difficult.

A solution has been provided by the Rust SDK [1] itself, via `ruma` [2]. Markdown soft line breaks are transformed into hard line breaks, when compiling Markdown to HTML. Doing that inside the Markdown parser itself is the correct place, as it's particularly difficult and tricky to detect soft line breaks correctly in Markdown.

This patch reverts #1463, but the Rust SDK must be updated to correctly experience the fix.

[1]: https://github.com/matrix-org/matrix-rust-sdk/pull/2452
[2]: https://github.com/ruma/ruma/pull/1636