### PR TITLE
Use TextKit 2 for MessageText

### DIFF
--- a/ElementX/Sources/Other/Pills/MessageText.swift
+++ b/ElementX/Sources/Other/Pills/MessageText.swift
@@ -46,7 +46,7 @@ struct MessageText: UIViewRepresentable {
         textView.contentInsetAdjustmentBehavior = .never
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
-        textView.layoutManager.usesFontLeading = false
+        textView.textLayoutManager?.usesFontLeading = false
         textView.backgroundColor = .clear
         textView.attributedText = NSAttributedString(attributedString)
         textView.delegate = context.coordinator


### PR DESCRIPTION
Since we were accessing the old NSLayoutManager instead of the new NSTextLayoutManager, we were forcing the TextView to be refreshed as a TextKit 1 version instead of the TextKit 2 version (which is more performant)

This removes the warning and should increase the performance slightly