### PR TITLE
Signposting tweaks

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -67,6 +67,8 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
         navigationRootCoordinator = NavigationRootCoordinator()
         
         Self.setupServiceLocator(navigationRootCoordinator: navigationRootCoordinator, appSettings: appSettings)
+        
+        ServiceLocator.shared.analytics.signpost.beginFirstRooms()
 
         ServiceLocator.shared.analytics.startIfEnabled()
 
@@ -546,7 +548,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
     private func startSync() {
         guard let userSession else { return }
         
-        ServiceLocator.shared.analytics.signpost.beginSync()
+        ServiceLocator.shared.analytics.signpost.beginFirstSync()
         userSession.clientProxy.startSync()
         
         let identifier = "StaleDataIndicator"
@@ -568,7 +570,7 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
                 case .startedUpdating:
                     showLoadingIndicator()
                 case .receivedSyncUpdate:
-                    ServiceLocator.shared.analytics.signpost.endSync()
+                    ServiceLocator.shared.analytics.signpost.endFirstSync()
                     ServiceLocator.shared.userIndicatorController.retractIndicatorWithId(identifier)
                 default:
                     break

--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -164,7 +164,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 
                 // End the initial sync performance timing once the room list is about to be displayed.
                 if roomListMode == .rooms, self.state.roomListMode == .skeletons {
-                    analytics.signpost.endSync()
+                    analytics.signpost.endFirstRooms()
                 }
                 
                 self.state.roomListMode = roomListMode

--- a/ElementX/Sources/Services/Analytics/Signposter.swift
+++ b/ElementX/Sources/Services/Analytics/Signposter.swift
@@ -26,7 +26,8 @@ class Signposter {
     /// Signpost name constants.
     enum Name {
         static let login: StaticString = "Login"
-        static let sync: StaticString = "Sync"
+        static let firstSync: StaticString = "FirstSync"
+        static let firstRooms: StaticString = "FirstRooms"
         static let roomFlow: StaticString = "RoomFlow"
     }
     
@@ -51,19 +52,34 @@ class Signposter {
         self.loginState = nil
     }
     
-    // MARK: - Sync
+    // MARK: - FirstSync
     
-    private var syncState: OSSignpostIntervalState?
+    private var firstSyncState: OSSignpostIntervalState?
     
-    func beginSync() {
-        syncState = signposter.beginInterval(Name.sync)
+    func beginFirstSync() {
+        firstSyncState = signposter.beginInterval(Name.firstSync)
     }
     
-    func endSync() {
-        guard let syncState else { return }
+    func endFirstSync() {
+        guard let firstSyncState else { return }
         
-        signposter.endInterval(Name.sync, syncState)
-        self.syncState = nil
+        signposter.endInterval(Name.firstSync, firstSyncState)
+        self.firstSyncState = nil
+    }
+    
+    // MARK: - FirstRooms
+    
+    private var firstRoomsState: OSSignpostIntervalState?
+    
+    func beginFirstRooms() {
+        firstRoomsState = signposter.beginInterval(Name.firstRooms)
+    }
+    
+    func endFirstRooms() {
+        guard let firstRoomsState else { return }
+        
+        signposter.endInterval(Name.firstRooms, firstRoomsState)
+        self.firstRoomsState = nil
     }
     
     // MARK: - Room Flow

--- a/Tools/Scripts/parsePerformanceMetrics.sh
+++ b/Tools/Scripts/parsePerformanceMetrics.sh
@@ -14,8 +14,9 @@ NOW=`date -u -Iminutes`
 grep ".*measured.*values" $1 | sed -e "s/.*Test Case .*-\[//" -e "s/\]' measured \[/,/" -e "s/\].*values: \[/,/" -e "s/\], performance.*//" -e "s/^/$2,/" \
    -e "s/IntegrationTests.LoginTests testLoginFlow,Duration .AppLaunch., s/launchPerformance/" \
    -e "s/IntegrationTests.LoginTests testLoginFlow,Duration .Login., s/loginPerformance/" \
-   -e "s/IntegrationTests.LoginTests testLoginFlow,Duration .RoomFlow., s/roomflowPerformance/" \
-   -e "s/IntegrationTests.LoginTests testLoginFlow,Duration .Sync., s/syncPerformance/" \
+   -e "s/IntegrationTests.LoginTests testLoginFlow,Duration .RoomFlow., s/roomFlowPerformance/" \
+   -e "s/IntegrationTests.LoginTests testLoginFlow,Duration .FirstRooms., s/firstRoomsPerformance/" \
+   -e "s/IntegrationTests.LoginTests testLoginFlow,Duration .FirstSync., s/firstSyncPerformance/" \
    -e "s/IntegrationTests.LoginTests testLoginFlow,Clock Monotonic Time, s/totalTime/" \
    -e "s/^/$NOW,/"
 


### PR DESCRIPTION
Split `sync` into `initialSync` and `firstRooms` which will track how long the very first sync takes separately from how long the first rooms appear in the list

Fixes #1529, goes in hand with #1558