### PR TITLE
Remove ‘copy’ action for "media like" types

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -558,7 +558,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             actions.append(.edit)
         }
 
-        if item.isMessage, !item.isLocation {
+        if item.isCopyable {
             actions.append(.copy)
         }
         

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
@@ -43,10 +43,6 @@ extension EventBasedTimelineItemProtocol {
         properties.deliveryStatus == .sendingFailed
     }
 
-    var isLocation: Bool {
-        self is LocationRoomTimelineItem
-    }
-
     var pollIfAvailable: Poll? {
         (self as? PollRoomTimelineItem)?.poll
     }

--- a/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/EventBasedTimelineItemProtocol.swift
@@ -43,10 +43,6 @@ extension EventBasedTimelineItemProtocol {
         properties.deliveryStatus == .sendingFailed
     }
 
-    var isMessage: Bool {
-        self is EventBasedMessageTimelineItemProtocol
-    }
-
     var isLocation: Bool {
         self is LocationRoomTimelineItem
     }
@@ -88,5 +84,18 @@ extension EventBasedTimelineItemProtocol {
             start = "\(L10n.commonEditedSuffix) "
         }
         return start + timestamp
+    }
+
+    var isCopyable: Bool {
+        guard let messageBasedItem = self as? EventBasedMessageTimelineItemProtocol else {
+            return false
+        }
+
+        switch messageBasedItem.contentType {
+        case .audio, .file, .image, .video, .location, .voice:
+            return false
+        case .text, .emote, .notice:
+            return true
+        }
     }
 }


### PR DESCRIPTION
This PR removes the "copy" actions for "media like" events.
This is because the "copy" action currently copies the textual body of the event and not the actual media like users probably expect-.