### PR TITLE
Update the SDK, minor version, handle API break

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -6247,7 +6247,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				KEYCHAIN_ACCESS_GROUP_IDENTIFIER = "$(AppIdentifierPrefix)$(BASE_BUNDLE_IDENTIFIER)";
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 1.3.4;
+				MARKETING_VERSION = 1.4.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -6322,7 +6322,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				KEYCHAIN_ACCESS_GROUP_IDENTIFIER = "$(AppIdentifierPrefix)$(BASE_BUNDLE_IDENTIFIER)";
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 1.3.4;
+				MARKETING_VERSION = 1.4.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -6596,7 +6596,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "0.0.1-october23";
+				version = "0.0.2-october23";
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -129,8 +129,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "f53f5302ddcd81e4134fa7437fedd5c33cd7c1bf",
-        "version" : "0.0.1-october23"
+        "revision" : "48f7062bd94debe766820a28c77f40a6e51900c3",
+        "version" : "0.0.2-october23"
       }
     },
     {
@@ -262,7 +262,7 @@
     {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
+      "location" : "https://github.com/siteline/SwiftUI-Introspect",
       "state" : {
         "revision" : "b94da693e57eaf79d16464b8b7c90d09cba4e290",
         "version" : "0.9.2"

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -2697,17 +2697,22 @@ class SecureBackupControllerMock: SecureBackupControllerProtocol {
             return isLastSessionReturnValue
         }
     }
-    //MARK: - waitForKeyBackup
+    //MARK: - waitForKeyBackupUpload
 
-    var waitForKeyBackupCallsCount = 0
-    var waitForKeyBackupCalled: Bool {
-        return waitForKeyBackupCallsCount > 0
+    var waitForKeyBackupUploadCallsCount = 0
+    var waitForKeyBackupUploadCalled: Bool {
+        return waitForKeyBackupUploadCallsCount > 0
     }
-    var waitForKeyBackupClosure: (() async -> Void)?
+    var waitForKeyBackupUploadReturnValue: Result<Void, SecureBackupControllerError>!
+    var waitForKeyBackupUploadClosure: (() async -> Result<Void, SecureBackupControllerError>)?
 
-    func waitForKeyBackup() async {
-        waitForKeyBackupCallsCount += 1
-        await waitForKeyBackupClosure?()
+    func waitForKeyBackupUpload() async -> Result<Void, SecureBackupControllerError> {
+        waitForKeyBackupUploadCallsCount += 1
+        if let waitForKeyBackupUploadClosure = waitForKeyBackupUploadClosure {
+            return await waitForKeyBackupUploadClosure()
+        } else {
+            return waitForKeyBackupUploadReturnValue
+        }
     }
 }
 class SessionVerificationControllerProxyMock: SessionVerificationControllerProxyProtocol {

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupLogoutConfirmationScreen/SecureBackupLogoutConfirmationScreenModels.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupLogoutConfirmationScreen/SecureBackupLogoutConfirmationScreenModels.swift
@@ -30,6 +30,15 @@ enum SecureBackupLogoutConfirmationScreenViewMode {
 
 struct SecureBackupLogoutConfirmationScreenViewState: BindableState {
     var mode: SecureBackupLogoutConfirmationScreenViewMode
+    var bindings = SecureBackupLogoutConfirmationScreenBindings()
+}
+
+struct SecureBackupLogoutConfirmationScreenBindings {
+    var alertInfo: AlertInfo<SecureBackupLogoutConfirmationScreenAlertType>?
+}
+
+enum SecureBackupLogoutConfirmationScreenAlertType {
+    case backupUploadFailed
 }
 
 enum SecureBackupLogoutConfirmationScreenViewAction {

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupLogoutConfirmationScreen/View/SecureBackupLogoutConfirmationScreen.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupLogoutConfirmationScreen/View/SecureBackupLogoutConfirmationScreen.swift
@@ -33,6 +33,7 @@ struct SecureBackupLogoutConfirmationScreen: View {
             .toolbar { toolbar }
             .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
             .safeAreaInset(edge: .bottom) { footer.padding() }
+            .alert(item: $context.alertInfo)
         }
     }
     

--- a/ElementX/Sources/Services/SecureBackup/SecureBackupControllerProtocol.swift
+++ b/ElementX/Sources/Services/SecureBackup/SecureBackupControllerProtocol.swift
@@ -45,6 +45,8 @@ enum SecureBackupControllerError: Error {
     case failedConfirmingRecoveryKey
     
     case failedFetchingSessionState
+    
+    case failedUploadingForBackup
 }
 
 // sourcery: AutoMockable
@@ -61,7 +63,7 @@ protocol SecureBackupControllerProtocol {
     
     func isLastSession() async -> Result<Bool, SecureBackupControllerError>
     
-    func waitForKeyBackup() async
+    func waitForKeyBackupUpload() async -> Result<Void, SecureBackupControllerError>
 }
 
 extension SecureBackupControllerMock {

--- a/project.yml
+++ b/project.yml
@@ -29,7 +29,7 @@ settings:
   APP_NAME: ElementX
   APP_DISPLAY_NAME: Element X
   KEYCHAIN_ACCESS_GROUP_IDENTIFIER: $(AppIdentifierPrefix)$(BASE_BUNDLE_IDENTIFIER)
-  MARKETING_VERSION: 1.3.4
+  MARKETING_VERSION: 1.4.0
   CURRENT_PROJECT_VERSION: 1
   DEVELOPMENT_TEAM: 7J4U792NQT
 
@@ -45,7 +45,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 0.0.1-october23
+    exactVersion: 0.0.2-october23
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/vector-im/compound-ios


### PR DESCRIPTION
The PR updates the SDK to `v0.0.2-october23` which is built from the tag `0.7.0-recovery-alpha`, handling a small an API change. Additionally it bumps the app to version 1.4.0 for the release.

Fixes #1975.