### PR TITLE
Ignore keyboard input in "voice message mode"

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -6612,7 +6612,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-wysiwyg-composer-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 2.14.4;
+				version = 2.15.0;
 			};
 		};
 		96495DD8554E2F39D3954354 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -138,8 +138,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-wysiwyg-composer-swift",
       "state" : {
-        "revision" : "e60d0ffa9fbb1368bd837c94dede2d8d48952c7f",
-        "version" : "2.14.4"
+        "revision" : "379ab4d0ff194eba197606c56345e5718b2e3810",
+        "version" : "2.15.0"
       }
     },
     {
@@ -262,7 +262,7 @@
     {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect",
+      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
       "state" : {
         "revision" : "b94da693e57eaf79d16464b8b7c90d09cba4e290",
         "version" : "0.9.2"

--- a/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -53,7 +53,10 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
         context.$viewState
             .map(\.composerMode)
             .removeDuplicates()
-            .sink { [weak self] in self?.actionsSubject.send(.composerModeChanged(mode: $0)) }
+            .sink { [weak self] in
+                self?.wysiwygViewModel.shouldReplaceText = $0.isTextEditingEnabled
+                self?.actionsSubject.send(.composerModeChanged(mode: $0))
+            }
             .store(in: &cancellables)
 
         context.$viewState

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -52,6 +52,15 @@ enum RoomScreenComposerMode: Equatable {
             return false
         }
     }
+
+    var isTextEditingEnabled: Bool {
+        switch self {
+        case .default, .reply, .edit:
+            return true
+        case .recordVoiceMessage, .previewVoiceMessage:
+            return false
+        }
+    }
 }
 
 enum RoomScreenViewAction {

--- a/project.yml
+++ b/project.yml
@@ -112,7 +112,7 @@ packages:
     minorVersion: 2.0.0
   WysiwygComposer:
     url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift
-    exactVersion: 2.14.4
+    exactVersion: 2.15.0
 #    path: ../matrix-wysiwyg/platforms/ios/lib/WysiwygComposer
   SwiftOGG:
     url: https://github.com/vector-im/swift-ogg


### PR DESCRIPTION
This PR:
- Updates RTE to `2.15.0`
- Ignores keyboard inputs when the user is using the voice message feature

| Before | After |
| --- | --- |
|![b](https://github.com/vector-im/element-x-ios/assets/19324622/7b1548b5-82ff-431d-981c-2051aefa9000)|![a](https://github.com/vector-im/element-x-ios/assets/19324622/d5773f7b-ce36-49d2-847d-db143e98baac)|

