### PR TITLE
Limit the number of rooms the summary provider handles to 500

### DIFF
--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
@@ -42,7 +42,7 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
         }
     }
     
-    func setRoomList(_ roomList: RoomList) { }
+    func setRoomList(_ roomList: RoomListProtocol) { }
     
     func updateVisibleRange(_ range: Range<Int>) { }
     

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProviderProtocol.swift
@@ -96,7 +96,7 @@ protocol RoomSummaryProviderProtocol {
     
     /// This is outside of the constructor because the invites list is added later on the Rust side.
     /// Wanted to be able to build the InvitesSummaryProvider directly instead of having to inform the HomeScreenViewModel about it later
-    func setRoomList(_ roomList: RoomList)
+    func setRoomList(_ roomList: RoomListProtocol)
     
     func updateVisibleRange(_ range: Range<Int>)
     


### PR DESCRIPTION
In order to avoid overloading the room summary serial diff processing queue with diffs the user most likely is not interested in, this PR introduced a hard limit on the amount of rooms that we show in the room list. It does so by simply ignoring diffs outside of that range.
Searching and the rest of the functionality is not affected.

P.S. Tried unit testing but couldn't find a way around private constructors or closed classes in the various uniffi components needed