### PR TITLE
Remove the border around the voice message composer

### DIFF
--- a/ElementX/Sources/Screens/ComposerToolbar/View/VoiceMessagePreviewComposer.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/VoiceMessagePreviewComposer.swift
@@ -90,8 +90,6 @@ struct VoiceMessagePreviewComposer: View {
             ZStack {
                 roundedRectangle
                     .fill(Color.compound.bgSubtleSecondary)
-                roundedRectangle
-                    .stroke(Color.compound._borderTextFieldFocused, lineWidth: 0.5)
             }
         }
         .frame(minHeight: 42)

--- a/ElementX/Sources/Screens/ComposerToolbar/View/VoiceMessageRecordingComposer.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/VoiceMessageRecordingComposer.swift
@@ -30,8 +30,6 @@ struct VoiceMessageRecordingComposer: View {
                 ZStack {
                     roundedRectangle
                         .fill(Color.compound.bgSubtleSecondary)
-                    roundedRectangle
-                        .stroke(Color.compound._borderTextFieldFocused, lineWidth: 0.5)
                 }
             }
             .frame(minHeight: 42)

--- a/UnitTests/__Snapshots__/PreviewTests/test_composerToolbar.Voice-Message.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_composerToolbar.Voice-Message.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b75d67814719e5a44c8e647a8e4fb2b1f9b893ccfbc2fcc9939270e40bc2fc0f
-size 95523
+oid sha256:4a5e4b21a9286f303e23fc85ac6ea0f108a37be0a22b02fd944dfe004de93e99
+size 93494

--- a/UnitTests/__Snapshots__/PreviewTests/test_voiceMessagePreviewComposer.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_voiceMessagePreviewComposer.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:efc7fa1ab541e5dd8bb1757ed782065e7c7e84d7354fe90702f1091134a24467
-size 63847
+oid sha256:e94b55edca09448dfa1309331d238f029a86b40061bad197ef8cd5c6d421a1b4
+size 62636

--- a/UnitTests/__Snapshots__/PreviewTests/test_voiceMessageRecordingComposer.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_voiceMessageRecordingComposer.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af1d1d6fcf418f97cc9aae336b349b3630a1e2995c26ab8565421c97a823935a
-size 59818
+oid sha256:49ba019171a846ae54d2849ff4ae4f02194fceda407fd26077cbf16a5f8682f3
+size 58567


### PR DESCRIPTION
This PR removes the border around `VoiceMesagePreviewComposer` and `VoiceMessageRecordingComposer`