### PR TITLE
Fix spring board crash when muting a notification

### DIFF
--- a/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
+++ b/ElementX/Sources/Services/Notification/Proxy/NotificationItemProxy.swift
@@ -179,7 +179,8 @@ extension NotificationItemProxyProtocol {
         notification.eventID = eventID
         notification.sound = isNoisy ? UNNotificationSound(named: UNNotificationSoundName(rawValue: "message.caf")) : nil
         // So that the UI groups notification that are received for the same room but also for the same user
-        notification.threadIdentifier = "\(receiverID)\(roomID)"
+        // Removing the @ fixes an iOS bug where the notification crashes if the mute button is tapped
+        notification.threadIdentifier = "\(receiverID)\(roomID)".replacingOccurrences(of: "@", with: "")
         return notification
     }
 

--- a/changelog.d/1519.bugfix
+++ b/changelog.d/1519.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug that made the spring board crash when trying to mute notifications.


### PR DESCRIPTION
fixes #1519 

This is actually caused by an Apple Bug, opening a feedback report about this incident.