### PR TITLE
Session verification fixes

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -6588,7 +6588,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.1.26;
+				version = "0.0.1-october23";
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -129,8 +129,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "e7bacee684806d125077b032e3848189ad370f3b",
-        "version" : "1.1.26"
+        "revision" : "f53f5302ddcd81e4134fa7437fedd5c33cd7c1bf",
+        "version" : "0.0.1-october23"
       }
     },
     {
@@ -262,7 +262,7 @@
     {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
+      "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
         "revision" : "b94da693e57eaf79d16464b8b7c90d09cba4e290",
         "version" : "0.9.2"

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2704,12 +2704,24 @@ class SessionVerificationControllerProxyMock: SessionVerificationControllerProxy
         set(value) { underlyingCallbacks = value }
     }
     var underlyingCallbacks: PassthroughSubject<SessionVerificationControllerProxyCallback, Never>!
-    var isVerified: Bool {
-        get { return underlyingIsVerified }
-        set(value) { underlyingIsVerified = value }
-    }
-    var underlyingIsVerified: Bool!
 
+    //MARK: - isVerified
+
+    var isVerifiedCallsCount = 0
+    var isVerifiedCalled: Bool {
+        return isVerifiedCallsCount > 0
+    }
+    var isVerifiedReturnValue: Result<Bool, SessionVerificationControllerProxyError>!
+    var isVerifiedClosure: (() async -> Result<Bool, SessionVerificationControllerProxyError>)?
+
+    func isVerified() async -> Result<Bool, SessionVerificationControllerProxyError> {
+        isVerifiedCallsCount += 1
+        if let isVerifiedClosure = isVerifiedClosure {
+            return await isVerifiedClosure()
+        } else {
+            return isVerifiedReturnValue
+        }
+    }
     //MARK: - requestVerification
 
     var requestVerificationCallsCount = 0

--- a/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/SDKGeneratedMocks.swift
@@ -165,6 +165,23 @@ class SDKClientMock: SDKClientProtocol {
             return displayNameReturnValue
         }
     }
+    //MARK: - encryption
+
+    public var encryptionCallsCount = 0
+    public var encryptionCalled: Bool {
+        return encryptionCallsCount > 0
+    }
+    public var encryptionReturnValue: Encryption!
+    public var encryptionClosure: (() -> Encryption)?
+
+    public func encryption() -> Encryption {
+        encryptionCallsCount += 1
+        if let encryptionClosure = encryptionClosure {
+            return encryptionClosure()
+        } else {
+            return encryptionReturnValue
+        }
+    }
     //MARK: - getDmRoom
 
     public var getDmRoomUserIdThrowableError: Error?

--- a/ElementX/Sources/Mocks/SessionVerificationControllerProxyMock.swift
+++ b/ElementX/Sources/Mocks/SessionVerificationControllerProxyMock.swift
@@ -30,7 +30,7 @@ extension SessionVerificationControllerProxyMock {
                               requestDelay: Duration = .seconds(1)) -> SessionVerificationControllerProxyMock {
         let mock = SessionVerificationControllerProxyMock()
         mock.underlyingCallbacks = callbacks
-        mock.underlyingIsVerified = isVerified
+        mock.isVerifiedReturnValue = .success(isVerified)
 
         mock.requestVerificationClosure = { [unowned mock] in
             Task.detached {

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenModels.swift
@@ -41,7 +41,7 @@ struct SettingsScreenViewState: BindableState {
     var accountSessionsListURL: URL?
     var userAvatarURL: URL?
     var userDisplayName: String?
-    var isSessionVerified: Bool
+    var isSessionVerified = false
     var chatBackupEnabled = false
     var showSecureBackupBadge = false
     var showAppLockSettings: Bool

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenViewModel.swift
@@ -33,16 +33,10 @@ class SettingsScreenViewModel: SettingsScreenViewModelType, SettingsScreenViewMo
         self.userSession = userSession
         self.appSettings = appSettings
         
-        var isSessionVerified = true
-        if let sessionVerificationController = userSession.sessionVerificationController {
-            isSessionVerified = sessionVerificationController.isVerified
-        }
-        
         super.init(initialViewState: .init(deviceID: userSession.deviceID,
                                            userID: userSession.userID,
                                            accountProfileURL: userSession.clientProxy.accountURL(action: .profile),
                                            accountSessionsListURL: userSession.clientProxy.accountURL(action: .sessionsList),
-                                           isSessionVerified: isSessionVerified,
                                            showAppLockSettings: appSettings.appLockFlowEnabled,
                                            showDeveloperOptions: appSettings.canShowDeveloperOptions),
                    imageProvider: userSession.mediaProvider)
@@ -77,6 +71,11 @@ class SettingsScreenViewModel: SettingsScreenViewModelType, SettingsScreenViewMo
         Task {
             await userSession.clientProxy.loadUserAvatarURL()
             await userSession.clientProxy.loadUserDisplayName()
+            
+            if let sessionVerificationController = userSession.sessionVerificationController,
+               case let .success(isVerified) = await sessionVerificationController.isVerified() {
+                state.isSessionVerified = isVerified
+            }
         }
         
         userSession.callbacks

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
@@ -247,7 +247,7 @@ private extension TimelineStyle {
 struct SettingsScreen_Previews: PreviewProvider, TestablePreview {
     static let viewModel = {
         let verificationController = SessionVerificationControllerProxyMock()
-        verificationController.isVerified = false
+        verificationController.isVerifiedReturnValue = .success(false)
         let userSession = MockUserSession(sessionVerificationController: verificationController,
                                           clientProxy: MockClientProxy(userID: "@userid:example.com",
                                                                        deviceID: "AAAAAAAAAAA"),

--- a/ElementX/Sources/Services/Session/UserSession.swift
+++ b/ElementX/Sources/Services/Session/UserSession.swift
@@ -64,12 +64,12 @@ class UserSession: UserSessionProtocol {
                 
                 tearDownSessionVerificationControllerWatchdog()
                 
-                if isVerified == false {
+                if !isVerified {
                     callbacks.send(.sessionVerificationNeeded)
                 }
-
+                
                 self.sessionVerificationController = sessionVerificationController
-
+                
                 sessionVerificationController.callbacks.sink { [weak self] callback in
                     switch callback {
                     case .finished:

--- a/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
+++ b/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxy.swift
@@ -65,8 +65,13 @@ class SessionVerificationControllerProxy: SessionVerificationControllerProxyProt
     
     let callbacks = PassthroughSubject<SessionVerificationControllerProxyCallback, Never>()
     
-    var isVerified: Bool {
-        sessionVerificationController.isVerified()
+    func isVerified() async -> Result<Bool, SessionVerificationControllerProxyError> {
+        do {
+            let result = try await sessionVerificationController.isVerified()
+            return .success(result)
+        } catch {
+            return .failure(.failedCheckingVerificationState)
+        }
     }
     
     func requestVerification() async -> Result<Void, SessionVerificationControllerProxyError> {

--- a/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxyProtocol.swift
+++ b/ElementX/Sources/Services/SessionVerification/SessionVerificationControllerProxyProtocol.swift
@@ -18,6 +18,7 @@ import Combine
 import Foundation
 
 enum SessionVerificationControllerProxyError: Error {
+    case failedCheckingVerificationState
     case failedRequestingVerification
     case failedStartingSasVerification
     case failedApprovingVerification
@@ -43,7 +44,7 @@ struct SessionVerificationEmoji: Hashable {
 protocol SessionVerificationControllerProxyProtocol {
     var callbacks: PassthroughSubject<SessionVerificationControllerProxyCallback, Never> { get }
     
-    var isVerified: Bool { get }
+    func isVerified() async -> Result<Bool, SessionVerificationControllerProxyError>
         
     func requestVerification() async -> Result<Void, SessionVerificationControllerProxyError>
     

--- a/project.yml
+++ b/project.yml
@@ -45,7 +45,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 1.1.26
+    exactVersion: 0.0.1-october23
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/vector-im/compound-ios


### PR DESCRIPTION
Fixes #1868: Incorrect `is_verified` flag after successfully running verification flow
- the inner user_identity isn't automatically updated when the flow finishes, needs to be fetched again from encryption
- also replaces `UserIdentity.is_verified` with `Device.is_cross_signed_by_owner`
- depends on matrix-org/matrix-rust-sdk/pull/2775