### PR TITLE
Set voice messages max width

### DIFF
--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomTimelineView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomTimelineView.swift
@@ -35,6 +35,7 @@ struct VoiceMessageRoomTimelineView: View {
                                          onSeek: { onPlaybackSeek($0) },
                                          onScrubbing: { onPlaybackScrubbing($0) })
                 .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 400)
         }
     }
     


### PR DESCRIPTION
Useful for limiting the width of voice messages on iPad or landscape mode.