### PR TITLE
Various small UI tweaks for the new user details edit screen

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -2,6 +2,8 @@
 "a11y_hide_password" = "Hide password";
 "a11y_notifications_mentions_only" = "Mentions only";
 "a11y_notifications_muted" = "Muted";
+"a11y_poll" = "Poll";
+"a11y_poll_end" = "Ended poll";
 "a11y_send_files" = "Send files";
 "a11y_show_password" = "Show password";
 "a11y_user_menu" = "User menu";
@@ -274,6 +276,7 @@
 "screen_edit_profile_display_name_placeholder" = "Your display name";
 "screen_edit_profile_error" = "An unknown error was encountered and the information couldn't be changed.";
 "screen_edit_profile_error_title" = "Unable to update profile";
+"screen_edit_profile_title" = "Edit profile";
 "screen_edit_profile_updating_details" = "Updating profile…";
 "screen_invites_decline_chat_message" = "Are you sure you want to decline the invitation to join %1$@?";
 "screen_invites_decline_chat_title" = "Decline invite";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -16,6 +16,10 @@ public enum L10n {
   public static var a11yNotificationsMentionsOnly: String { return L10n.tr("Localizable", "a11y_notifications_mentions_only") }
   /// Muted
   public static var a11yNotificationsMuted: String { return L10n.tr("Localizable", "a11y_notifications_muted") }
+  /// Poll
+  public static var a11yPoll: String { return L10n.tr("Localizable", "a11y_poll") }
+  /// Ended poll
+  public static var a11yPollEnd: String { return L10n.tr("Localizable", "a11y_poll_end") }
   /// Send files
   public static var a11ySendFiles: String { return L10n.tr("Localizable", "a11y_send_files") }
   /// Show password
@@ -692,6 +696,8 @@ public enum L10n {
   public static var screenEditProfileError: String { return L10n.tr("Localizable", "screen_edit_profile_error") }
   /// Unable to update profile
   public static var screenEditProfileErrorTitle: String { return L10n.tr("Localizable", "screen_edit_profile_error_title") }
+  /// Edit profile
+  public static var screenEditProfileTitle: String { return L10n.tr("Localizable", "screen_edit_profile_title") }
   /// Updating profile…
   public static var screenEditProfileUpdatingDetails: String { return L10n.tr("Localizable", "screen_edit_profile_updating_details") }
   /// Are you sure you want to decline the invitation to join %1$@?

--- a/ElementX/Sources/Other/AvatarSize.swift
+++ b/ElementX/Sources/Other/AvatarSize.swift
@@ -50,6 +50,7 @@ enum UserAvatarSizeOnScreen {
     case memberDetails
     case inviteUsers
     case readReceipt
+    case editUserDetails
 
     var value: CGFloat {
         switch self {
@@ -60,7 +61,7 @@ enum UserAvatarSizeOnScreen {
         case .home:
             return 32
         case .settings:
-            return 60
+            return 52
         case .roomDetails:
             return 44
         case .startChat:
@@ -69,6 +70,8 @@ enum UserAvatarSizeOnScreen {
             return 70
         case .inviteUsers:
             return 56
+        case .editUserDetails:
+            return 96
         }
     }
 }

--- a/ElementX/Sources/Screens/Settings/UserDetailsEditScreen/View/UserDetailsEditScreen.swift
+++ b/ElementX/Sources/Screens/Settings/UserDetailsEditScreen/View/UserDetailsEditScreen.swift
@@ -23,11 +23,21 @@ struct UserDetailsEditScreen: View {
         
     var body: some View {
         Form {
-            avatar
+            Section {
+                avatar
+            } footer: {
+                Text(context.viewState.userID)
+                    .frame(maxWidth: .infinity)
+                    .font(.compound.bodyLG)
+                    .foregroundColor(.compound.textPrimary)
+                    .padding(.bottom, 16)
+            }
+            
             nameSection
         }
         .compoundList()
         .scrollDismissesKeyboard(.immediately)
+        .navigationTitle(L10n.screenEditProfileTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { toolbar }
     }
@@ -53,7 +63,7 @@ struct UserDetailsEditScreen: View {
                                    url: context.viewState.selectedAvatarURL,
                                    name: context.viewState.currentDisplayName,
                                    contentID: context.viewState.userID,
-                                   avatarSize: .user(on: .memberDetails),
+                                   avatarSize: .user(on: .editUserDetails),
                                    imageProvider: context.imageProvider)
                 .overlay(alignment: .bottomTrailing) {
                     avatarOverlayIcon


### PR DESCRIPTION
Followup from https://github.com/vector-im/element-x-ios/pull/1718

@callumu  said:
 > This all works as expected. A few visual comments:
> 
> * Can the 'Edit profile' page header be added?
> * The matrix ID is under the image on the edit profile screen in the designs. In your opinion, do you feel like this is necessary to show?
> * Can the sizes of avatar be updated in both the Settings page (52x52) and the Edit profile page (96x96)?

So we did:

<img width="545" alt="Screenshot 2023-09-15 at 16 39 24" src="https://github.com/vector-im/element-x-ios/assets/637564/33a9bd4c-d401-4724-b1a6-db2fb03df443">

<img width="545" alt="Screenshot 2023-09-15 at 16 39 23" src="https://github.com/vector-im/element-x-ios/assets/637564/8b0394da-4787-48e8-813a-8e9c26b05d78">

