### PR TITLE
Update RTE version to 2.8.0

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -5591,7 +5591,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-wysiwyg-composer-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 2.6.3;
+				version = 2.8.0;
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -138,8 +138,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-wysiwyg-composer-swift",
       "state" : {
-        "revision" : "2827fea6508b62b8c458a29cb74282d99e63ecf7",
-        "version" : "2.6.3"
+        "revision" : "30d41b07b636f67e06bc50d8982c98ee3b97d4ae",
+        "version" : "2.8.0"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -114,4 +114,4 @@ packages:
     minorVersion: 2.0.0
   WysiwygComposer:
     url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift
-    exactVersion: 2.6.3
+    exactVersion: 2.8.0


### PR DESCRIPTION
Only currently significant change for this version: 
OS logs are now configurable. By default only errors will show in the console. 