### PR TITLE
Make the reldbg profile default for SDK builds again

### DIFF
--- a/Tools/Sources/BuildSDK.swift
+++ b/Tools/Sources/BuildSDK.swift
@@ -25,7 +25,7 @@ struct BuildSDK: ParsableCommand {
     var target: Target?
     
     @Option(help: "The profile to use when building the SDK. Omit this option to build in debug mode.")
-    var profile: Profile = .debug
+    var profile: Profile = .reldbg
 
     enum Error: LocalizedError {
         case rustupOutputFailure


### PR DESCRIPTION
Following https://github.com/matrix-org/matrix-rust-sdk/pull/2765 we need to switch back to reldbg which not contains debug symbols but also doesn't crash

Revert "Debug is no longer crashing as of matrix-rust-sdk/pull/2595time to make it the default again so that debugging works properly"

This reverts commit eb9c69ce20a05ebabee7a9580e1a8a7f8cc3ebb9.