### PR TITLE
Use Safari for OIDC account URL.

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -397,18 +397,24 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
         }
         
         Task {
-            //  first log out from the server
-            _ = await userSession.clientProxy.logout()
+            // First log out from the server
+            let accountLogoutURL = await userSession.clientProxy.logout()
             
-            //  regardless of the result, clear user data
+            // Regardless of the result, clear user data
             userSessionStore.logout(userSession: userSession)
             tearDownUserSession()
             
-            // reset analytics
+            // Reset analytics
             ServiceLocator.shared.analytics.optOut()
             ServiceLocator.shared.analytics.resetConsentState()
             
             stateMachine.processEvent(.completedSigningOut(isSoft: isSoft))
+            
+            // Handle OIDC's RP-Initiated Logout if needed. Don't fallback to an ASWebAuthenticationSession
+            // as it looks weird to show an alert to the user asking them to sign in to their provider.
+            if let accountLogoutURL, UIApplication.shared.canOpenURL(accountLogoutURL) {
+                await UIApplication.shared.open(accountLogoutURL)
+            }
             
             hideLoadingIndicator()
         }

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenCoordinator.swift
@@ -88,12 +88,19 @@ final class SettingsScreenCoordinator: CoordinatorProtocol {
             return
         }
         
-        // Safari never works in the simulator, use a Web Authentication Session instead.
-        accountSettingsPresenter = OIDCAccountSettingsPresenter(accountURL: accountURL, presentationAnchor: window)
-        accountSettingsPresenter?.start()
+        #if targetEnvironment(simulator)
+        let canOpenURL = false // Safari can't access the cookie on the iOS 16 simulator 🤷‍♂️
+        #else
+        let canOpenURL = UIApplication.shared.canOpenURL(accountURL)
+        #endif
         
-        // Safari isn't working with the shared browser session 😕
-        // UIApplication.shared.open(accountURL)
+        if canOpenURL {
+            UIApplication.shared.open(accountURL)
+        } else {
+            // Fall back to an ASWebAuthenticationSession to handle the URL inside the app.
+            accountSettingsPresenter = OIDCAccountSettingsPresenter(accountURL: accountURL, presentationAnchor: window)
+            accountSettingsPresenter?.start()
+        }
     }
     
     private func presentAnalyticsScreen() {

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -312,6 +312,7 @@ class ClientProxy: ClientProxyProtocol {
                 return try self.client.logout().flatMap(URL.init(string:))
             } catch {
                 MXLog.error("Failed logging out with error: \(error)")
+                return nil
             }
         }
     }

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -306,11 +306,10 @@ class ClientProxy: ClientProxyProtocol {
         }
     }
 
-    func logout() async {
+    func logout() async -> URL? {
         await Task.dispatch(on: clientQueue) {
             do {
-                // We aren't currently handling the RP initiated sign out URL.
-                _ = try self.client.logout()
+                return try self.client.logout().flatMap(URL.init(string:))
             } catch {
                 MXLog.error("Failed logging out with error: \(error)")
             }

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -107,7 +107,7 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     
     func sessionVerificationControllerProxy() async -> Result<SessionVerificationControllerProxyProtocol, ClientProxyError>
 
-    func logout() async
+    func logout() async -> URL?
 
     func setPusher(with configuration: PusherConfiguration) async throws
     

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -116,8 +116,8 @@ class MockClientProxy: ClientProxyProtocol {
         }
     }
     
-    func logout() async {
-        // no-op
+    func logout() async -> URL? {
+        nil
     }
     
     var setPusherErrorToThrow: Error?

--- a/changelog.d/pr-1591.change
+++ b/changelog.d/pr-1591.change
@@ -1,0 +1,1 @@
+Use Safari for OIDC account management.


### PR DESCRIPTION
Following on from https://github.com/matrix-org/matrix-authentication-service/pull/1598, cookies are now correctly shared from the `ASWebAuthenticationSession` to Safari. As requested by the auth team, we now open the account URL in Safari. The WAS is still used in the follow scenarios:

- On the simulator - it doesn't get access to the cookie in Safari for some reason.
- When Safari is disabled behind Screen Time (by checking for canOpenURL).

Additionally, this PR will present RP-Initiated Logout to the user when returned by the authentication issuer (untested).