### PR TITLE
Fix room notification mode decoration with unread indicator

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenModels.swift
@@ -125,10 +125,20 @@ struct HomeScreenRoom: Identifiable, Equatable {
     
     var notificationMode: RoomNotificationModeProxy?
     
+    var showUnreadIndicator: Bool {
+        // Do not display the unread indicator if the notification mode is either .mute or .mentionsAndKeywordsOnly
+        switch notificationMode {
+        case .some(let mode) where [.mute, .mentionsAndKeywordsOnly].contains(mode):
+            return false
+        default:
+            return hasUnreads
+        }
+    }
+    
     var hasDecoration: Bool {
         // notification setting is displayed only for .mentionsAndKeywords and .mute
         let showNotificationSettings = notificationMode != nil
-        return hasUnreads || showNotificationSettings
+        return showUnreadIndicator || showNotificationSettings
     }
     
     var isPlaceholder = false

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
@@ -95,8 +95,8 @@ struct HomeScreenRoomCell: View {
             
             if let timestamp = room.timestamp {
                 Text(timestamp)
-                    .font(room.hasUnreads ? .compound.bodySMSemibold : .compound.bodySM)
-                    .foregroundColor(room.hasUnreads ? .compound.textActionAccent : .compound.textSecondary)
+                    .font(room.showUnreadIndicator ? .compound.bodySMSemibold : .compound.bodySM)
+                    .foregroundColor(room.showUnreadIndicator ? .compound.textActionAccent : .compound.textSecondary)
             }
         }
     }
@@ -118,9 +118,9 @@ struct HomeScreenRoomCell: View {
             
             HStack(spacing: 8) {
                 notificationModeIcon
-                    .foregroundColor(room.hasUnreads ? .compound.iconAccentTertiary : .compound.iconQuaternary)
+                    .foregroundColor(.compound.iconQuaternary)
                 
-                if room.hasUnreads {
+                if room.showUnreadIndicator {
                     Circle()
                         .frame(width: 12, height: 12)
                         .foregroundColor(.compound.iconAccentTertiary)


### PR DESCRIPTION
This PR fixes the following issue:

If the notification mode is set to `.mentionsAndKeywordsOnly` or `.mute` while a room has unread notifications, we should not display the unread indicator.

`.allMessages` with unread notifications:
<img width="472" alt="Screenshot 2023-09-15 at 14 30 26" src="https://github.com/vector-im/element-x-ios/assets/4334885/d4e0ab3b-7f65-4890-94c4-73a48462b5a1">

`.mentionsAndKeywordsOnly` with unread notifications:
<img width="475" alt="Screenshot 2023-09-15 at 14 36 01" src="https://github.com/vector-im/element-x-ios/assets/4334885/1f978002-dec1-48ac-aa4e-fa8ddead8027">

`.mute` with unread notifications:
<img width="474" alt="Screenshot 2023-09-15 at 14 30 52" src="https://github.com/vector-im/element-x-ios/assets/4334885/a57c3cb5-0bb9-49a5-9fda-9394a7022815">
