### PR TITLE
Revert the OIDC callback to use a custom scheme for now.

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -134,13 +134,8 @@ final class AppSettings {
     
     /// Any pre-defined static client registrations for OIDC issuers.
     let oidcStaticRegistrations: [URL: String] = ["https://id.thirdroom.io/realms/thirdroom": "elementx"]
-    /// The redirect URL used for OIDC. The bundle ID suffix avoids app association conflicts between Element X, Nightly and PR builds.
-    let oidcRedirectURL = {
-        guard let bundleIDSuffix = InfoPlistReader.main.bundleIdentifier.split(separator: ".").last,
-              let redirectURL = URL(string: "https://mobile.element.io/oidc/\(bundleIDSuffix)")
-        else { fatalError("Failed creating a valid OIDC redirect URL.") }
-        return redirectURL
-    }()
+    /// The redirect URL used for OIDC.
+    let oidcRedirectURL: URL = "io.element:/callback"
 
     /// The date that the call to `/login` completed successfully. This is used to put
     /// a hard wall on the history of encrypted messages until we have key backup.

--- a/changelog.d/1936.bugfix
+++ b/changelog.d/1936.bugfix
@@ -1,0 +1,1 @@
+Revert the OIDC redirect URL back to using a custom scheme.


### PR DESCRIPTION
Universal links are still slightly unreliable for the OIDC callback. This PR is the first part of #1936 and a partial revert of #1681. Will follow this up in November once we have time to test hosting a page with a redirect as a fallback.