### PR TITLE
Use a universal link for the OIDC callback.

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -120,10 +120,15 @@ final class AppSettings {
     /// The URL that is opened when tapping the Learn more button on the sliding sync alert during authentication.
     let slidingSyncLearnMoreURL: URL = "https://github.com/matrix-org/sliding-sync/blob/main/docs/Landing.md"
     
-    /// The redirect URL used for OIDC.
-    let oidcRedirectURL: URL = "io.element:/callback"
     /// Any pre-defined static client registrations for OIDC issuers.
     let oidcStaticRegistrations: [URL: String] = ["https://id.thirdroom.io/realms/thirdroom": "elementx"]
+    /// The redirect URL used for OIDC. The bundle ID suffix avoids app association conflicts between Element X, Nightly and PR builds.
+    let oidcRedirectURL = {
+        guard let bundleIDSuffix = InfoPlistReader.main.bundleIdentifier.split(separator: ".").last,
+              let redirectURL = URL(string: "https://mobile.element.io/oidc/\(bundleIDSuffix)")
+        else { fatalError("Failed creating a valid OIDC redirect URL.") }
+        return redirectURL
+    }()
 
     /// The date that the call to `/login` completed successfully. This is used to put
     /// a hard wall on the history of encrypted messages until we have key backup.

--- a/ElementX/Sources/Screens/Authentication/OIDCAuthenticationPresenter.swift
+++ b/ElementX/Sources/Screens/Authentication/OIDCAuthenticationPresenter.swift
@@ -23,6 +23,16 @@ class OIDCAuthenticationPresenter: NSObject {
     private let oidcRedirectURL: URL
     private let presentationAnchor: UIWindow
     
+    /// The data required to complete a request.
+    struct Request {
+        let session: ASWebAuthenticationSession
+        let oidcData: OIDCAuthenticationDataProxy
+        let continuation: CheckedContinuation<Result<UserSessionProtocol, AuthenticationServiceError>, Never>
+    }
+    
+    /// The current request in progress. This is a single use value and will be moved on access.
+    @Consumable private var request: Request?
+    
     init(authenticationService: AuthenticationServiceProxyProtocol, oidcRedirectURL: URL, presentationAnchor: UIWindow) {
         self.authenticationService = authenticationService
         self.oidcRedirectURL = oidcRedirectURL
@@ -35,40 +45,69 @@ class OIDCAuthenticationPresenter: NSObject {
         await withCheckedContinuation { continuation in
             let session = ASWebAuthenticationSession(url: oidcData.url,
                                                      callbackURLScheme: oidcRedirectURL.scheme) { [weak self] url, error in
+                // This closure won't be called if the scheme is https, see handleUniversalLinkCallback for more info.
                 guard let self else { return }
                 
                 guard let url else {
+                    // Check for user cancellation to avoid showing an alert in that instance.
                     if let nsError = error as? NSError,
                        nsError.domain == ASWebAuthenticationSessionErrorDomain,
                        nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
-                        continuation.resume(returning: .failure(AuthenticationServiceError.oidcError(.userCancellation)))
+                        self.completeAuthentication(throwing: .oidcError(.userCancellation))
                         return
                     }
                     
-                    continuation.resume(returning: .failure(AuthenticationServiceError.oidcError(.unknown)))
+                    self.completeAuthentication(throwing: .oidcError(.unknown))
                     return
                 }
                 
-                completeAuthentication(callbackURL: url, data: oidcData, continuation: continuation)
+                completeAuthentication(callbackURL: url)
             }
             
             session.prefersEphemeralWebBrowserSession = false
             session.presentationContextProvider = self
+            
+            request = Request(session: session, oidcData: oidcData, continuation: continuation)
+            
             session.start()
         }
     }
     
-    private func completeAuthentication(callbackURL: URL,
-                                        data: OIDCAuthenticationDataProxy,
-                                        continuation: CheckedContinuation<Result<UserSessionProtocol, AuthenticationServiceError>, Never>) {
+    /// This method will be used if the `appSettings.oidcRedirectURL`'s scheme is `https`.
+    /// When using a custom scheme, the redirect will be handled by the web auth session's closure.
+    func handleUniversalLinkCallback(_ url: URL) {
+        completeAuthentication(callbackURL: url)
+    }
+    
+    /// Completes the authentication by exchanging the callback URL for a user session.
+    private func completeAuthentication(callbackURL: URL) {
+        guard let request else {
+            MXLog.error("Failed to complete authentication. Missing request.")
+            return
+        }
+        
+        if callbackURL.scheme?.starts(with: "http") == true {
+            request.session.cancel()
+        }
+        
         Task {
-            switch await authenticationService.loginWithOIDCCallback(callbackURL, data: data) {
+            switch await authenticationService.loginWithOIDCCallback(callbackURL, data: request.oidcData) {
             case .success(let userSession):
-                continuation.resume(returning: .success(userSession))
+                request.continuation.resume(returning: .success(userSession))
             case .failure(let error):
-                continuation.resume(returning: .failure(error))
+                request.continuation.resume(returning: .failure(error))
             }
         }
+    }
+    
+    /// Aborts the authentication with the supplied error.
+    private func completeAuthentication(throwing error: AuthenticationServiceError) {
+        guard let request else {
+            MXLog.error("Failed to throw authentication error. Missing request.")
+            return
+        }
+        
+        request.continuation.resume(returning: .failure(error))
     }
 }
 

--- a/changelog.d/1734.change
+++ b/changelog.d/1734.change
@@ -1,0 +1,1 @@
+Use a universal link for OIDC callbacks.


### PR DESCRIPTION
This PR updates OIDC the OIDC callback to use a universal link of `mobile.element.io/oidc/appvariant`. Changes and notes:
- For some reason using `element.io/mobile/oidc/appvariant` was unreliable.
- `/appvariant` is added to avoid e.g. the Nightly build opening the link from a PR build (see MRs on `mobile-web-fallback` for more information).
- Universal links aren't captured by the ASWebAuthenticationSession, so the OIDC presenter was tweaked to accept completion externally.
- The state machine is tweaked so that the AppCoordinator can tell if it should forward the universal link to the authentication flow or the soft logout coordinator (its quite possible that OIDC isn't configured to signal a soft logout through Rust, and there may be a more efficient way to re-authenticate when this occurs).

Marking this PR as ready although it will need another deployment of mobile.element.io and a final round of testing to make sure EI doesn't hijack the callback links.

Fixes #1734.