### PR TITLE
Notification fixes

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -400,6 +400,11 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
             return
         }
         
+        // The user will log out, clear any existing notifications
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+        UIApplication.shared.applicationIconBadgeNumber = 0
+        
         Task {
             // First log out from the server
             let accountLogoutURL = await userSession.clientProxy.logout()

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -60,7 +60,8 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
         Task {
             await run(with: credentials,
                       roomId: roomId,
-                      eventId: eventId)
+                      eventId: eventId,
+                      unreadCount: request.unreadCount)
         }
     }
     
@@ -73,7 +74,8 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
 
     private func run(with credentials: KeychainCredentials,
                      roomId: String,
-                     eventId: String) async {
+                     eventId: String,
+                     unreadCount: Int?) async {
         MXLog.info("\(tag) run with roomId: \(roomId), eventId: \(eventId)")
 
         do {
@@ -102,6 +104,12 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
                 modifiedContent = latestContent
             }
             // We still notify, but without the media attachment if it fails to load
+            
+            // Finally update the app badge
+            if let unreadCount {
+                modifiedContent?.badge = NSNumber(value: unreadCount)
+            }
+            
             return notify()
         } catch {
             MXLog.error("NSE run error: \(error)")


### PR DESCRIPTION
- Fixes #1573 - Retract all notifications and app badges when signing out
- Update the app badge after receiving a notification by reading and using the unreadCount from the request payload