### PR TITLE
Speed up unit tests by removing artifacts uploading (they're slow and…

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -41,15 +41,6 @@ jobs:
 
       - name: Run tests
         run: bundle exec fastlane unit_tests
-        
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: test-output
-          path: fastlane/test_output
-          retention-days: 7
-          if-no-files-found: ignore
       
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
… we're not really using them)