### PR TITLE
Fix replying in UI tests.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/SwipeRightAction.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/SwipeRightAction.swift
@@ -75,16 +75,15 @@ struct SwipeRightAction<Label: View>: ViewModifier {
                     }
                     
                     xOffset = 0.0
-                }
-            )
-            .onChange(of: dragGestureActive, perform: { value in
+                })
+            .onChange(of: dragGestureActive) { value in
                 if value == true {
                     if shouldStartAction() {
                         feedbackGenerator.prepare()
                         canStartAction = true
                     }
                 }
-            })
+            }
             .overlay(alignment: .leading) {
                 // We want the action icon to follow the view translation and gradually fade in
                 label()

--- a/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItemProxy.swift
@@ -34,7 +34,7 @@ struct TimelineItemIdentifier: Hashable {
 extension TimelineItemIdentifier {
     /// Use only for mocks/tests
     static var random: Self {
-        .init(timelineID: UUID().uuidString)
+        .init(timelineID: UUID().uuidString, eventID: UUID().uuidString)
     }
 }
 


### PR DESCRIPTION
The mocks were missing an `eventID` so all considered to be local echoes. This PR fixes that.

UI tests run is here: https://github.com/vector-im/element-x-ios/actions/runs/6297508527