### PR TITLE
Debounce PIN entry to show the last digit before submitting.

### DIFF
--- a/ElementX/Sources/Screens/AppLock/AppLockScreen/AppLockScreenModels.swift
+++ b/ElementX/Sources/Screens/AppLock/AppLockScreen/AppLockScreenModels.swift
@@ -60,8 +60,6 @@ enum AppLockScreenAlertType {
 }
 
 enum AppLockScreenViewAction {
-    /// Attempt to unlock the app with the supplied PIN code.
-    case submitPINCode
     /// Clears the PIN code after a failure animation.
     case clearPINCode
     /// The user didn't heed the warnings and can't remember their PIN.

--- a/ElementX/Sources/Screens/AppLock/AppLockScreen/View/AppLockScreen.swift
+++ b/ElementX/Sources/Screens/AppLock/AppLockScreen/View/AppLockScreen.swift
@@ -49,10 +49,6 @@ struct AppLockScreen: View {
                     .accessibilityValue(L10n.a11yDigitsEntered(context.viewState.numberOfDigitsEntered))
                 
                 AppLockScreenPINKeypad(pinCode: $context.pinCode)
-                    .onChange(of: context.pinCode) { newValue in
-                        guard newValue.count == 4 else { return }
-                        context.send(viewAction: .submitPINCode)
-                    }
             }
         } bottomContent: {
             Button(L10n.screenAppLockForgotPin) {

--- a/ElementX/Sources/Screens/AppLock/AppLockSetupPINScreen/AppLockSetupPINScreenModels.swift
+++ b/ElementX/Sources/Screens/AppLock/AppLockSetupPINScreen/AppLockSetupPINScreenModels.swift
@@ -88,8 +88,6 @@ enum AppLockSetupPINScreenAlertType {
 }
 
 enum AppLockSetupPINScreenViewAction {
-    /// Confirm the entered PIN.
-    case submitPINCode
     /// Stop entering a PIN.
     case cancel
 }

--- a/ElementX/Sources/Screens/AppLock/AppLockSetupPINScreen/View/AppLockSetupPINScreen.swift
+++ b/ElementX/Sources/Screens/AppLock/AppLockSetupPINScreen/View/AppLockSetupPINScreen.swift
@@ -43,10 +43,6 @@ struct AppLockSetupPINScreen: View {
                 PINTextField(pinCode: $context.pinCode,
                              isSecure: context.viewState.mode == .unlock)
                     .focused($textFieldFocus)
-                    .onChange(of: context.pinCode) { newValue in
-                        guard newValue.count == 4 else { return }
-                        context.send(viewAction: .submitPINCode)
-                    }
             }
             .padding(.horizontal, 16)
             .padding(.top, UIConstants.iconTopPaddingToNavigationBar)

--- a/changelog.d/2010.bugfix
+++ b/changelog.d/2010.bugfix
@@ -1,0 +1,1 @@
+Make sure the last digit is visible when entering a PIN.


### PR DESCRIPTION
The PR removes the manual `send(viewAction)` on PIN entry, instead debouncing the input in the viewState and using this to delay the call to submit. The value is slightly lower on the lock screen to align better with the failure nudge and because you don't actually need to read the number, seeing a dot briefly is enough.

Fixes #2010.

https://github.com/vector-im/element-x-ios/assets/6060466/11bf89b4-59ec-4eed-85bf-0cf7a3326215

https://github.com/vector-im/element-x-ios/assets/6060466/d8b12ea7-dba7-487d-ad5e-60a971933762
