### PR TITLE
Prevent the timeline from jumping whenever a room is entered

### DIFF
--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -99,6 +99,10 @@ class RoomProxy: RoomProxyProtocol {
         
         let timelineListener = RoomTimelineListener { [weak self] timelineDiffs in
             self?.timelineUpdatesSubject.send(timelineDiffs)
+            
+            // Workaround for subscribeToRoomStateUpdates creating problems in the timeline
+            // https://github.com/matrix-org/matrix-rust-sdk/issues/2488
+            self?.stateUpdatesSubject.send()
         }
         
         self.timelineListener = timelineListener
@@ -108,7 +112,7 @@ class RoomProxy: RoomProxyProtocol {
         
         subscribeToBackpagination()
         
-        subscribeToRoomStateUpdates()
+        // subscribeToRoomStateUpdates()
         
         innerTimelineProvider = await RoomTimelineProvider(currentItems: result.items,
                                                            updatePublisher: timelineUpdatesSubject.eraseToAnyPublisher(),


### PR DESCRIPTION
- caused by https://github.com/matrix-org/matrix-rust-sdk/issues/2488
- rolled back to a solution similar to what we had before