### PR TITLE
Initial skeleton for Universal Link handling.

### DIFF
--- a/ElementX/Sources/Application/AppCoordinatorProtocol.swift
+++ b/ElementX/Sources/Application/AppCoordinatorProtocol.swift
@@ -18,4 +18,5 @@ import Foundation
 
 protocol AppCoordinatorProtocol: CoordinatorProtocol {
     var notificationManager: NotificationManagerProtocol { get }
+    func handleUniversalLink(_ url: URL)
 }

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -35,6 +35,7 @@ struct Application: App {
         WindowGroup {
             appCoordinator.toPresentable()
                 .statusBarHidden(shouldHideStatusBar)
+                .onOpenURL { appCoordinator.handleUniversalLink($0) }
                 .introspect(.window, on: .iOS(.v16)) { window in
                     // Workaround for SwiftUI not consistently applying the tint colour to Alerts/Confirmation Dialogs.
                     window.tintColor = .compound.textActionPrimary

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -60,6 +60,10 @@ class UITestsAppCoordinator: AppCoordinatorProtocol {
     func toPresentable() -> AnyView {
         navigationRootCoordinator.toPresentable()
     }
+    
+    func handleUniversalLink(_ url: URL) {
+        fatalError("Not implemented.")
+    }
 }
 
 @MainActor

--- a/ElementX/Sources/UnitTests/UnitTestsAppCoordinator.swift
+++ b/ElementX/Sources/UnitTests/UnitTestsAppCoordinator.swift
@@ -36,4 +36,8 @@ class UnitTestsAppCoordinator: AppCoordinatorProtocol {
     func toPresentable() -> AnyView {
         AnyView(ProgressView("Running Unit Tests"))
     }
+    
+    func handleUniversalLink(_ url: URL) {
+        fatalError("Not implemented.")
+    }
 }

--- a/changelog.d/pr-1638.change
+++ b/changelog.d/pr-1638.change
@@ -1,0 +1,1 @@
+Hook up universal links to the App Coordinator (this doesn't actually handle them yet).


### PR DESCRIPTION
This PR adds the initial implementation for receiving Universal Links into the App Coordinator. It doesn't implement parsing `AppRoute`s from the links or do anything with them yet though.

Additionally it removes all use of `ServiceLocator.shared.settings` in the App Coordinator.

@stefanceriu You're welcome to merge this tomorrow morning if you're happy with it and need to use it.