### PR TITLE
Add "end poll" confirmation dialog 

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -70,6 +70,7 @@
 "action_take_photo" = "Take photo";
 "action_view_source" = "View Source";
 "action_yes" = "Yes";
+"action.edit_poll" = "Edit poll";
 "common_about" = "About";
 "common_acceptable_use_policy" = "Acceptable use policy";
 "common_advanced_settings" = "Advanced settings";
@@ -147,6 +148,7 @@
 "common_verification_complete" = "Verification complete";
 "common_video" = "Video";
 "common_waiting" = "Waiting…";
+"common_poll_end_confirmation" = "Are you sure you want to end this poll?";
 "common_poll_summary" = "Poll: %1$@";
 "crash_detection_dialog_content" = "%1$@ crashed the last time it was used. Would you like to share a crash report with us?";
 "dialog_permission_camera" = "In order to let the application use the camera, please grant the permission in the system settings.";

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -236,6 +236,8 @@ public enum L10n {
   public static var commonPermalink: String { return L10n.tr("Localizable", "common_permalink") }
   /// Permission
   public static var commonPermission: String { return L10n.tr("Localizable", "common_permission") }
+  /// Are you sure you want to end this poll?
+  public static var commonPollEndConfirmation: String { return L10n.tr("Localizable", "common_poll_end_confirmation") }
   /// Poll: %1$@
   public static func commonPollSummary(_ p1: Any) -> String {
     return L10n.tr("Localizable", "common_poll_summary", String(describing: p1))
@@ -1300,6 +1302,11 @@ public enum L10n {
   public static var testLanguageIdentifier: String { return L10n.tr("Localizable", "test_language_identifier") }
   /// en
   public static var testUntranslatedDefaultLanguageIdentifier: String { return L10n.tr("Localizable", "test_untranslated_default_language_identifier") }
+
+  public enum Action {
+    /// Edit poll
+    public static var editPoll: String { return L10n.tr("Localizable", "action.edit_poll") }
+  }
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces

--- a/ElementX/Sources/Screens/CreatePollScreen/CreatePollScreenViewModel.swift
+++ b/ElementX/Sources/Screens/CreatePollScreen/CreatePollScreenViewModel.swift
@@ -43,7 +43,7 @@ class CreatePollScreenViewModel: CreatePollScreenViewModelType, CreatePollScreen
                 state.bindings.alertInfo = .init(id: .init(),
                                                  title: L10n.screenCreatePollDiscardConfirmationTitle,
                                                  message: L10n.screenCreatePollDiscardConfirmation,
-                                                 primaryButton: .init(title: L10n.actionCancel, action: nil),
+                                                 primaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil),
                                                  secondaryButton: .init(title: L10n.actionOk, action: { self.actionsSubject.send(.cancel) }))
             } else {
                 actionsSubject.send(.cancel)

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -125,6 +125,9 @@ struct RoomScreenViewStateBindings {
     /// Information describing the currently displayed alert.
     var alertInfo: AlertInfo<RoomScreenErrorType>?
 
+    /// An alert info for confirmation actions (e.g. ending a poll)
+    var confirmationAlertInfo: AlertInfo<UUID>?
+
     var debugInfo: TimelineItemDebugInfo?
     
     var actionMenuInfo: TimelineItemActionMenuInfo?

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -155,7 +155,11 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         case .disableLongPress(let itemID):
             state.longPressDisabledItemID = itemID
         case let .endPoll(pollStartID):
-            endPoll(pollStartID: pollStartID)
+            state.bindings.confirmationAlertInfo = .init(id: .init(),
+                                                         title: L10n.actionEndPoll,
+                                                         message: L10n.commonPollEndConfirmation,
+                                                         primaryButton: .init(title: L10n.actionCancel, role: .cancel, action: nil),
+                                                         secondaryButton: .init(title: L10n.actionOk, action: { self.endPoll(pollStartID: pollStartID) }))
         }
     }
 

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -54,6 +54,7 @@ struct RoomScreen: View {
             .toolbarBackground(.visible, for: .navigationBar) // Fix the toolbar's background.
             .overlay { loadingIndicator }
             .alert(item: $context.alertInfo)
+            .alert(item: $context.confirmationAlertInfo)
             .sheet(item: $context.debugInfo) { TimelineItemDebugView(info: $0) }
             .sheet(item: $context.actionMenuInfo) { info in
                 context.viewState.timelineItemMenuActionProvider?(info.item.id).map { actions in


### PR DESCRIPTION
This PR adds a confirmation dialog when ending a poll directly using the "creator view" in the timeline.

| **Result** |
| --- |
| ![Simulator Screenshot - iPhone 14 - 2023-09-26 at 11 05 14](https://github.com/vector-im/element-x-ios/assets/19324622/e0881754-234f-4c96-8c33-5cf9d38d4261)|
