### PR TITLE
Fix Suggestion Pattern when text is empty

### DIFF
--- a/ElementX/Sources/Screens/ComposerToolbar/CompletionSuggestionService.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/CompletionSuggestionService.swift
@@ -56,13 +56,9 @@ final class CompletionSuggestionService: CompletionSuggestionServiceProtocol {
                 }
             }
             // We only debounce if the suggestion is nil
-            .map { [weak self] value in
-                let delay = self?.suggestionTriggerSubject.value == nil ? 0.0 : 0.5
-                return Just(value).delay(for: .seconds(delay), scheduler: DispatchQueue.main)
+            .debounceAndRemoveDuplicates(on: DispatchQueue.main) { [weak self] _ in
+                self?.suggestionTriggerSubject.value != nil ? .milliseconds(500) : .milliseconds(0)
             }
-            .switchToLatest()
-            .removeDuplicates()
-            .eraseToAnyPublisher()
         
         Task {
             switch await roomProxy.canUserTriggerRoomNotification(userID: roomProxy.ownUserID) {

--- a/ElementX/Sources/Screens/ComposerToolbar/CompletionSuggestionService.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/CompletionSuggestionService.swift
@@ -55,6 +55,7 @@ final class CompletionSuggestionService: CompletionSuggestionServiceProtocol {
                     return membersSuggestion
                 }
             }
+            // We only debounce if the suggestion is nil
             .map { [weak self] value in
                 let delay = self?.suggestionTriggerSubject.value == nil ? 0.0 : 0.5
                 return Just(value).delay(for: .seconds(delay), scheduler: DispatchQueue.main)

--- a/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/InviteUsersScreenViewModel.swift
@@ -95,7 +95,7 @@ class InviteUsersScreenViewModel: InviteUsersScreenViewModelType, InviteUsersScr
     private func setupSubscriptions(selectedUsers: CurrentValuePublisher<[UserProfileProxy], Never>) {
         context.$viewState
             .map(\.bindings.searchQuery)
-            .debounceAndRemoveDuplicates()
+            .debounceTextQueriesAndRemoveDuplicates()
             .sink { [weak self] _ in
                 self?.fetchUsers()
             }

--- a/ElementX/Sources/Screens/StartChatScreen/StartChatScreenViewModel.swift
+++ b/ElementX/Sources/Screens/StartChatScreen/StartChatScreenViewModel.swift
@@ -92,7 +92,7 @@ class StartChatScreenViewModel: StartChatScreenViewModelType, StartChatScreenVie
     private func setupBindings() {
         context.$viewState
             .map(\.bindings.searchQuery)
-            .debounceAndRemoveDuplicates()
+            .debounceTextQueriesAndRemoveDuplicates()
             .sink { [weak self] _ in
                 self?.fetchUsers()
             }


### PR DESCRIPTION
The user suggestions should appear even when there is not text yet after the @ character. This PR fixes this issue. Also it improves debouncing, by only doing that when the suggestion pattern is not nil.