### PR TITLE
Fix: release audio session after playback ends

### DIFF
--- a/ElementX/Sources/Services/Audio/Player/AudioPlayer.swift
+++ b/ElementX/Sources/Services/Audio/Player/AudioPlayer.swift
@@ -157,7 +157,6 @@ class AudioPlayer: NSObject, AudioPlayerProtocol {
     }
     
     private func releaseAudioSession() {
-        releaseAudioSessionTask?.cancel()
         releaseAudioSessionTask = nil
         if audioSession.category == .playback, !audioSession.isOtherAudioPlaying {
             MXLog.info("releasing audio session")


### PR DESCRIPTION
This PR releases the audio session using a cancellable task when the playback ends