### PR TITLE
Application: pass AppDelegate in initializer, instead of using singleton

### DIFF
--- a/ElementX/Sources/Application/AppDelegate.swift
+++ b/ElementX/Sources/Application/AppDelegate.swift
@@ -24,12 +24,9 @@ enum AppDelegateCallback {
 }
 
 class AppDelegate: NSObject, UIApplicationDelegate {
-    private(set) static var shared: AppDelegate!
     let callbacks = PassthroughSubject<AppDelegateCallback, Never>()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-        // worst singleton ever
-        Self.shared = self
         NSTextAttachment.registerViewProviderClass(PillAttachmentViewProvider.self, forFileType: InfoPlistReader.main.pillsUTType)
         return true
     }

--- a/ElementX/Sources/Application/Application.swift
+++ b/ElementX/Sources/Application/Application.swift
@@ -20,7 +20,7 @@ import SwiftUI
 struct Application: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var applicationDelegate
     @Environment(\.openURL) private var openURL
-    private let appCoordinator: AppCoordinatorProtocol
+    private var appCoordinator: AppCoordinatorProtocol!
 
     init() {
         if ProcessInfo.isRunningUITests {
@@ -28,7 +28,7 @@ struct Application: App {
         } else if ProcessInfo.isRunningUnitTests {
             appCoordinator = UnitTestsAppCoordinator()
         } else {
-            appCoordinator = AppCoordinator()
+            appCoordinator = AppCoordinator(appDelegate: applicationDelegate)
         }
     }
 
@@ -57,7 +57,7 @@ struct Application: App {
                 }
         }
     }
-    
+
     private var shouldHideStatusBar: Bool {
         ProcessInfo.isRunningUITests
     }


### PR DESCRIPTION
switches to using an implicitly unwrapped optional, but the value is set within the initializer. this made more sense to me

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

**UI changes have been tested with:**
- [ ] iPhone and iPad simulators in portrait and landscape orientations.
- [ ] Dark mode enabled and disabled.
- [ ] Various sizes of dynamic type.
- [ ] Voiceover enabled.
