### PR TITLE
Switch ElementCall's base URL to .dev

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -211,7 +211,7 @@ final class AppSettings {
     
     // MARK: - Element Call
     
-    let elementCallBaseURL: URL = "https://call.element.io"
+    let elementCallBaseURL: URL = "https://call.element.dev"
     
     // MARK: - Notifications
 


### PR DESCRIPTION
In order to speed up widget development we decided to switch ElementCalls's base URL to call.element.dev, at least while it's under a feature flag.