### PR TITLE
implement emotes (/me)

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -5801,7 +5801,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.1.20;
+				version = 1.1.21;
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -129,8 +129,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "5f3a195f6a461b4d40a8a705a3af8235711f12f5",
-        "version" : "1.1.20"
+        "revision" : "22461632db17a6dc1193dcdcfa3231614649c517",
+        "version" : "1.1.21"
       }
     },
     {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -21,7 +21,6 @@ import SwiftUI
 
 typealias RoomScreenViewModelType = StateStoreViewModel<RoomScreenViewState, RoomScreenViewAction>
 
-// swiftlint:disable type_body_length
 class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol {
     private enum Constants {
         static let backPaginationEventLimit: UInt = 20
@@ -888,8 +887,6 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         timelineController.playbackViewState(for: itemID)
     }
 }
-
-// swiftlint:enable type_body_length
 
 private extension RoomProxyProtocol {
     /// Checks if the other person left the room in a direct chat

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -21,6 +21,7 @@ import SwiftUI
 
 typealias RoomScreenViewModelType = StateStoreViewModel<RoomScreenViewState, RoomScreenViewAction>
 
+// swiftlint:disable type_body_length
 class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol {
     private enum Constants {
         static let backPaginationEventLimit: UInt = 20
@@ -615,10 +616,16 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
                 } else {
                     text = messageTimelineItem.body
                 }
+            case .emote(let emoteItem):
+                if ServiceLocator.shared.settings.richTextEditorEnabled, let formattedBodyHTMLString = emoteItem.formattedBodyHTMLString {
+                    text = "/me " + formattedBodyHTMLString
+                } else {
+                    text = "/me " + messageTimelineItem.body
+                }
             default:
                 text = messageTimelineItem.body
             }
-
+            
             actionsSubject.send(.composer(action: .setText(text: text)))
             actionsSubject.send(.composer(action: .setMode(mode: .edit(originalItemId: messageTimelineItem.id))))
         case .copyPermalink:
@@ -881,6 +888,8 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         timelineController.playbackViewState(for: itemID)
     }
 }
+
+// swiftlint:enable type_body_length
 
 private extension RoomProxyProtocol {
     /// Checks if the other person left the room in a direct chat

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -274,7 +274,7 @@ class RoomProxy: RoomProxyProtocol {
         
         var body: String = message
         var htmlBody: String? = html
-        var emote: Bool = checkEmote(body: &body, htmlBody: &htmlBody)
+        let emote: Bool = checkEmote(body: &body, htmlBody: &htmlBody)
         
         let messageContent: RoomMessageEventContentWithoutRelation
         if let htmlBody {

--- a/ElementX/Sources/Services/Room/RoomProxy.swift
+++ b/ElementX/Sources/Services/Room/RoomProxy.swift
@@ -268,9 +268,17 @@ class RoomProxy: RoomProxyProtocol {
         
         let messageContent: RoomMessageEventContentWithoutRelation
         if let htmlBody {
-            messageContent = messageEventContentFromHtml(body: body, htmlBody: htmlBody, emote: isEmote)
+            if isEmote {
+                messageContent = messageEventContentFromHtmlAsEmote(body: body, htmlBody: htmlBody)
+            } else {
+                messageContent = messageEventContentFromHtml(body: body, htmlBody: htmlBody)
+            }
         } else {
-            messageContent = messageEventContentFromMarkdown(md: body, emote: isEmote)
+            if isEmote {
+                messageContent = messageEventContentFromMarkdownAsEmote(md: body)
+            } else {
+                messageContent = messageEventContentFromMarkdown(md: body)
+            }
         }
         return await Task.dispatch(on: messageSendingDispatchQueue) {
             do {
@@ -457,11 +465,18 @@ class RoomProxy: RoomProxyProtocol {
 
         let newMessageContent: RoomMessageEventContentWithoutRelation
         if let htmlBody {
-            newMessageContent = messageEventContentFromHtml(body: body, htmlBody: htmlBody, emote: isEmote)
+            if isEmote {
+                newMessageContent = messageEventContentFromHtmlAsEmote(body: body, htmlBody: htmlBody)
+            } else {
+                newMessageContent = messageEventContentFromHtml(body: body, htmlBody: htmlBody)
+            }
         } else {
-            newMessageContent = messageEventContentFromMarkdown(md: body, emote: isEmote)
+            if isEmote {
+                newMessageContent = messageEventContentFromMarkdownAsEmote(md: body)
+            } else {
+                newMessageContent = messageEventContentFromMarkdown(md: body)
+            }
         }
-
         return await Task.dispatch(on: messageSendingDispatchQueue) {
             do {
                 let originalEvent = try self.room.getEventTimelineItemByEventId(eventId: eventID)

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/EmoteRoomTimelineItemContent.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/EmoteRoomTimelineItemContent.swift
@@ -19,4 +19,6 @@ import UIKit
 struct EmoteRoomTimelineItemContent: Hashable {
     let body: String
     var formattedBody: AttributedString?
+    /// The original textual representation of the formatted body directly from the event (usually HTML code)
+    var formattedBodyHTMLString: String?
 }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -558,7 +558,7 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
             formattedBody = attributedStringBuilder.fromPlain(L10n.commonEmote(name, messageContent.body))
         }
         
-        return .init(body: messageContent.body, formattedBody: formattedBody)
+        return .init(body: messageContent.body, formattedBody: formattedBody, formattedBodyHTMLString: htmlBody)
     }
     
     // MARK: - State Events

--- a/changelog.d/1841.feature
+++ b/changelog.d/1841.feature
@@ -1,0 +1,1 @@
+Implement /me

--- a/project.yml
+++ b/project.yml
@@ -46,7 +46,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.1.20
+    exactVersion: 1.1.21
     # path: ../matrix-rust-sdk
   DesignKit:
     path: DesignKit


### PR DESCRIPTION
requires https://github.com/matrix-org/matrix-rust-sdk/pull/2648

closes https://github.com/vector-im/element-x-ios/issues/1107

Arguably this could be handled by a slash-command engine in matrix-sdk-ui, but given it's not clear EX is going to even have slash commands (given whatsapp & imessage & signal etc don't), I'm adding it as a quick & dirty easter egg in the application layer. Given the logic is so simple, I'm not convinced it's worth the complexity of shoving it into the SDK at this point.

Handles:
 * [x] plaintext/markdown msg which begins `/me `
 * [x] richtext editor msg whose plaintext/markdown representation begins `/me `
 * [x] editing existing plaintext msgs
 * [x] editing existing richtext msgs
 * [x] replying with a /me (plaintext)
 * [x] replying with a /me (richtext)

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
