### PR TITLE
Disable animation for unit tests

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Animation/ShimmerModifier.swift
+++ b/ElementX/Sources/Other/SwiftUI/Animation/ShimmerModifier.swift
@@ -41,7 +41,10 @@ struct ShimmerModifier: ViewModifier {
     private let regularColor = Color.white
     
     /// A slow linear animation which auto-repeats after a delay.
-    private let animation: Animation = Tests.isRunningUITests ? .noAnimation : .linear(duration: 1.75).delay(0.5).repeatForever(autoreverses: false)
+    private let animation: Animation = .linear(duration: 1.75)
+        .delay(0.5)
+        .repeatForever(autoreverses: false)
+        .disabledDuringTests()
     
     func body(content: Content) -> some View {
         content

--- a/ElementX/Sources/Other/Tests.swift
+++ b/ElementX/Sources/Other/Tests.swift
@@ -34,6 +34,11 @@ public enum Tests {
         false
         #endif
     }
+
+    /// Flag indicating whether the app is running the UI tests or unit tests.
+    static var isRunningTests: Bool {
+        isRunningUITests || isRunningUnitTests
+    }
     
     /// The identifier of the screen to be loaded when running UI tests.
     static var screenID: UITestsScreenIdentifier? {

--- a/ElementX/Sources/Screens/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/ComposerToolbar.swift
@@ -102,7 +102,7 @@ struct ComposerToolbar: View {
                 .padding(4)
         }
         .disabled(context.viewState.sendButtonDisabled)
-        .animation(.linear(duration: 0.1), value: context.viewState.sendButtonDisabled)
+        .animation(.linear(duration: 0.1).disabledDuringTests(), value: context.viewState.sendButtonDisabled)
         .keyboardShortcut(.return, modifiers: [.command])
     }
     

--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreenRoomCell.swift
@@ -167,7 +167,7 @@ struct HomeScreenRoomCellButtonStyle: ButtonStyle {
         configuration.label
             .background(isSelected ? Color.compound.bgSubtleSecondary : Color.compound.bgCanvasDefault)
             .contentShape(Rectangle())
-            .animation(isSelected ? .none : .easeOut(duration: 0.1), value: isSelected)
+            .animation(isSelected ? .none : .easeOut(duration: 0.1).disabledDuringTests(), value: isSelected)
     }
 }
 

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -106,7 +106,7 @@ struct InviteUsersScreen: View {
                 }
                 .onChange(of: context.viewState.scrollToLastID) { lastAddedID in
                     guard let id = lastAddedID else { return }
-                    withAnimation(.easeInOut) {
+                    withElementAnimation(.easeInOut) {
                         scrollView.scrollTo(id)
                     }
                 }

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/LongPressWithFeedback.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/LongPressWithFeedback.swift
@@ -31,7 +31,7 @@ struct LongPressWithFeedback: ViewModifier {
             .shadow(color: .black.opacity(isLongPressing ? 0.1 : 0.0), radius: isLongPressing ? 3 : 0)
             .scaleEffect(x: isLongPressing ? 1.05 : 1,
                          y: isLongPressing ? 1.05 : 1)
-            .animation(isLongPressing ? .spring(response: 0.5).delay(0.1) : .spring(response: 0.5),
+            .animation(.spring(response: 0.5).delay(isLongPressing ? 0.1 : 0).disabledDuringTests(),
                        value: isLongPressing)
             // The minimum duration here doesn't actually invoke the perform block when elapsed (thus
             // the implementation below) but it does cancel other system gestures e.g. swipe to reply

--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReactionsView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReactionsView.swift
@@ -61,7 +61,7 @@ struct TimelineReactionsView: View {
             .reactionLayoutItem(.addMore)
         }
         .environment(\.layoutDirection, reactionsLayoutDirection)
-        .animation(.easeInOut(duration: 0.1), value: reactions)
+        .animation(.easeInOut(duration: 0.1).disabledDuringTests(), value: reactions)
         .padding(.leading, 4)
     }
 }


### PR DESCRIPTION
This PR refactors `Animation` extension to take in account unit tests as well.