### PR TITLE
Add missing gradient to lock screen placeholder.

### DIFF
--- a/ElementX/Sources/FlowCoordinators/AppLockFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AppLockFlowCoordinator.swift
@@ -118,7 +118,7 @@ class AppLockFlowCoordinator: CoordinatorProtocol {
     
     /// Displays the unlock flow with the app's placeholder view to hide obscure the view hierarchy in the app switcher.
     private func showPlaceholder() {
-        navigationCoordinator.setRootCoordinator(PlaceholderScreenCoordinator(), animated: false)
+        navigationCoordinator.setRootCoordinator(PlaceholderScreenCoordinator(showsBackgroundGradient: true), animated: false)
         actionsSubject.send(.lockApp)
     }
     

--- a/ElementX/Sources/Screens/Other/PlaceholderScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Other/PlaceholderScreenCoordinator.swift
@@ -33,7 +33,7 @@ struct PlaceholderScreen: View {
     let showsBackgroundGradient: Bool
     
     var body: some View {
-        OnboardingLogo(isOnGradient: false)
+        OnboardingLogo(isOnGradient: showsBackgroundGradient)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background {
                 if showsBackgroundGradient {

--- a/ElementX/Sources/Screens/Other/PlaceholderScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/Other/PlaceholderScreenCoordinator.swift
@@ -17,16 +17,29 @@
 import SwiftUI
 
 class PlaceholderScreenCoordinator: CoordinatorProtocol {
+    private let showsBackgroundGradient: Bool
+    
+    init(showsBackgroundGradient: Bool = false) {
+        self.showsBackgroundGradient = showsBackgroundGradient
+    }
+    
     func toPresentable() -> AnyView {
-        AnyView(PlaceholderScreen())
+        AnyView(PlaceholderScreen(showsBackgroundGradient: showsBackgroundGradient))
     }
 }
 
 /// The screen shown in split view when the detail has no content.
 struct PlaceholderScreen: View {
+    let showsBackgroundGradient: Bool
+    
     var body: some View {
         OnboardingLogo(isOnGradient: false)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background {
+                if showsBackgroundGradient {
+                    OnboardingScreenBackgroundImage()
+                }
+            }
             .background()
             .environment(\.backgroundStyle, AnyShapeStyle(Color.compound.bgCanvasDefault))
             .ignoresSafeArea(edges: .top)
@@ -35,8 +48,11 @@ struct PlaceholderScreen: View {
 
 struct PlaceholderScreen_Previews: PreviewProvider, TestablePreview {
     static var previews: some View {
-        PlaceholderScreen()
+        PlaceholderScreen(showsBackgroundGradient: false)
             .previewDisplayName("Screen")
+        
+        PlaceholderScreen(showsBackgroundGradient: true)
+            .previewDisplayName("With background")
         
         NavigationSplitView {
             List {
@@ -45,7 +61,7 @@ struct PlaceholderScreen_Previews: PreviewProvider, TestablePreview {
                 }
             }
         } detail: {
-            PlaceholderScreen()
+            PlaceholderScreen(showsBackgroundGradient: false)
         }
         .previewDisplayName("Split View")
         .previewInterfaceOrientation(.landscapeLeft)

--- a/UnitTests/__Snapshots__/PreviewTests/test_placeholderScreen.With-background.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_placeholderScreen.With-background.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ef95f8bd9bac10ef7d41dc421fffa2a207de434f2e3bc0fffe01da099445fe6
-size 1002179

--- a/UnitTests/__Snapshots__/PreviewTests/test_placeholderScreen.With-background.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_placeholderScreen.With-background.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ef95f8bd9bac10ef7d41dc421fffa2a207de434f2e3bc0fffe01da099445fe6
+size 1002179


### PR DESCRIPTION
The designs have a gradient in the background of the placeholder when the app is shown in the app switcher and this was missing from the implementation. This PR fixes that.