### PR TITLE
Add polls' room summaries

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -5738,7 +5738,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.1.17;
+				version = 1.1.18;
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -129,8 +129,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "5f7b353fc306e21237f71b9e242f7fc086ad00c8",
-        "version" : "1.1.17"
+        "revision" : "f00c834ec4f80c9eea43282b79b368c93ad6bd82",
+        "version" : "1.1.18"
       }
     },
     {

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "a11y_show_password" = "Show password";
 "a11y_user_menu" = "User menu";
 "action_accept" = "Accept";
+"action_add_to_timeline" = "Add to timeline";
 "action_back" = "Back";
 "action_cancel" = "Cancel";
 "action_choose_photo" = "Choose photo";
@@ -144,6 +145,7 @@
 "common_verification_complete" = "Verification complete";
 "common_video" = "Video";
 "common_waiting" = "Waiting…";
+"common_poll_summary" = "Poll: %1$@";
 "crash_detection_dialog_content" = "%1$@ crashed the last time it was used. Would you like to share a crash report with us?";
 "dialog_title_confirmation" = "Confirmation";
 "dialog_title_warning" = "Warning";
@@ -331,7 +333,7 @@
 "screen_report_content_block_user_hint" = "Check if you want to hide all current and future messages from this user";
 "screen_room_attachment_source_camera" = "Camera";
 "screen_room_attachment_source_camera_photo" = "Take photo";
-"screen_room_attachment_source_camera_video" = "Record a video";
+"screen_room_attachment_source_camera_video" = "Record video";
 "screen_room_attachment_source_files" = "Attachment";
 "screen_room_attachment_source_gallery" = "Photo & Video Library";
 "screen_room_attachment_source_location" = "Location";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -28,6 +28,8 @@ public enum L10n {
   public static var a11yUserMenu: String { return L10n.tr("Localizable", "a11y_user_menu") }
   /// Accept
   public static var actionAccept: String { return L10n.tr("Localizable", "action_accept") }
+  /// Add to timeline
+  public static var actionAddToTimeline: String { return L10n.tr("Localizable", "action_add_to_timeline") }
   /// Back
   public static var actionBack: String { return L10n.tr("Localizable", "action_back") }
   /// Cancel
@@ -230,6 +232,10 @@ public enum L10n {
   public static var commonPeople: String { return L10n.tr("Localizable", "common_people") }
   /// Permalink
   public static var commonPermalink: String { return L10n.tr("Localizable", "common_permalink") }
+  /// Poll: %1$@
+  public static func commonPollSummary(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "common_poll_summary", String(describing: p1))
+  }
   /// Total votes: %1$@
   public static func commonPollTotalVotes(_ p1: Any) -> String {
     return L10n.tr("Localizable", "common_poll_total_votes", String(describing: p1))
@@ -830,7 +836,7 @@ public enum L10n {
   public static var screenRoomAttachmentSourceCamera: String { return L10n.tr("Localizable", "screen_room_attachment_source_camera") }
   /// Take photo
   public static var screenRoomAttachmentSourceCameraPhoto: String { return L10n.tr("Localizable", "screen_room_attachment_source_camera_photo") }
-  /// Record a video
+  /// Record video
   public static var screenRoomAttachmentSourceCameraVideo: String { return L10n.tr("Localizable", "screen_room_attachment_source_camera_video") }
   /// Attachment
   public static var screenRoomAttachmentSourceFiles: String { return L10n.tr("Localizable", "screen_room_attachment_source_files") }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -1370,11 +1370,11 @@ class RoomProxyMock: RoomProxyProtocol {
         return setNameCallsCount > 0
     }
     var setNameReceivedName: String?
-    var setNameReceivedInvocations: [String?] = []
+    var setNameReceivedInvocations: [String] = []
     var setNameReturnValue: Result<Void, RoomProxyError>!
-    var setNameClosure: ((String?) async -> Result<Void, RoomProxyError>)?
+    var setNameClosure: ((String) async -> Result<Void, RoomProxyError>)?
 
-    func setName(_ name: String?) async -> Result<Void, RoomProxyError> {
+    func setName(_ name: String) async -> Result<Void, RoomProxyError> {
         setNameCallsCount += 1
         setNameReceivedName = name
         setNameReceivedInvocations.append(name)

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -633,7 +633,7 @@ class RoomProxy: RoomProxyProtocol {
         }
     }
     
-    func setName(_ name: String?) async -> Result<Void, RoomProxyError> {
+    func setName(_ name: String) async -> Result<Void, RoomProxyError> {
         await Task.dispatch(on: .global()) {
             do {
                 return try .success(self.room.setName(name: name))

--- a/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
+++ b/ElementX/Sources/Services/Room/RoomProxyProtocol.swift
@@ -159,7 +159,7 @@ protocol RoomProxyProtocol {
     
     func invite(userID: String) async -> Result<Void, RoomProxyError>
     
-    func setName(_ name: String?) async -> Result<Void, RoomProxyError>
+    func setName(_ name: String) async -> Result<Void, RoomProxyError>
     
     func setTopic(_ topic: String) async -> Result<Void, RoomProxyError>
     

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
@@ -69,7 +69,7 @@ struct RoomEventStringBuilder {
                                           memberIsYou: isOutgoing)
                 .map(AttributedString.init)
         case .poll(let question, _, _, _, _, _):
-            return prefix(question, with: senderDisplayName)
+            return prefix(L10n.commonPollSummary(question), with: senderDisplayName)
         }
     }
     

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomEventStringBuilder.swift
@@ -68,9 +68,8 @@ struct RoomEventStringBuilder {
                                           member: sender.id,
                                           memberIsYou: isOutgoing)
                 .map(AttributedString.init)
-        case .poll:
-            // The Rust SDK doesn't support poll events as room summaries yet
-            return nil
+        case .poll(let question, _, _, _, _, _):
+            return prefix(question, with: senderDisplayName)
         }
     }
     

--- a/project.yml
+++ b/project.yml
@@ -45,7 +45,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.1.17
+    exactVersion: 1.1.18
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
This PR:
- Updates the matrix sdk to the version `1.1.18`
- Adds the support for polls' room summaries

**Result**

![Simulator Screenshot - iPhone 15 - 2023-09-20 at 17 20 59](https://github.com/vector-im/element-x-ios/assets/19324622/a02b4425-d60e-4bbb-8838-94e3f0a5fa6d)