### PR TITLE
Fix: the duration of voice messages is now expressed in milliseconds

### DIFF
--- a/ElementX/Sources/Services/AudioPlayer/AudioPlayer.swift
+++ b/ElementX/Sources/Services/AudioPlayer/AudioPlayer.swift
@@ -127,7 +127,7 @@ class AudioPlayer: NSObject, AudioPlayerProtocol {
     func seek(to progress: Double) async {
         guard let internalAudioPlayer else { return }
         let time = progress * duration
-        await internalAudioPlayer.seek(to: CMTime(seconds: time, preferredTimescale: 60000))
+        await internalAudioPlayer.seek(to: CMTime(seconds: time, preferredTimescale: 60))
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -475,7 +475,7 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
         }
 
         return AudioRoomTimelineItemContent(body: messageContent.body,
-                                            duration: (messageContent.audio?.duration ?? 0) / 1000.0,
+                                            duration: messageContent.audio?.duration ?? 0,
                                             waveform: waveform,
                                             source: MediaSourceProxy(source: messageContent.source, mimeType: messageContent.info?.mimetype),
                                             contentType: UTType(mimeType: messageContent.info?.mimetype, fallbackFilename: messageContent.body))


### PR DESCRIPTION
This PR fixes an issue with the duration of voice messages, which is now expressed in seconds rather than milliseconds in Ruma.