### PR TITLE
Fix button and make mxid copyable.

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Views/AvatarHeaderView.swift
+++ b/ElementX/Sources/Other/SwiftUI/Views/AvatarHeaderView.swift
@@ -37,6 +37,7 @@ struct AvatarHeaderView<Footer: View>: View {
                                     avatarSize: avatarSize,
                                     imageProvider: imageProvider)
             }
+            .buttonStyle(.borderless) // Add a button style to stop the whole row being tappable.
 
             Text(name ?? id)
                 .foregroundColor(.compound.textPrimary)
@@ -48,6 +49,7 @@ struct AvatarHeaderView<Footer: View>: View {
                     .foregroundColor(.compound.textSecondary)
                     .font(.compound.bodyLG)
                     .multilineTextAlignment(.center)
+                    .textSelection(.enabled)
             }
             
             footer()

--- a/changelog.d/1669.bugfix
+++ b/changelog.d/1669.bugfix
@@ -1,0 +1,1 @@
+Fix avatar button size and make mxid copyable in Room/Member details screens.


### PR DESCRIPTION
On the room/member details screens, the avatar button was applied to the entire row, this PR fixes that and makes the MXID copyable.

Fixes #1669 