### PR TITLE
Fix presentation when not enrolled in Touch/Face ID.

### DIFF
--- a/changelog.d/pr-1981.wip
+++ b/changelog.d/pr-1981.wip
@@ -1,0 +1,1 @@
+Fix a bug when setting up App Lock if biometrics aren't available.


### PR DESCRIPTION
This PR makes a small tweak to the app lock setup state machine to differentiate between creating a PIN or updating a PIN.