### PR TITLE
Stop the sync service constantly attempting to restart on auth error.

### DIFF
--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinator.swift
@@ -73,14 +73,15 @@ class UserSessionFlowCoordinator: FlowCoordinatorProtocol {
         
         setupStateMachine()
         
-        roomFlowCoordinator.actions.sink { action in
+        roomFlowCoordinator.actions.sink { [weak self] action in
+            guard let self else { return }
             switch action {
             case .presentedRoom(let roomID):
-                self.analytics.signpost.beginRoomFlow(roomID)
-                self.stateMachine.processEvent(.selectRoom(roomID: roomID))
+                analytics.signpost.beginRoomFlow(roomID)
+                stateMachine.processEvent(.selectRoom(roomID: roomID))
             case .dismissedRoom:
-                self.stateMachine.processEvent(.deselectRoom)
-                self.analytics.signpost.endRoomFlow()
+                stateMachine.processEvent(.deselectRoom)
+                analytics.signpost.endRoomFlow()
             }
         }
         .store(in: &cancellables)


### PR DESCRIPTION
Additionally removes a retain cycle that was preventing the client from being released.

This really isn't the ultimate solution. The sync service should provide us with more context as to what error occurred, and more specifically, what conditions need to change before a restart is triggered (e.g. network conditions/some user input/none, its fatal)