### PR TITLE
Element call tweaks

### DIFF
--- a/ElementX/Sources/Application/Navigation/AppRoutes.swift
+++ b/ElementX/Sources/Application/Navigation/AppRoutes.swift
@@ -91,7 +91,9 @@ struct ElementCallURLParser: URLParser {
             }
             
             guard let encodedURLString = components.queryItems?.first(where: { $0.name == customSchemeURLQueryParameterName })?.value,
-                  let callURL = URL(string: encodedURLString) else {
+                  let callURL = URL(string: encodedURLString),
+                  callURL.scheme == "https" // Don't allow URLs from potentially unsafe domains
+            else {
                 MXLog.error("Invalid custom scheme call parameters: \(url)")
                 return nil
             }

--- a/UnitTests/Sources/AppRouteURLParserTests.swift
+++ b/UnitTests/Sources/AppRouteURLParserTests.swift
@@ -34,4 +34,42 @@ class AppRouteURLParserTests: XCTestCase {
         
         XCTAssertEqual(AppRouteURLParser(appSettings: ServiceLocator.shared.settings).route(from: customSchemeURL), AppRoute.genericCallLink(url: url))
     }
+    
+    func testCustomDomainUniversalLinkCallRoutes() {
+        guard let url = URL(string: "https://somecustomdomain.element.io/test") else {
+            XCTFail("URL invalid")
+            return
+        }
+        
+        XCTAssertEqual(AppRouteURLParser(appSettings: ServiceLocator.shared.settings).route(from: url), nil)
+    }
+    
+    func testCustomSchemeLinkCallRoutes() {
+        let urlString = "https://somecustomdomain.element.io/test?param=123"
+        guard let url = URL(string: urlString) else {
+            XCTFail("URL invalid")
+            return
+        }
+        
+        guard let encodedURLString = urlString.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) else {
+            XCTFail("Could not encode URL string")
+            return
+        }
+        
+        guard let customSchemeURL = URL(string: "io.element.call:/?url=\(encodedURLString)") else {
+            XCTFail("URL invalid")
+            return
+        }
+        
+        XCTAssertEqual(AppRouteURLParser(appSettings: ServiceLocator.shared.settings).route(from: customSchemeURL), AppRoute.genericCallLink(url: url))
+    }
+    
+    func testHttpCustomSchemeLinkCallRoutes() {
+        guard let customSchemeURL = URL(string: "io.element.call:/?url=http%3A%2F%2Fcall.element.io%2Ftest") else {
+            XCTFail("URL invalid")
+            return
+        }
+        
+        XCTAssertEqual(AppRouteURLParser(appSettings: ServiceLocator.shared.settings).route(from: customSchemeURL), nil)
+    }
 }


### PR DESCRIPTION
* Only allow `https` call links to be passed through the custom app scheme
* Pass in custom call URL query parameters
* Add more tests for the AppRouteURLParser