### PR TITLE
Fix computing the time it takes to render the first rooms

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -138,6 +138,8 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             return
         }
         
+        ServiceLocator.shared.analytics.signpost.beginFirstRooms()
+        
         // Combine together the state and the room list to correctly compute the view state if
         // data is present in the room list "cold cache"
         Publishers.CombineLatest(roomSummaryProvider.statePublisher,
@@ -160,6 +162,10 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
                 
                 guard roomListMode != self.state.roomListMode else {
                     return
+                }
+                
+                if roomListMode == .rooms, self.state.roomListMode == .skeletons {
+                    ServiceLocator.shared.analytics.signpost.endFirstRooms()
                 }
                 
                 self.state.roomListMode = roomListMode

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -399,8 +399,6 @@ class ClientProxy: ClientProxyProtocol {
                                     appIdentifier: "MainApp")
                 .finish()
             let roomListService = syncService.roomListService()
-            
-            ServiceLocator.shared.analytics.signpost.beginFirstRooms()
 
             let eventStringBuilder = RoomEventStringBuilder(stateEventStringBuilder: RoomStateEventStringBuilder(userID: userID))
             roomSummaryProvider = RoomSummaryProvider(roomListService: roomListService,

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -166,8 +166,6 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         
         MXLog.verbose("\(name): Finished applying \(diffs.count) diffs, new room list \(rooms.compactMap { $0.id ?? "Empty" })")
         
-        ServiceLocator.shared.analytics.signpost.endFirstRooms()
-        
         MXLog.info("Finished processing room list diffs")
     }
     


### PR DESCRIPTION
Was looking at the performance graphs and the first rooms one seemed too good to be true. Turns out the SDK sends a reset diff with 0 entries when logging in (which the integration tests keep doing). On top of that, because of the analytics screen, the startSync method isn't called to later.
Decided to move the call so the screen itself so that we start when the screen is created and we stop as soon as we go into state.rooms (coming from skeletons)