### PR TITLE
Fix timestamp padding for .horizontal bubble layout style

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -186,13 +186,9 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                 .cornerRadius(10)
                 .padding(.trailing, 4)
                 .padding(.bottom, 4)
-        case .overlay(capsuleStyle: false):
+        case .horizontal, .overlay(capsuleStyle: false):
             localizedSendInfo
                 .padding(.bottom, -4)
-        case .horizontal:
-            localizedSendInfo
-                .padding(.bottom, 4)
-                .padding(.trailing, 4)
         case .vertical:
             GridRow {
                 localizedSendInfo


### PR DESCRIPTION
This PR fixes the timestamp position for bubbles with a `.horizontal` layout style.

Before:

<img width="490" alt="Screenshot 2023-09-13 at 17 04 43" src="https://github.com/vector-im/element-x-ios/assets/4334885/9f974355-58b8-46ca-a37e-bee63b22a169">

After:

<img width="487" alt="Screenshot 2023-09-13 at 17 04 05" src="https://github.com/vector-im/element-x-ios/assets/4334885/00a1d7a6-581d-4dab-8c53-be75717fdb7c">

I've checked the UITests, but this change has no impact on the current screenshots.