### PR TITLE
Debug is no longer crashing as of matrix-rust-sdk/pull/2595, time to …

### DIFF
--- a/Tools/Sources/BuildSDK.swift
+++ b/Tools/Sources/BuildSDK.swift
@@ -25,7 +25,7 @@ struct BuildSDK: ParsableCommand {
     var target: Target?
     
     @Option(help: "The profile to use when building the SDK. Omit this option to build in debug mode.")
-    var profile: Profile = .reldbg
+    var profile: Profile = .debug
 
     enum Error: LocalizedError {
         case rustupOutputFailure


### PR DESCRIPTION
…make it the default again so that debugging works properly

https://github.com/matrix-org/matrix-rust-sdk/pull/2595