### PR TITLE
Member optimisations

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -793,11 +793,11 @@ class RoomProxyMock: RoomProxyProtocol {
     var displayName: String?
     var topic: String?
     var avatarURL: URL?
-    var membersPublisher: AnyPublisher<[RoomMemberProxyProtocol], Never> {
-        get { return underlyingMembersPublisher }
-        set(value) { underlyingMembersPublisher = value }
+    var members: CurrentValuePublisher<[RoomMemberProxyProtocol], Never> {
+        get { return underlyingMembers }
+        set(value) { underlyingMembers = value }
     }
-    var underlyingMembersPublisher: AnyPublisher<[RoomMemberProxyProtocol], Never>!
+    var underlyingMembers: CurrentValuePublisher<[RoomMemberProxyProtocol], Never>!
     var invitedMembersCount: Int {
         get { return underlyingInvitedMembersCount }
         set(value) { underlyingInvitedMembersCount = value }

--- a/ElementX/Sources/Mocks/RoomProxyMock.swift
+++ b/ElementX/Sources/Mocks/RoomProxyMock.swift
@@ -64,10 +64,10 @@ extension RoomProxyMock {
         activeMembersCount = configuration.activeMembersCount
         ownUserID = configuration.ownUserID
 
-        if let members = configuration.members {
-            membersPublisher = Just(members).eraseToAnyPublisher()
+        if let configuredMembers = configuration.members {
+            members = CurrentValueSubject(configuredMembers).asCurrentValuePublisher()
         } else {
-            membersPublisher = Just([]).eraseToAnyPublisher()
+            members = CurrentValueSubject([]).asCurrentValuePublisher()
         }
         
         if let inviter = configuration.inviter {

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
@@ -119,9 +119,10 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
             hideLoader()
         }
         
-        roomProxy.membersPublisher
+        roomProxy.members
             .filter { !$0.isEmpty }
             .first()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] members in
                 self?.buildMembershipStateIfNeeded(members: members)
             }

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -145,7 +145,8 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
             return
         }
         
-        roomProxy.membersPublisher
+        roomProxy.members
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] members in
                 guard let self else { return }
                 let dmRecipient = members.first(where: { !$0.isAccountOwner })

--- a/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenViewModel.swift
@@ -67,8 +67,9 @@ class RoomMembersListScreenViewModel: RoomMembersListScreenViewModelType, RoomMe
             hideLoader()
         }
         
-        roomProxy.membersPublisher
+        roomProxy.members
             .filter { !$0.isEmpty }
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] members in
                 self?.updateState(members: members)
             }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -210,12 +210,13 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             .weakAssign(to: \.state.readReceiptsEnabled, on: self)
             .store(in: &cancellables)
 
-        roomProxy.membersPublisher
+        roomProxy.members
             .map { members in
                 members.reduce(into: [String: RoomMemberState]()) { dictionary, member in
                     dictionary[member.userID] = RoomMemberState(displayName: member.displayName, avatarURL: member.avatarURL)
                 }
             }
+            .receive(on: DispatchQueue.main)
             .weakAssign(to: \.state.members, on: self)
             .store(in: &cancellables)
     }

--- a/ElementX/Sources/Services/Room/RoomMember/RoomMemberProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomMember/RoomMemberProxy.swift
@@ -31,45 +31,25 @@ final class RoomMemberProxy: RoomMemberProxyProtocol {
         self.member = member
     }
 
-    var userID: String {
-        member.userId()
-    }
+    lazy var userID = member.userId()
 
-    var displayName: String? {
-        member.displayName()
-    }
+    lazy var displayName = member.displayName()
 
-    var avatarURL: URL? {
-        member.avatarUrl().flatMap(URL.init(string:))
-    }
+    lazy var avatarURL = member.avatarUrl().flatMap(URL.init(string:))
 
-    var membership: MembershipState {
-        member.membership()
-    }
+    lazy var membership = member.membership()
 
-    var isNameAmbiguous: Bool {
-        member.isNameAmbiguous()
-    }
+    lazy var isNameAmbiguous = member.isNameAmbiguous()
 
-    var powerLevel: Int {
-        Int(member.powerLevel())
-    }
+    lazy var powerLevel = Int(member.powerLevel())
 
-    var normalizedPowerLevel: Int {
-        Int(member.normalizedPowerLevel())
-    }
+    lazy var normalizedPowerLevel = Int(member.normalizedPowerLevel())
 
-    var isAccountOwner: Bool {
-        member.isAccountUser()
-    }
+    lazy var isAccountOwner = member.isAccountUser()
 
-    var isIgnored: Bool {
-        member.isIgnored()
-    }
+    lazy var isIgnored = member.isIgnored()
     
-    var canInviteUsers: Bool {
-        member.canInvite()
-    }
+    lazy var canInviteUsers = member.canInvite()
     
     func canSendStateEvent(type: StateEventType) -> Bool {
         member.canSendState(stateEvent: type)

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -40,10 +40,8 @@ class RoomProxy: RoomProxyProtocol {
 
     private let backPaginationStateSubject = PassthroughSubject<BackPaginationStatus, Never>()
     private let membersSubject = CurrentValueSubject<[RoomMemberProxyProtocol], Never>([])
-    var membersPublisher: AnyPublisher<[RoomMemberProxyProtocol], Never> {
-        membersSubject
-            .receive(on: DispatchQueue.main)
-            .eraseToAnyPublisher()
+    var members: CurrentValuePublisher<[RoomMemberProxyProtocol], Never> {
+        membersSubject.asCurrentValuePublisher()
     }
     
     private var timelineListener: RoomTimelineListener?

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -67,7 +67,7 @@ protocol RoomProxyProtocol {
     
     var avatarURL: URL? { get }
 
-    var membersPublisher: AnyPublisher<[RoomMemberProxyProtocol], Never> { get }
+    var members: CurrentValuePublisher<[RoomMemberProxyProtocol], Never> { get }
     
     var invitedMembersCount: Int { get }
     
@@ -206,6 +206,6 @@ extension RoomProxyProtocol {
 
     func members() async -> [RoomMemberProxyProtocol]? {
         await updateMembers()
-        return await membersPublisher.values.first()
+        return members.value
     }
 }


### PR DESCRIPTION
* Prevent mapping members on the main queue inside the room screen view model
* Avoid too much back and forth through FFI by lazily fetching and storing member proxy properties