### PR TITLE
Change timeline animations to use .top (flipped).

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/TimelineTableViewController.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/TimelineTableViewController.swift
@@ -178,8 +178,10 @@ class TimelineTableViewController: UIViewController {
             cell.contentView.transform = CGAffineTransform(scaleX: 1, y: -1)
             return cell
         }
-
-        dataSource?.defaultRowAnimation = .fade
+        
+        // We only animate when there's a new last message, so its safe
+        // to animate from the bottom (which is the top as we're flipped).
+        dataSource?.defaultRowAnimation = .top
         tableView.delegate = self
     }
     


### PR DESCRIPTION
This PR changes the timeline animations (which are only applied when the last message ID changes).


**Before**

https://github.com/vector-im/element-x-ios/assets/6060466/1084f8f6-ef69-44b7-bdb9-9101049c4ec3


**After**

https://github.com/vector-im/element-x-ios/assets/6060466/00571e04-8e7a-4209-a1cf-c9531cd1ac95



