### PR TITLE
Add app logo to OIDC and fix policy URL

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -5575,7 +5575,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.1.2;
+				version = 1.1.3;
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -129,8 +129,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "3cc7cbd7b93d2492525678b37324f11ccb7a1889",
-        "version" : "1.1.2"
+        "revision" : "2599119dfacd12208896e8c52c58e424015ec997",
+        "version" : "1.1.3"
       }
     },
     {
@@ -244,7 +244,7 @@
     {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
+      "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
         "revision" : "b94da693e57eaf79d16464b8b7c90d09cba4e290",
         "version" : "0.9.2"

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -102,6 +102,17 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.hasShownWelcomeScreen, defaultValue: false, storageType: .userDefaults(store))
     var hasShownWelcomeScreen: Bool
     
+    /// A URL where users can go read more about the app.
+    let websiteURL: URL = "https://element.io"
+    /// A URL that contains the app's logo that may be used when showing content in a web view.
+    let logoURL: URL = "https://element.io/mobile-icon.png"
+    /// A URL that contains that app's copyright notice.
+    let copyrightURL: URL = "https://element.io/copyright"
+    /// A URL that contains the app's Terms of use.
+    let acceptableUseURL: URL = "https://element.io/acceptable-use-policy-terms"
+    /// A URL that contains the app's Privacy Policy.
+    let privacyURL: URL = "https://element.io/privacy"
+    
     // MARK: - Authentication
     
     /// The URL that is opened when tapping the Learn more button on the sliding sync alert during authentication.
@@ -109,12 +120,6 @@ final class AppSettings {
     
     /// The redirect URL used for OIDC.
     let oidcRedirectURL: URL = "io.element:/callback"
-    /// The app's main URL shown when using OIDC.
-    let oidcClientURL: URL = "https://element.io"
-    /// The app's Terms of Service URL shown when using OIDC.
-    let oidcTermsURL: URL = "https://element.io/user-terms-of-service"
-    /// The app's Privacy Policy URL shown when using OIDC.
-    let oidcPolicyURL: URL = "https://element.io/privacy"
     /// Any pre-defined static client registrations for OIDC issuers.
     let oidcStaticRegistrations: [URL: String] = ["https://id.thirdroom.io/realms/thirdroom": "elementx"]
 

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -311,7 +311,8 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
                                                                    userIndicatorController: userIndicatorController,
                                                                    userSession: userSession,
                                                                    bugReportService: bugReportService,
-                                                                   notificationSettings: userSession.clientProxy.notificationSettings())
+                                                                   notificationSettings: userSession.clientProxy.notificationSettings(),
+                                                                   appSettings: appSettings)
         let settingsScreenCoordinator = SettingsScreenCoordinator(parameters: parameters)
         settingsScreenCoordinator.callback = { [weak self] action in
             guard let self else { return }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.3 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable all

--- a/ElementX/Sources/Screens/Settings/LegalInformationScreen/LegalInformationScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/LegalInformationScreen/LegalInformationScreenCoordinator.swift
@@ -18,7 +18,11 @@ import Combine
 import SwiftUI
 
 final class LegalInformationScreenCoordinator: CoordinatorProtocol {
-    private let viewModel = LegalInformationScreenViewModel()
+    private let viewModel: LegalInformationScreenViewModel
+    
+    init(appSettings: AppSettings) {
+        viewModel = LegalInformationScreenViewModel(appSettings: appSettings)
+    }
     
     func toPresentable() -> AnyView {
         AnyView(LegalInformationScreen(context: viewModel.context))

--- a/ElementX/Sources/Screens/Settings/LegalInformationScreen/LegalInformationScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/LegalInformationScreen/LegalInformationScreenModels.swift
@@ -18,6 +18,10 @@ import Foundation
 
 enum LegalInformationScreenViewModelAction { }
 
-struct LegalInformationScreenViewState: BindableState { }
+struct LegalInformationScreenViewState: BindableState {
+    let copyrightURL: URL
+    let acceptableUseURL: URL
+    let privacyURL: URL
+}
 
 enum LegalInformationScreenViewAction { }

--- a/ElementX/Sources/Screens/Settings/LegalInformationScreen/LegalInformationScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/LegalInformationScreen/LegalInformationScreenViewModel.swift
@@ -20,7 +20,9 @@ import SwiftUI
 typealias LegalInformationScreenViewModelType = StateStoreViewModel<LegalInformationScreenViewState, LegalInformationScreenViewAction>
 
 class LegalInformationScreenViewModel: LegalInformationScreenViewModelType, LegalInformationScreenViewModelProtocol {
-    init() {
-        super.init(initialViewState: LegalInformationScreenViewState())
+    init(appSettings: AppSettings) {
+        super.init(initialViewState: LegalInformationScreenViewState(copyrightURL: appSettings.copyrightURL,
+                                                                     acceptableUseURL: appSettings.acceptableUseURL,
+                                                                     privacyURL: appSettings.privacyURL))
     }
 }

--- a/ElementX/Sources/Screens/Settings/LegalInformationScreen/View/LegalInformationScreen.swift
+++ b/ElementX/Sources/Screens/Settings/LegalInformationScreen/View/LegalInformationScreen.swift
@@ -25,11 +25,11 @@ struct LegalInformationScreen: View {
         Form {
             Section {
                 ListRow(label: .plain(title: L10n.commonCopyright),
-                        kind: .navigationLink { openURL("https://element.io/copyright") })
+                        kind: .button { openURL(context.viewState.copyrightURL) })
                 ListRow(label: .plain(title: L10n.commonAcceptableUsePolicy),
-                        kind: .navigationLink { openURL("https://element.io/acceptable-use-policy-terms") })
+                        kind: .button { openURL(context.viewState.acceptableUseURL) })
                 ListRow(label: .plain(title: L10n.commonPrivacyPolicy),
-                        kind: .navigationLink { openURL("https://element.io/privacy") })
+                        kind: .button { openURL(context.viewState.privacyURL) })
             }
         }
         .compoundList()
@@ -41,7 +41,7 @@ struct LegalInformationScreen: View {
 // MARK: - Previews
 
 struct LegalInformationScreen_Previews: PreviewProvider {
-    static let viewModel = LegalInformationScreenViewModel()
+    static let viewModel = LegalInformationScreenViewModel(appSettings: AppSettings())
     static var previews: some View {
         LegalInformationScreen(context: viewModel.context)
     }

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenCoordinator.swift
@@ -22,6 +22,7 @@ struct SettingsScreenCoordinatorParameters {
     let userSession: UserSessionProtocol
     let bugReportService: BugReportServiceProtocol
     let notificationSettings: NotificationSettingsProxyProtocol
+    let appSettings: AppSettings
 }
 
 enum SettingsScreenCoordinatorAction {
@@ -132,7 +133,7 @@ final class SettingsScreenCoordinator: CoordinatorProtocol {
     }
     
     private func presentLegalInformationScreen() {
-        parameters.navigationStackCoordinator?.push(LegalInformationScreenCoordinator())
+        parameters.navigationStackCoordinator?.push(LegalInformationScreenCoordinator(appSettings: parameters.appSettings))
     }
     
     private func verifySession() {

--- a/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
+++ b/ElementX/Sources/Services/Authentication/AuthenticationServiceProxy.swift
@@ -33,9 +33,10 @@ class AuthenticationServiceProxy: AuthenticationServiceProxyProtocol {
         
         let oidcConfiguration = OidcConfiguration(clientName: InfoPlistReader.main.bundleDisplayName,
                                                   redirectUri: appSettings.oidcRedirectURL.absoluteString,
-                                                  clientUri: appSettings.oidcClientURL.absoluteString,
-                                                  tosUri: appSettings.oidcTermsURL.absoluteString,
-                                                  policyUri: appSettings.oidcPolicyURL.absoluteString,
+                                                  clientUri: appSettings.websiteURL.absoluteString,
+                                                  logoUri: appSettings.logoURL.absoluteString,
+                                                  tosUri: appSettings.acceptableUseURL.absoluteString,
+                                                  policyUri: appSettings.privacyURL.absoluteString,
                                                   staticRegistrations: appSettings.oidcStaticRegistrations.mapKeys { $0.absoluteString })
         
         authenticationService = AuthenticationService(basePath: userSessionStore.baseDirectory.path,

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -171,7 +171,8 @@ class MockScreen: Identifiable {
                                                                           userIndicatorController: nil,
                                                                           userSession: MockUserSession(clientProxy: clientProxy, mediaProvider: MockMediaProvider()),
                                                                           bugReportService: BugReportServiceMock(),
-                                                                          notificationSettings: NotificationSettingsProxyMock(with: .init())))
+                                                                          notificationSettings: NotificationSettingsProxyMock(with: .init()),
+                                                                          appSettings: ServiceLocator.shared.settings))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator
         case .bugReport:

--- a/changelog.d/1547.bugfix
+++ b/changelog.d/1547.bugfix
@@ -1,0 +1,1 @@
+Add app logo and fix terms link for OIDC login (only affects fresh app installs).

--- a/project.yml
+++ b/project.yml
@@ -45,7 +45,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.1.2
+    exactVersion: 1.1.3
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
This PR makes the following changes:

- Make app URLs generic and not scoped to OIDC (fixing an incorrect URL in the process).
- Use these app URLs in the `LegalInformationScreen` instead of hard coding them there.
- Remove navigation chevrons from above screen (discussed with Design as part of OIDC Account URL work).
- Update the SDK.
- Provide an entry for the `logoURL` field in the OIDC configuration.

Note: These changes are only visible on a fresh install of EX if you have already attempted to login via OIDC as the existing registration will be reused. To see the changes delete the app and re-install it.

Fixes #1547.

![Simulator Screenshot - iPhone 14 - 2023-08-29 at 18 42 49](https://github.com/vector-im/element-x-ios/assets/6060466/66a11018-469f-4851-bb4a-d14a366667ca)