### PR TITLE
Fix: Keep the progress indicator visible after pausing or scrubbing.

### DIFF
--- a/ElementX/Sources/Other/VoiceMessage/WaveformInteractionModifier.swift
+++ b/ElementX/Sources/Other/VoiceMessage/WaveformInteractionModifier.swift
@@ -35,11 +35,6 @@ private struct WaveformInteractionModifier: ViewModifier {
     func body(content: Content) -> some View {
         GeometryReader { geometry in
             content
-                .gesture(SpatialTapGesture()
-                    .onEnded { tapGesture in
-                        let progress = tapGesture.location.x / geometry.size.width
-                        onSeek(max(0, min(progress, 1.0)))
-                    })
                 .progressCursor(progress: progress) {
                     WaveformCursorView(color: .compound.iconAccentTertiary)
                         .frame(width: cursorVisibleWidth, height: cursorVisibleHeight)
@@ -56,6 +51,11 @@ private struct WaveformInteractionModifier: ViewModifier {
                         )
                         .offset(x: -cursorInteractiveSize / 2, y: 0)
                 }
+                .gesture(SpatialTapGesture()
+                    .onEnded { tapGesture in
+                        let progress = tapGesture.location.x / geometry.size.width
+                        onSeek(max(0, min(progress, 1.0)))
+                    })
         }
         .coordinateSpace(name: Self.namespaceName)
         .animation(nil, value: progress)

--- a/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarModels.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarModels.swift
@@ -37,6 +37,7 @@ enum ComposerToolbarViewModelAction {
     case deleteVoiceMessageRecording
     case startVoiceMessagePlayback
     case pauseVoiceMessagePlayback
+    case scrubbingVoiceMessagePlayback(scrubbing: Bool)
     case seekVoiceMessagePlayback(progress: Double)
     case sendVoiceMessage
 }
@@ -61,6 +62,7 @@ enum ComposerToolbarViewAction {
     case deleteVoiceMessageRecording
     case startVoiceMessagePlayback
     case pauseVoiceMessagePlayback
+    case scrubbingVoiceMessagePlayback(scrubbing: Bool)
     case seekVoiceMessagePlayback(progress: Double)
 }
 

--- a/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarModels.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarModels.swift
@@ -37,7 +37,7 @@ enum ComposerToolbarViewModelAction {
     case deleteVoiceMessageRecording
     case startVoiceMessagePlayback
     case pauseVoiceMessagePlayback
-    case scrubbingVoiceMessagePlayback(scrubbing: Bool)
+    case scrubVoiceMessagePlayback(scrubbing: Bool)
     case seekVoiceMessagePlayback(progress: Double)
     case sendVoiceMessage
 }
@@ -62,7 +62,7 @@ enum ComposerToolbarViewAction {
     case deleteVoiceMessageRecording
     case startVoiceMessagePlayback
     case pauseVoiceMessagePlayback
-    case scrubbingVoiceMessagePlayback(scrubbing: Bool)
+    case scrubVoiceMessagePlayback(scrubbing: Bool)
     case seekVoiceMessagePlayback(progress: Double)
 }
 

--- a/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -155,8 +155,8 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
             actionsSubject.send(.pauseVoiceMessagePlayback)
         case .seekVoiceMessagePlayback(let progress):
             actionsSubject.send(.seekVoiceMessagePlayback(progress: progress))
-        case .scrubbingVoiceMessagePlayback(let scrubbing):
-            actionsSubject.send(.scrubbingVoiceMessagePlayback(scrubbing: scrubbing))
+        case .scrubVoiceMessagePlayback(let scrubbing):
+            actionsSubject.send(.scrubVoiceMessagePlayback(scrubbing: scrubbing))
         }
     }
 

--- a/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -155,6 +155,8 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
             actionsSubject.send(.pauseVoiceMessagePlayback)
         case .seekVoiceMessagePlayback(let progress):
             actionsSubject.send(.seekVoiceMessagePlayback(progress: progress))
+        case .scrubbingVoiceMessagePlayback(let scrubbing):
+            actionsSubject.send(.scrubbingVoiceMessagePlayback(scrubbing: scrubbing))
         }
     }
 

--- a/ElementX/Sources/Screens/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/ComposerToolbar.swift
@@ -33,6 +33,7 @@ struct ComposerToolbar: View {
     @State private var showVoiceMessageRecordingTooltip = false
     @ScaledMetric private var voiceMessageTooltipPointerHeight = 6
     @State private var voiceMessageRecordingButtonFrame: CGRect = .zero
+    @State private var resumeVoiceMessagePlaybackAfterScrubbing = false
     
     private let voiceMessageMinimumRecordingDuration = 1.0
     private let voiceMessageTooltipDuration = 1.0
@@ -325,6 +326,18 @@ struct ComposerToolbar: View {
             context.send(viewAction: .pauseVoiceMessagePlayback)
         } onSeek: { progress in
             context.send(viewAction: .seekVoiceMessagePlayback(progress: progress))
+        } onScrubbing: { isScrubbing in
+            if isScrubbing {
+                if audioPlayerState.playbackState == .playing {
+                    resumeVoiceMessagePlaybackAfterScrubbing = true
+                    context.send(viewAction: .pauseVoiceMessagePlayback)
+                }
+            } else {
+                if resumeVoiceMessagePlaybackAfterScrubbing {
+                    context.send(viewAction: .startVoiceMessagePlayback)
+                    resumeVoiceMessagePlaybackAfterScrubbing = false
+                }
+            }
         }
     }
 }

--- a/ElementX/Sources/Screens/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/ComposerToolbar.swift
@@ -33,7 +33,6 @@ struct ComposerToolbar: View {
     @State private var showVoiceMessageRecordingTooltip = false
     @ScaledMetric private var voiceMessageTooltipPointerHeight = 6
     @State private var voiceMessageRecordingButtonFrame: CGRect = .zero
-    @State private var resumeVoiceMessagePlaybackAfterScrubbing = false
     
     private let voiceMessageMinimumRecordingDuration = 1.0
     private let voiceMessageTooltipDuration = 1.0
@@ -327,17 +326,7 @@ struct ComposerToolbar: View {
         } onSeek: { progress in
             context.send(viewAction: .seekVoiceMessagePlayback(progress: progress))
         } onScrubbing: { isScrubbing in
-            if isScrubbing {
-                if audioPlayerState.playbackState == .playing {
-                    resumeVoiceMessagePlaybackAfterScrubbing = true
-                    context.send(viewAction: .pauseVoiceMessagePlayback)
-                }
-            } else {
-                if resumeVoiceMessagePlaybackAfterScrubbing {
-                    context.send(viewAction: .startVoiceMessagePlayback)
-                    resumeVoiceMessagePlaybackAfterScrubbing = false
-                }
-            }
+            context.send(viewAction: .scrubbingVoiceMessagePlayback(scrubbing: isScrubbing))
         }
     }
 }

--- a/ElementX/Sources/Screens/ComposerToolbar/View/ComposerToolbar.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/ComposerToolbar.swift
@@ -326,7 +326,7 @@ struct ComposerToolbar: View {
         } onSeek: { progress in
             context.send(viewAction: .seekVoiceMessagePlayback(progress: progress))
         } onScrubbing: { isScrubbing in
-            context.send(viewAction: .scrubbingVoiceMessagePlayback(scrubbing: isScrubbing))
+            context.send(viewAction: .scrubVoiceMessagePlayback(scrubbing: isScrubbing))
         }
     }
 }

--- a/ElementX/Sources/Screens/ComposerToolbar/View/VoiceMessagePreviewComposer.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/VoiceMessagePreviewComposer.swift
@@ -30,6 +30,7 @@ struct VoiceMessagePreviewComposer: View {
     let onPlay: () -> Void
     let onPause: () -> Void
     let onSeek: (Double) -> Void
+    let onScrubbing: (Bool) -> Void
 
     var timeLabelContent: String {
         // Display the duration if progress is 0.0
@@ -39,10 +40,6 @@ struct VoiceMessagePreviewComposer: View {
         return DateFormatter.elapsedTimeFormatter.string(from: elapsed)
     }
     
-    var showWaveformCursor: Bool {
-        playerState.playbackState == .playing || isDragging
-    }
-            
     var body: some View {
         HStack {
             HStack {
@@ -60,8 +57,11 @@ struct VoiceMessagePreviewComposer: View {
             waveformView
                 .waveformInteraction(isDragging: $isDragging,
                                      progress: playerState.progress,
-                                     showCursor: showWaveformCursor,
+                                     showCursor: playerState.showProgressIndicator,
                                      onSeek: onSeek)
+        }
+        .onChange(of: isDragging) { isDragging in
+            onScrubbing(isDragging)
         }
         .padding(.vertical, 4.0)
         .padding(.horizontal, 6.0)
@@ -133,7 +133,7 @@ struct VoiceMessagePreviewComposer_Previews: PreviewProvider, TestablePreview {
     
     static var previews: some View {
         VStack {
-            VoiceMessagePreviewComposer(playerState: playerState, waveform: .data(waveformData), onPlay: { }, onPause: { }, onSeek: { _ in })
+            VoiceMessagePreviewComposer(playerState: playerState, waveform: .data(waveformData), onPlay: { }, onPause: { }, onSeek: { _ in }, onScrubbing: { _ in })
                 .fixedSize(horizontal: false, vertical: true)
         }
     }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -214,8 +214,8 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             pausePlayingRecordedVoiceMessage()
         case .seekVoiceMessagePlayback(let progress):
             Task { await seekRecordedVoiceMessage(to: progress) }
-        case .scrubbingVoiceMessagePlayback(let scrubbing):
-            Task { await scrubbingVoiceMessagePlayback(scrubbing: scrubbing) }
+        case .scrubVoiceMessagePlayback(let scrubbing):
+            Task { await scrubVoiceMessagePlayback(scrubbing: scrubbing) }
         }
     }
     
@@ -1030,7 +1030,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         await voiceMessageRecorder.seekPlayback(to: progress)
     }
     
-    private func scrubbingVoiceMessagePlayback(scrubbing: Bool) async {
+    private func scrubVoiceMessagePlayback(scrubbing: Bool) async {
         guard let audioPlayerState = voiceMessageRecorder.previewAudioPlayerState else {
             return
         }

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -349,7 +349,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         }
         
         switch await timelineController.sendReadReceipt(for: eventItemID) {
-        case .success():
+        case .success:
             break
         case let .failure(error):
             MXLog.error("[TimelineViewController] Failed to send read receipt: \(error)")
@@ -1025,6 +1025,7 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     }
     
     private func seekRecordedVoiceMessage(to progress: Double) async {
+        await mediaPlayerProvider.detachAllStates(except: voiceMessageRecorder.previewAudioPlayerState)
         await voiceMessageRecorder.seekPlayback(to: progress)
     }
     

--- a/ElementX/Sources/Services/Audio/Player/AudioPlayerState.swift
+++ b/ElementX/Sources/Services/Audio/Player/AudioPlayerState.swift
@@ -148,6 +148,7 @@ class AudioPlayerState: ObservableObject, Identifiable {
             }
         case .didFailWithError:
             stopPublishProgress()
+            playbackState = .error
         }
     }
     

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
@@ -322,6 +322,7 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
         guard let playerState = mediaPlayerProvider.playerState(for: .timelineItemIdentifier(itemID)) else {
             return
         }
+        await mediaPlayerProvider.detachAllStates(except: playerState)
         await playerState.updateState(progress: progress)
     }
     

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomPlaybackView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomPlaybackView.swift
@@ -40,10 +40,6 @@ struct VoiceMessageRoomPlaybackView: View {
         }
     }
     
-    var showWaveformCursor: Bool {
-        playerState.playbackState == .playing || isDragging
-    }
-    
     var body: some View {
         HStack {
             HStack {
@@ -61,7 +57,7 @@ struct VoiceMessageRoomPlaybackView: View {
             waveformView
                 .waveformInteraction(isDragging: $isDragging,
                                      progress: playerState.progress,
-                                     showCursor: showWaveformCursor,
+                                     showCursor: playerState.showProgressIndicator,
                                      onSeek: onSeek)
         }
         .padding(.leading, 2)

--- a/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorder.swift
+++ b/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorder.swift
@@ -91,12 +91,13 @@ class VoiceMessageRecorder: VoiceMessageRecorderProtocol {
             return .failure(.previewNotAvailable)
         }
         
+        await previewAudioPlayerState.attachAudioPlayer(audioPlayer)
+        
         if audioPlayer.url == url {
             audioPlayer.play()
             return .success(())
         }
         
-        await previewAudioPlayerState.attachAudioPlayer(audioPlayer)
         let pendingMediaSource = MediaSourceProxy(url: url, mimeType: mp4accMimeType)
         audioPlayer.load(mediaSource: pendingMediaSource, using: url, autoplay: true)
         return .success(())

--- a/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorder.swift
+++ b/ElementX/Sources/Services/VoiceMessage/VoiceMessageRecorder.swift
@@ -91,7 +91,9 @@ class VoiceMessageRecorder: VoiceMessageRecorderProtocol {
             return .failure(.previewNotAvailable)
         }
         
-        await previewAudioPlayerState.attachAudioPlayer(audioPlayer)
+        if await !previewAudioPlayerState.isAttached {
+            await previewAudioPlayerState.attachAudioPlayer(audioPlayer)
+        }
         
         if audioPlayer.url == url {
             audioPlayer.play()

--- a/UnitTests/Sources/VoiceMessageRecorderTests.swift
+++ b/UnitTests/Sources/VoiceMessageRecorderTests.swift
@@ -43,6 +43,7 @@ class VoiceMessageRecorderTests: XCTestCase {
         audioRecorder.averagePowerForChannelNumberReturnValue = 0
         audioPlayer = AudioPlayerMock()
         audioPlayer.actions = audioPlayerActions
+        audioPlayer.state = .stopped
         
         mediaPlayerProvider = MediaPlayerProviderMock()
         mediaPlayerProvider.playerForClosure = { _ in


### PR DESCRIPTION
This PR changes the criteria for displaying the progress indicator.

The progress indicator is now displayed when an audio player is attached to the voice message view or when a scrub is performed.
When a scrub is performed on a voice message other than the one currently playing, playback is stopped and the audio player is detached.

In this way, the progress indicator disappears when it is displayed in another view, preventing multiple progress indicators from being displayed at the same time.