### PR TITLE
"Poll start" event push notification

### DIFF
--- a/NSE/Sources/NotificationContentBuilder.swift
+++ b/NSE/Sources/NotificationContentBuilder.swift
@@ -43,9 +43,7 @@ struct NotificationContentBuilder {
                 case .roomMessage(let messageType, _):
                     return try await processRoomMessage(notificationItem: notificationItem, messageType: messageType, mediaProvider: mediaProvider)
                 case .poll(let question):
-                    let notification = try await processCommonRoomMessage(notificationItem: notificationItem, mediaProvider: mediaProvider)
-                    notification.body = L10n.commonPollSummary(question)
-                    return notification
+                    return try await processPollStartEvent(notificationItem: notificationItem, pollQuestion: question, mediaProvider: mediaProvider)
                 default:
                     return processEmpty(notificationItem: notificationItem)
                 }
@@ -121,6 +119,12 @@ struct NotificationContentBuilder {
             break
         }
         
+        return notification
+    }
+
+    private func processPollStartEvent(notificationItem: NotificationItemProxyProtocol, pollQuestion: String, mediaProvider: MediaProviderProtocol?) async throws -> UNMutableNotificationContent {
+        let notification = try await processCommonRoomMessage(notificationItem: notificationItem, mediaProvider: mediaProvider)
+        notification.body = L10n.commonPollSummary(pollQuestion)
         return notification
     }
 


### PR DESCRIPTION
This PR handles push notifications for "poll start" events.
Other work will follow to handle the related push rules on EX.

|**Result**|
|:-|
|![Simulator Screenshot - iPhone 14 - 2023-09-28 at 10 28 14](https://github.com/vector-im/element-x-ios/assets/19324622/0afa40d0-66db-4f2b-8059-82330af54703)|
