### PR TITLE
Adopt the new room list service syncIndicatorListener

### DIFF
--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -19,7 +19,6 @@ import Foundation
 import MatrixRustSDK
 
 enum ClientProxyCallback {
-    case startedUpdating
     case receivedSyncUpdate
     case receivedAuthError(isSoftLogout: Bool)
     case updateRestorationToken
@@ -31,6 +30,11 @@ enum ClientProxyCallback {
             return false
         }
     }
+}
+
+enum ClientProxyLoadingState {
+    case loading
+    case notLoading
 }
 
 enum ClientProxyError: Error {
@@ -66,6 +70,8 @@ struct PusherConfiguration {
 
 protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     var callbacks: PassthroughSubject<ClientProxyCallback, Never> { get }
+    
+    var loadingStatePublisher: CurrentValuePublisher<ClientProxyLoadingState, Never> { get }
     
     var userID: String { get }
 

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -21,6 +21,8 @@ import MatrixRustSDK
 class MockClientProxy: ClientProxyProtocol {
     let callbacks = PassthroughSubject<ClientProxyCallback, Never>()
     
+    let loadingStatePublisher = CurrentValuePublisher<ClientProxyLoadingState, Never>(.notLoading)
+    
     let userID: String
     let deviceID: String?
     let homeserver = ""


### PR DESCRIPTION
* expose sync service loading state through a client proxy current value publisher and use it accordingly
* a current value publisher because the UI might not be instantiated by the time it finishes loading