### PR TITLE
Fixes 1864 - Message forwarding room list filtering and pagination problems

### DIFF
--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -684,7 +684,7 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     }
     
     private func presentMessageForwarding(for itemID: TimelineItemIdentifier) {
-        guard let roomProxy, let roomSummaryProvider = userSession.clientProxy.roomSummaryProvider, let eventID = itemID.eventID else {
+        guard let roomProxy, let roomSummaryProvider = userSession.clientProxy.messageForwardingRoomSummaryProvider, let eventID = itemID.eventID else {
             fatalError()
         }
         

--- a/ElementX/Sources/Other/Extensions/Bundle.swift
+++ b/ElementX/Sources/Other/Extensions/Bundle.swift
@@ -47,7 +47,10 @@ public extension Bundle {
         }
         
         let bundle = Bundle(url: lprojURL)
-        cachedLocalizationBundles[language] = bundle
+        
+        DispatchQueue.main.async {
+            cachedLocalizationBundles[language] = bundle
+        }
         
         return bundle
     }

--- a/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
@@ -64,13 +64,11 @@ public extension DTHTMLElement {
         }
     }
     
-    private static var allowedHTMLTags = {
-        ["font", // custom to matrix for IRC-style font coloring
-         "del", // for markdown
-         "body", // added internally by DTCoreText
-         "mx-reply",
-         "h1", "h2", "h3", "h4", "h5", "h6", "blockquote", "p", "a", "ul", "ol",
-         "nl", "li", "b", "i", "u", "strong", "em", "strike", "code", "hr", "br", "div",
-         "table", "thead", "caption", "tbody", "tr", "th", "td", "pre"]
-    }()
+    private static var allowedHTMLTags = ["font", // custom to matrix for IRC-style font coloring
+                                          "del", // for markdown
+                                          "body", // added internally by DTCoreText
+                                          "mx-reply",
+                                          "h1", "h2", "h3", "h4", "h5", "h6", "blockquote", "p", "a", "ul", "ol",
+                                          "nl", "li", "b", "i", "u", "strong", "em", "strike", "code", "hr", "br", "div",
+                                          "table", "thead", "caption", "tbody", "tr", "th", "td", "pre"]
 }

--- a/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/DTHTMLElement+AttributedStringBuilder.swift
@@ -64,7 +64,7 @@ public extension DTHTMLElement {
         }
     }
     
-    private static var allowedHTMLTags = ["font", // custom to matrix for IRC-style font coloring
+    private static let allowedHTMLTags = ["font", // custom to matrix for IRC-style font coloring
                                           "del", // for markdown
                                           "body", // added internally by DTCoreText
                                           "mx-reply",

--- a/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenModels.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenModels.swift
@@ -24,15 +24,6 @@ enum MessageForwardingScreenViewModelAction {
 struct MessageForwardingScreenViewState: BindableState {
     var rooms: [MessageForwardingRoom] = []
     var selectedRoomID: String?
-    
-    var visibleRooms: [MessageForwardingRoom] {
-        if bindings.searchQuery.isEmpty {
-            return rooms
-        }
-        
-        return rooms.filter { $0.name.localizedStandardContains(bindings.searchQuery) }
-    }
-    
     var bindings = MessageForwardingScreenViewStateBindings()
 }
 
@@ -44,6 +35,8 @@ enum MessageForwardingScreenViewAction {
     case cancel
     case send
     case selectRoom(roomID: String)
+    case reachedTop
+    case reachedBottom
 }
 
 struct MessageForwardingRoom: Identifiable, Equatable {

--- a/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenViewModel.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/MessageForwardingScreenViewModel.swift
@@ -106,7 +106,11 @@ class MessageForwardingScreenViewModel: MessageForwardingScreenViewModelType, Me
     }
     
     /// The actual range values don't matter as long as they contain the lower
-    /// or upper bounds
+    /// or upper bounds. updateVisibleRange is a hybrid API that powers both
+    /// sliding sync visible range update and list paginations
+    /// For lists other than the home screen one we don't care about visible ranges,
+    /// we just need the respective bounds to be there to trigger a next page load or
+    /// a reset to just one page
     private func updateVisibleRange(edge: UIRectEdge) {
         guard let roomSummaryProvider else {
             return

--- a/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
@@ -22,9 +22,17 @@ struct MessageForwardingScreen: View {
     var body: some View {
         Form {
             Section {
-                ForEach(context.viewState.visibleRooms) { room in
+                ForEach(context.viewState.rooms) { room in
                     MessageForwardingRoomCell(room: room, context: context)
                         .buttonStyle(FormButtonStyle(accessory: .singleSelection(isSelected: context.viewState.selectedRoomID == room.id)))
+                }
+            } header: {
+                Rectangle().hidden().onAppear {
+                    context.send(viewAction: .reachedTop)
+                }
+            } footer: {
+                Rectangle().hidden().onAppear {
+                    context.send(viewAction: .reachedBottom)
                 }
             }
             .compoundFormSection()

--- a/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
@@ -26,6 +26,7 @@ struct MessageForwardingScreen: View {
                     MessageForwardingRoomCell(room: room, context: context)
                         .buttonStyle(FormButtonStyle(accessory: .singleSelection(isSelected: context.viewState.selectedRoomID == room.id)))
                 }
+                // Replace these with ScrollView's `scrollPosition` when dropping iOS 16.
             } header: {
                 Rectangle().hidden().onAppear {
                     context.send(viewAction: .reachedTop)

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -35,8 +35,11 @@ class ClientProxy: ClientProxyProtocol {
     private var syncService: SyncService?
     private var syncServiceStateUpdateTaskHandle: TaskHandle?
     
+    // These following summary providers both operate on the same allRooms() list but
+    // can apply their own filtering and pagination
     private(set) var roomSummaryProvider: RoomSummaryProviderProtocol?
     private(set) var messageForwardingRoomSummaryProvider: RoomSummaryProviderProtocol?
+    
     private(set) var inviteSummaryProvider: RoomSummaryProviderProtocol?
     
     let notificationSettings: NotificationSettingsProxyProtocol

--- a/ElementX/Sources/Services/Client/ClientProxy.swift
+++ b/ElementX/Sources/Services/Client/ClientProxy.swift
@@ -35,10 +35,11 @@ class ClientProxy: ClientProxyProtocol {
     private var syncService: SyncService?
     private var syncServiceStateUpdateTaskHandle: TaskHandle?
     
-    var roomSummaryProvider: RoomSummaryProviderProtocol?
-    var inviteSummaryProvider: RoomSummaryProviderProtocol?
+    private(set) var roomSummaryProvider: RoomSummaryProviderProtocol?
+    private(set) var messageForwardingRoomSummaryProvider: RoomSummaryProviderProtocol?
+    private(set) var inviteSummaryProvider: RoomSummaryProviderProtocol?
     
-    var notificationSettings: NotificationSettingsProxyProtocol
+    let notificationSettings: NotificationSettingsProxyProtocol
 
     private let roomListRecencyOrderingAllowedEventTypes = ["m.room.message", "m.room.encrypted", "m.sticker"]
 
@@ -451,9 +452,17 @@ class ClientProxy: ClientProxyProtocol {
             roomSummaryProvider = RoomSummaryProvider(roomListService: roomListService,
                                                       eventStringBuilder: eventStringBuilder,
                                                       name: "AllRooms",
+                                                      shouldUpdateVisibleRange: true,
                                                       notificationSettings: notificationSettings,
                                                       backgroundTaskService: backgroundTaskService)
             try await roomSummaryProvider?.setRoomList(roomListService.allRooms())
+            
+            messageForwardingRoomSummaryProvider = RoomSummaryProvider(roomListService: roomListService,
+                                                                       eventStringBuilder: eventStringBuilder,
+                                                                       name: "MessageForwarding",
+                                                                       notificationSettings: notificationSettings,
+                                                                       backgroundTaskService: backgroundTaskService)
+            try await messageForwardingRoomSummaryProvider?.setRoomList(roomListService.allRooms())
             
             inviteSummaryProvider = RoomSummaryProvider(roomListService: roomListService,
                                                         eventStringBuilder: eventStringBuilder,

--- a/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
+++ b/ElementX/Sources/Services/Client/ClientProxyProtocol.swift
@@ -89,6 +89,8 @@ protocol ClientProxyProtocol: AnyObject, MediaLoaderProtocol {
     
     var roomSummaryProvider: RoomSummaryProviderProtocol? { get }
     
+    var messageForwardingRoomSummaryProvider: RoomSummaryProviderProtocol? { get }
+    
     var inviteSummaryProvider: RoomSummaryProviderProtocol? { get }
     
     var notificationSettings: NotificationSettingsProxyProtocol { get }

--- a/ElementX/Sources/Services/Client/MockClientProxy.swift
+++ b/ElementX/Sources/Services/Client/MockClientProxy.swift
@@ -30,6 +30,8 @@ class MockClientProxy: ClientProxyProtocol {
     
     var roomSummaryProvider: RoomSummaryProviderProtocol? = MockRoomSummaryProvider()
     
+    var messageForwardingRoomSummaryProvider: RoomSummaryProviderProtocol? = MockRoomSummaryProvider()
+    
     var inviteSummaryProvider: RoomSummaryProviderProtocol? = MockRoomSummaryProvider()
 
     var userAvatarURL: CurrentValuePublisher<URL?, Never> { CurrentValueSubject<URL?, Never>(nil).asCurrentValuePublisher() }

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
@@ -24,8 +24,17 @@ enum MockRoomSummaryProviderState {
 }
 
 class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
-    let roomListPublisher: CurrentValuePublisher<[RoomSummary], Never>
-    let statePublisher: CurrentValuePublisher<RoomSummaryProviderState, Never>
+    private let initialRooms: [RoomSummary]
+    
+    private let roomListSubject: CurrentValueSubject<[RoomSummary], Never>
+    var roomListPublisher: CurrentValuePublisher<[RoomSummary], Never> {
+        roomListSubject.asCurrentValuePublisher()
+    }
+    
+    private let stateSuject: CurrentValueSubject<RoomSummaryProviderState, Never>
+    var statePublisher: CurrentValuePublisher<RoomSummaryProviderState, Never> {
+        stateSuject.asCurrentValuePublisher()
+    }
     
     convenience init() {
         self.init(state: .loading)
@@ -34,11 +43,13 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
     init(state: MockRoomSummaryProviderState) {
         switch state {
         case .loading:
-            roomListPublisher = .init([])
-            statePublisher = .init(.notLoaded)
+            initialRooms = []
+            roomListSubject = .init(initialRooms)
+            stateSuject = .init(.notLoaded)
         case .loaded(let rooms):
-            roomListPublisher = .init(rooms)
-            statePublisher = .init(.loaded(totalNumberOfRooms: UInt(rooms.count)))
+            initialRooms = rooms
+            roomListSubject = .init(initialRooms)
+            stateSuject = .init(.loaded(totalNumberOfRooms: UInt(initialRooms.count)))
         }
     }
     
@@ -46,7 +57,16 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
     
     func updateVisibleRange(_ range: Range<Int>) { }
     
-    func setFilter(_ filter: RoomSummaryProviderFilter) { }
+    func setFilter(_ filter: RoomSummaryProviderFilter) {
+        switch filter {
+        case .all:
+            roomListSubject.send(initialRooms)
+        case .none:
+            roomListSubject.send([])
+        case .normalizedMatchRoomName(let filter):
+            roomListSubject.send(initialRooms.filter { $0.name?.localizedCaseInsensitiveContains(filter) ?? false })
+        }
+    }
 }
 
 extension Array where Element == RoomSummary {

--- a/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/MockRoomSummaryProvider.swift
@@ -45,10 +45,12 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
         case .loading:
             initialRooms = []
             roomListSubject = .init(initialRooms)
+            roomListSubject.send(initialRooms)
             stateSuject = .init(.notLoaded)
         case .loaded(let rooms):
             initialRooms = rooms
             roomListSubject = .init(initialRooms)
+            roomListSubject.send(initialRooms)
             stateSuject = .init(.loaded(totalNumberOfRooms: UInt(initialRooms.count)))
         }
     }
@@ -64,7 +66,11 @@ class MockRoomSummaryProvider: RoomSummaryProviderProtocol {
         case .none:
             roomListSubject.send([])
         case .normalizedMatchRoomName(let filter):
-            roomListSubject.send(initialRooms.filter { $0.name?.localizedCaseInsensitiveContains(filter) ?? false })
+            if filter.isEmpty {
+                roomListSubject.send(initialRooms)
+            } else {
+                roomListSubject.send(initialRooms.filter { $0.name?.localizedCaseInsensitiveContains(filter) ?? false })
+            }
         }
     }
 }

--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -26,7 +26,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
     private let notificationSettings: NotificationSettingsProxyProtocol
     private let backgroundTaskService: BackgroundTaskServiceProtocol
     
-    private let roomListPageSize = 40
+    private let roomListPageSize = 200
     
     private let serialDispatchQueue: DispatchQueue
     
@@ -57,6 +57,11 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         }
     }
     
+    /// Build a new summary provider with the given parameters
+    /// - Parameters:
+    ///   - shouldUpdateVisibleRange: whether this summary provider should foward visible ranges
+    ///   to the room list service through the `applyInput(input: .viewport(ranges` api. Only useful for
+    ///   lists that need to update the visible range on Sliding Sync
     init(roomListService: RoomListServiceProtocol,
          eventStringBuilder: RoomEventStringBuilder,
          name: String,

--- a/UnitTests/Sources/MessageForwardingScreenViewModelTests.swift
+++ b/UnitTests/Sources/MessageForwardingScreenViewModelTests.swift
@@ -40,9 +40,14 @@ class MessageForwardingScreenViewModelTests: XCTestCase {
         XCTAssertEqual(context.viewState.selectedRoomID, "2")
     }
     
-    func testSearching() {
+    func testSearching() async throws {
+        let defered = deferFulfillment(context.$viewState) { state in
+            state.rooms.count == 1
+        }
+        
         context.searchQuery = "Second"
-        XCTAssertEqual(context.viewState.visibleRooms.count, 1)
+            
+        try await defered.fulfill()
     }
     
     func testForwarding() {

--- a/UnitTests/__Snapshots__/PreviewTests/test_messageForwardingScreen.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_messageForwardingScreen.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:345aefea5a04ab6ba25c84a84cde9780a5061fdf4dee59e7cf7d3a61e821ea4b
-size 103346
+oid sha256:7c1ca96074ce2549180efe3350a9fdf2e1a9654042b48975e0226222fb6a6c7e
+size 103256

--- a/changelog.d/1864.bugfix
+++ b/changelog.d/1864.bugfix
@@ -1,0 +1,1 @@
+Fix message forwarding room list filtering and pagination problems


### PR DESCRIPTION
* use a separate room summary provider instance just for message forwarding
* filter rooms through the rust sdk
* add pagination support