### PR TITLE
Set the App Lock grace period to 0.

### DIFF
--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -124,7 +124,7 @@ final class AppSettings {
     /// The app must be locked with a PIN code as part of the authentication flow.
     let appLockIsMandatory = false
     /// The amount of time the app can remain in the background for without requesting the PIN/TouchID/FaceID.
-    let appLockGracePeriod: TimeInterval = 180
+    let appLockGracePeriod: TimeInterval = 0
     /// Any codes that the user isn't allowed to use for their PIN.
     let appLockPINCodeBlockList = ["0000", "1234"]
     /// The number of attempts the user has made to unlock the app with a PIN code (resets when unlocked).

--- a/changelog.d/2011.change
+++ b/changelog.d/2011.change
@@ -1,0 +1,1 @@
+Set the App Lock grace period to 0.


### PR DESCRIPTION
We decided to disable the grace period for our builds and forks can change the build setting to get their desired behaviour. Fixes #2011.