### PR TITLE
Use `trace` for Client and OIDC logs.

### DIFF
--- a/ElementX/Sources/Other/Logging/RustTracing.swift
+++ b/ElementX/Sources/Other/Logging/RustTracing.swift
@@ -87,9 +87,9 @@ struct TracingConfiguration {
         .elementx: .info,
         .hyper: .warn,
         .matrix_sdk_ffi: .info,
-        .matrix_sdk_client: .info,
+        .matrix_sdk_client: .trace,
         .matrix_sdk_crypto: .info,
-        .matrix_sdk_oidc: .info,
+        .matrix_sdk_oidc: .trace,
         .matrix_sdk_http_client: .info,
         .matrix_sdk_sliding_sync: .info,
         .matrix_sdk_base_sliding_sync: .info,
@@ -109,7 +109,7 @@ struct TracingConfiguration {
         
         let overrides = Self.targets.keys.reduce(into: [Target: LogLevel]()) { partialResult, target in
             // Keep the defaults here
-            let ignoredTargets: [Target] = [.common, .hyper]
+            let ignoredTargets: [Target] = [.common, .hyper, .matrix_sdk_client, .matrix_sdk_oidc]
             if ignoredTargets.contains(target) {
                 return
             }


### PR DESCRIPTION
For @bnjbvr to gather debug logs for OIDC token refresh. Internal builds of 1.2.9 are already doing this (and are probably more relevant given they're using the right SDK branch), but this will help for anyone on Nightly.