### PR TITLE
Hide share buttons + file name …

### DIFF
--- a/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
@@ -119,10 +119,6 @@ private struct MediaPreviewViewController: UIViewControllerRepresentable {
         func previewControllerDidDismiss(_ controller: QLPreviewController) {
             onDismiss()
         }
-        
-        func previewController(_ controller: QLPreviewController, editingModeFor previewItem: QLPreviewItem) -> QLPreviewItemEditingMode {
-            .disabled
-        }
     }
 }
 

--- a/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
+++ b/ElementX/Sources/Screens/FilePreviewScreen/InteractiveQuickLook.swift
@@ -119,6 +119,10 @@ private struct MediaPreviewViewController: UIViewControllerRepresentable {
         func previewControllerDidDismiss(_ controller: QLPreviewController) {
             onDismiss()
         }
+        
+        func previewController(_ controller: QLPreviewController, editingModeFor previewItem: QLPreviewItem) -> QLPreviewItemEditingMode {
+            .disabled
+        }
     }
 }
 

--- a/ElementX/Sources/Screens/MediaUploadPreviewScreen/View/MediaUploadPreviewScreen.swift
+++ b/ElementX/Sources/Screens/MediaUploadPreviewScreen/View/MediaUploadPreviewScreen.swift
@@ -130,10 +130,7 @@ private class PreviewViewController: QLPreviewController {
         
         // Remove top file details bar
         navigationController?.navigationBar.isHidden = true
-        
-        // Hide navigation bar share button
-        navigationItem.rightBarButtonItem = nil
-        
+                
         // Hide toolbar share button
         toolbarItems?.first?.isHidden = true
     }

--- a/ElementX/Sources/Screens/MediaUploadPreviewScreen/View/MediaUploadPreviewScreen.swift
+++ b/ElementX/Sources/Screens/MediaUploadPreviewScreen/View/MediaUploadPreviewScreen.swift
@@ -128,6 +128,13 @@ private class PreviewViewController: QLPreviewController {
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         
+        // Remove top file details bar
+        navigationController?.navigationBar.isHidden = true
+        
+        // Hide navigation bar share button
         navigationItem.rightBarButtonItem = nil
+        
+        // Hide toolbar share button
+        toolbarItems?.first?.isHidden = true
     }
 }


### PR DESCRIPTION
…bar for media upload previews

Continues #1544 and partially addresses #1646
* remove share buttons for videos too when uploading media
* removes file name bar from the media upload preview
