### PR TITLE
Remove unnecessary test

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
@@ -117,10 +117,8 @@ struct HomeScreenRoomCell: View {
             Spacer()
             
             HStack(spacing: 8) {
-                if let notificationMode = room.notificationMode {
-                    notificationModeIcon
-                        .foregroundColor(room.hasUnreads ? .compound.iconAccentTertiary : .compound.iconQuaternary)
-                }
+                notificationModeIcon
+                    .foregroundColor(room.hasUnreads ? .compound.iconAccentTertiary : .compound.iconQuaternary)
                 
                 if room.hasUnreads {
                     Circle()


### PR DESCRIPTION
This PR removes an Xcode warning in `HomeScreenRoomCell` by deleting an unnecessary test.