### PR TITLE
Improved rendering of voice messages

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/SwipeRightAction.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/SwipeRightAction.swift
@@ -24,7 +24,6 @@ struct SwipeRightAction<Label: View>: ViewModifier {
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .heavy)
     
     @State private var canStartAction = false
-    @State private var animate = false
     @GestureState private var dragGestureActive = false
     
     @State private var hasReachedActionThreshold = false
@@ -40,7 +39,7 @@ struct SwipeRightAction<Label: View>: ViewModifier {
     func body(content: Content) -> some View {
         content
             .offset(x: xOffset, y: 0.0)
-            .animation(.interactiveSpring().speed(0.5), value: animate)
+            .animation(.interactiveSpring().speed(0.5), value: xOffset)
             .gesture(DragGesture()
                 .updating($dragGestureActive) { _, state, _ in
                     // Available actions should be computed on the fly so we use a gesture state change
@@ -69,7 +68,6 @@ struct SwipeRightAction<Label: View>: ViewModifier {
                     } else {
                         hasReachedActionThreshold = false
                     }
-                    animate = true
                 }
                 .onEnded { _ in
                     if xOffset > actionThreshold {
@@ -77,7 +75,6 @@ struct SwipeRightAction<Label: View>: ViewModifier {
                     }
                     
                     xOffset = 0.0
-                    animate = false
                 }
             )
             .onChange(of: dragGestureActive, perform: { value in

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceRoomPlaybackView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceRoomPlaybackView.swift
@@ -33,11 +33,11 @@ struct VoiceRoomPlaybackView: View {
     
     var onPlayPause: () -> Void = { }
     var onSeek: (Double) -> Void = { _ in }
-    var onWaveformDragStateChanged: (Bool) -> Void = { _ in }
+    var onScrubbing: (Bool) -> Void = { _ in }
     
     private enum DragState: Equatable {
         case inactive
-        case pressing
+        case pressing(progress: Double)
         case dragging(progress: Double)
         
         var progress: Double {
@@ -69,11 +69,16 @@ struct VoiceRoomPlaybackView: View {
     }
     
     @GestureState private var dragState = DragState.inactive
+    @State private var tapProgress: Double = .zero
     
     var timeLabelContent: String {
         // Display the duration if progress is 0.0
         let percent = playbackViewState.progress > 0.0 ? playbackViewState.progress : 1.0
         return Self.elapsedTimeFormatter.string(from: Date(timeIntervalSinceReferenceDate: playbackViewState.duration * percent))
+    }
+    
+    var showWaveformCursor: Bool {
+        playbackViewState.playing || dragState.isDragging
     }
     
     var body: some View {
@@ -87,18 +92,25 @@ struct VoiceRoomPlaybackView: View {
             }
             .padding(.vertical, 6)
             GeometryReader { geometry in
-                WaveformView(waveform: playbackViewState.waveform, progress: playbackViewState.progress)
+                WaveformView(waveform: playbackViewState.waveform, progress: playbackViewState.progress, showCursor: showWaveformCursor)
                     // Add a gesture to drag the waveform
-                    .gesture(LongPressGesture()
+                    .gesture(SpatialTapGesture()
+                        .simultaneously(with: LongPressGesture())
                         .sequenced(before: DragGesture(coordinateSpace: .local))
                         .updating($dragState) { value, state, _ in
                             switch value {
-                            // Long press begins.
-                            case .first(true):
-                                state = .pressing
+                            // (SpatialTap, LongPress) begins.
+                            case .first(let spatialLongPress) where spatialLongPress.second == true:
+                                // Compute the progress with the spatialTap location
+                                let progress = (spatialLongPress.first?.location ?? .zero).x / geometry.size.width
+                                state = .pressing(progress: progress)
                             // Long press confirmed, dragging may begin.
-                            case .second(true, let drag):
-                                let progress: Double = (drag?.location.x ?? .zero) / geometry.size.width
+                            case .second(let spatialLongPress, let drag) where spatialLongPress.second == true:
+                                var progress: Double = tapProgress
+                                // Compute the progress with drag location
+                                if let loc = drag?.location {
+                                    progress = loc.x / geometry.size.width
+                                }
                                 state = .dragging(progress: progress)
                             // Dragging ended or the long press cancelled.
                             default:
@@ -111,9 +123,10 @@ struct VoiceRoomPlaybackView: View {
         .onChange(of: dragState) { newDragState in
             switch newDragState {
             case .inactive:
-                onWaveformDragStateChanged(false)
-            case .pressing:
-                onWaveformDragStateChanged(true)
+                onScrubbing(false)
+            case .pressing(let progress):
+                tapProgress = progress
+                onScrubbing(true)
                 feedbackGenerator.prepare()
                 sendFeedback = true
             case .dragging(let progress):

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceRoomTimelineView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceRoomTimelineView.swift
@@ -35,7 +35,7 @@ struct VoiceRoomTimelineView: View {
             VoiceRoomPlaybackView(playbackViewState: playbackViewState,
                                   onPlayPause: onPlaybackPlayPause,
                                   onSeek: onPlaybackSeek(_:),
-                                  onWaveformDragStateChanged: onPlaybackDragStateChanged(_:))
+                                  onScrubbing: onPlaybackScrubbing(_:))
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
@@ -48,7 +48,7 @@ struct VoiceRoomTimelineView: View {
         context.send(viewAction: .seekAudio(itemID: timelineItem.id, progress: progress))
     }
     
-    private func onPlaybackDragStateChanged(_ dragging: Bool) {
+    private func onPlaybackScrubbing(_ dragging: Bool) {
         if dragging {
             context.send(viewAction: .disableLongPress(itemID: timelineItem.id))
         } else {

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -461,7 +461,7 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
         }
 
         return AudioRoomTimelineItemContent(body: messageContent.body,
-                                            duration: messageContent.info?.duration ?? 0,
+                                            duration: (messageContent.audio?.duration ?? 0) / 1000.0,
                                             waveform: waveform,
                                             source: MediaSourceProxy(source: messageContent.source, mimeType: messageContent.info?.mimetype),
                                             contentType: UTType(mimeType: messageContent.info?.mimetype, fallbackFilename: messageContent.body))


### PR DESCRIPTION
This PR improves rendering of voice messages in the timeline:
- Fix an issue where the duration of voice messages sent by El-iOS was 0
- Reverse the fix made on `SwipeRightAction` as the bug is longer visible and the swipe right animation is smoother without this fix.
- Add a cursor during scrubbing and playback.
- On the waveform, when the drag starts, the progress is initialised with the location of the touch (using a SpatialTapGesture)