### PR TITLE
Fixes #1640 - Prevent loading skeletons from being dismissed too soon…

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -148,8 +148,10 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             .sink { [weak self] state, rooms in
                 guard let self else { return }
                 
-                let isLoadingData = !state.isLoaded && rooms.isEmpty
-                let hasNoRooms = (state.isLoaded && state.totalNumberOfRooms == 0 && rooms.isEmpty)
+                // Rust sends back loaded even when no rooms are loaded yet, check room for empty to be sure
+                let isLoadingData = !state.isLoaded || (state.totalNumberOfRooms != 0 && rooms.isEmpty)
+                
+                let hasNoRooms = state.isLoaded && state.totalNumberOfRooms == 0 && rooms.isEmpty
                 
                 var roomListMode = self.state.roomListMode
                 if isLoadingData {

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -82,7 +82,6 @@ struct HomeScreen: View {
             .scrollDismissesKeyboard(.immediately)
             .scrollDisabled(context.viewState.roomListMode == .skeletons)
             .scrollBounceBehavior(context.viewState.roomListMode == .empty ? .basedOnSize : .automatic)
-            .animation(.elementDefault, value: context.viewState.showSessionVerificationBanner)
             .animation(.elementDefault, value: context.viewState.roomListMode)
             .animation(.none, value: context.viewState.visibleRooms)
         }


### PR DESCRIPTION
…. Avoid weird animations caused by the session verification banner.
