### PR TITLE
Disable reply actions for local echoes

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -517,8 +517,8 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         
         var actions: [TimelineItemMenuAction] = []
 
-        if let messageitem = item as? EventBasedMessageTimelineItemProtocol {
-            actions.append(.reply(isThread: messageitem.isThreaded))
+        if let messageItem = item as? EventBasedMessageTimelineItemProtocol, messageItem.isRemoteMessage {
+            actions.append(.reply(isThread: messageItem.isThreaded))
             actions.append(.forward(itemID: itemID))
         }
 

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
@@ -33,6 +33,10 @@ extension EventBasedTimelineItemProtocol {
     var description: String {
         "\(String(describing: Self.self)): id: \(id), timestamp: \(timestamp), isOutgoing: \(isOutgoing), properties: \(properties)"
     }
+    
+    var isRemoteMessage: Bool {
+        id.eventID != nil
+    }
 
     var hasFailedToSend: Bool {
         properties.deliveryStatus == .sendingFailed


### PR DESCRIPTION
Sending replies to local echoes is not currently supported on the Rust side and RoomTimelineController just bails out if an in-reply-to message is missing its event id. This completely disables the action in these cases