### PR TITLE
Add deferred spinner for voice messages

### DIFF
--- a/ElementX/Sources/Other/VoiceMessage/VoiceMessageButton.swift
+++ b/ElementX/Sources/Other/VoiceMessage/VoiceMessageButton.swift
@@ -88,13 +88,13 @@ private struct VoiceMessageButtonStyle: ButtonStyle {
 }
 
 extension VoiceMessageButton.State {
-    init(state: AudioPlayerPlaybackState) {
+    init(_ state: AudioPlayerPlaybackState) {
         switch state {
         case .loading:
             self = .loading
         case .playing:
             self = .playing
-        default:
+        case .stopped, .error, .readyToPlay:
             self = .paused
         }
     }

--- a/ElementX/Sources/Screens/ComposerToolbar/View/VoiceMessagePreviewComposer.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/VoiceMessagePreviewComposer.swift
@@ -43,7 +43,7 @@ struct VoiceMessagePreviewComposer: View {
     var body: some View {
         HStack {
             HStack {
-                VoiceMessageButton(state: .init(playerState.delayedLoaderPlaybackState),
+                VoiceMessageButton(state: .init(playerState.playerButtonPlaybackState),
                                    size: .small,
                                    action: onPlayPause)
                 Text(timeLabelContent)

--- a/ElementX/Sources/Screens/ComposerToolbar/View/VoiceMessagePreviewComposer.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/VoiceMessagePreviewComposer.swift
@@ -43,7 +43,7 @@ struct VoiceMessagePreviewComposer: View {
     var body: some View {
         HStack {
             HStack {
-                VoiceMessageButton(state: .init(state: playerState.playbackState),
+                VoiceMessageButton(state: .init(playerState.delayedLoaderPlaybackState),
                                    size: .small,
                                    action: onPlayPause)
                 Text(timeLabelContent)

--- a/ElementX/Sources/Services/Audio/Player/AudioPlayerState.swift
+++ b/ElementX/Sources/Services/Audio/Player/AudioPlayerState.swift
@@ -39,7 +39,7 @@ class AudioPlayerState: ObservableObject, Identifiable {
     @Published private(set) var playbackState: AudioPlayerPlaybackState
     /// It's similar to `playbackState`, with the a difference: `.loading`
     /// updates are delayed by a fixed amount of time
-    @Published private(set) var delayedLoaderPlaybackState: AudioPlayerPlaybackState
+    @Published private(set) var playerButtonPlaybackState: AudioPlayerPlaybackState
     @Published private(set) var progress: Double
     @Published private(set) var showProgressIndicator: Bool
 
@@ -67,7 +67,7 @@ class AudioPlayerState: ObservableObject, Identifiable {
         self.progress = progress
         showProgressIndicator = false
         playbackState = .stopped
-        delayedLoaderPlaybackState = .stopped
+        playerButtonPlaybackState = .stopped
         setupPlaybackStateSubscription()
     }
     
@@ -196,7 +196,7 @@ class AudioPlayerState: ObservableObject, Identifiable {
             }
             .switchToLatest()
             .removeDuplicates()
-            .weakAssign(to: \.delayedLoaderPlaybackState, on: self)
+            .weakAssign(to: \.playerButtonPlaybackState, on: self)
     }
 }
 

--- a/ElementX/Sources/Services/Audio/Player/AudioPlayerState.swift
+++ b/ElementX/Sources/Services/Audio/Player/AudioPlayerState.swift
@@ -186,11 +186,11 @@ class AudioPlayerState: ObservableObject, Identifiable {
             .map { state in
                 switch state {
                 case .loading:
-                    Just(state)
+                    return Just(state)
                         .delay(for: .seconds(2), scheduler: RunLoop.main)
                         .eraseToAnyPublisher()
                 case .playing, .stopped, .error, .readyToPlay:
-                    Just(state)
+                    return Just(state)
                         .eraseToAnyPublisher()
                 }
             }

--- a/ElementX/Sources/Services/Audio/Player/AudioPlayerState.swift
+++ b/ElementX/Sources/Services/Audio/Player/AudioPlayerState.swift
@@ -37,11 +37,15 @@ class AudioPlayerState: ObservableObject, Identifiable {
     let duration: Double
     let waveform: EstimatedWaveform
     @Published private(set) var playbackState: AudioPlayerPlaybackState
+    /// It's similar to `playbackState`, with the a difference: `.loading`
+    /// updates are delayed by a fixed amount of time
+    @Published private(set) var delayedLoaderPlaybackState: AudioPlayerPlaybackState
     @Published private(set) var progress: Double
     @Published private(set) var showProgressIndicator: Bool
 
     private weak var audioPlayer: AudioPlayerProtocol?
-    private var cancellables: Set<AnyCancellable> = []
+    private var audioPlayerSubscription: AnyCancellable?
+    private var playbackStateSubscription: AnyCancellable?
     private var displayLink: CADisplayLink?
 
     /// The file url that the last player attached to this object has loaded.
@@ -63,6 +67,8 @@ class AudioPlayerState: ObservableObject, Identifiable {
         self.progress = progress
         showProgressIndicator = false
         playbackState = .stopped
+        delayedLoaderPlaybackState = .stopped
+        setupPlaybackStateSubscription()
     }
     
     deinit {
@@ -99,7 +105,7 @@ class AudioPlayerState: ObservableObject, Identifiable {
     func detachAudioPlayer() {
         audioPlayer?.stop()
         stopPublishProgress()
-        cancellables = []
+        audioPlayerSubscription = nil
         audioPlayer = nil
         playbackState = .stopped
         showProgressIndicator = false
@@ -112,7 +118,7 @@ class AudioPlayerState: ObservableObject, Identifiable {
     // MARK: - Private
     
     private func subscribeToAudioPlayer(audioPlayer: AudioPlayerProtocol) {
-        audioPlayer.actions
+        audioPlayerSubscription = audioPlayer.actions
             .receive(on: DispatchQueue.main)
             .sink { [weak self] action in
                 guard let self else {
@@ -122,7 +128,6 @@ class AudioPlayerState: ObservableObject, Identifiable {
                     await self.handleAudioPlayerAction(action)
                 }
             }
-            .store(in: &cancellables)
     }
     
     private func handleAudioPlayerAction(_ action: AudioPlayerAction) async {
@@ -174,6 +179,24 @@ class AudioPlayerState: ObservableObject, Identifiable {
     
     private func restoreAudioPlayerState(audioPlayer: AudioPlayerProtocol) async {
         await audioPlayer.seek(to: progress)
+    }
+    
+    private func setupPlaybackStateSubscription() {
+        playbackStateSubscription = $playbackState
+            .map { state in
+                switch state {
+                case .loading:
+                    Just(state)
+                        .delay(for: .seconds(2), scheduler: RunLoop.main)
+                        .eraseToAnyPublisher()
+                case .playing, .stopped, .error, .readyToPlay:
+                    Just(state)
+                        .eraseToAnyPublisher()
+                }
+            }
+            .switchToLatest()
+            .removeDuplicates()
+            .weakAssign(to: \.delayedLoaderPlaybackState, on: self)
     }
 }
 

--- a/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineController/RoomTimelineController.swift
@@ -409,8 +409,10 @@ class RoomTimelineController: RoomTimelineControllerProtocol {
                     guard let playerState = mediaPlayerProvider.playerState(for: .timelineItemIdentifier(timelineItem.id)) else {
                         continue
                     }
-                    playerState.detachAudioPlayer()
-                    mediaPlayerProvider.unregister(audioPlayerState: playerState)
+                    Task { @MainActor in
+                        playerState.detachAudioPlayer()
+                        mediaPlayerProvider.unregister(audioPlayerState: playerState)
+                    }
                 }
 
                 newTimelineItems.append(timelineItem)

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomPlaybackView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomPlaybackView.swift
@@ -43,7 +43,7 @@ struct VoiceMessageRoomPlaybackView: View {
     var body: some View {
         HStack {
             HStack {
-                VoiceMessageButton(state: .init(state: playerState.playbackState),
+                VoiceMessageButton(state: .init(playerState.delayedLoaderPlaybackState),
                                    size: .medium,
                                    action: onPlayPause)
                 Text(timeLabelContent)

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomPlaybackView.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Messages/VoiceMessages/VoiceMessageRoomPlaybackView.swift
@@ -43,7 +43,7 @@ struct VoiceMessageRoomPlaybackView: View {
     var body: some View {
         HStack {
             HStack {
-                VoiceMessageButton(state: .init(playerState.delayedLoaderPlaybackState),
+                VoiceMessageButton(state: .init(playerState.playerButtonPlaybackState),
                                    size: .medium,
                                    action: onPlayPause)
                 Text(timeLabelContent)

--- a/UnitTests/Sources/AudioPlayerStateTests.swift
+++ b/UnitTests/Sources/AudioPlayerStateTests.swift
@@ -74,9 +74,9 @@ class AudioPlayerStateTests: XCTestCase {
         
         XCTAssert(audioPlayerState.isAttached)
         XCTAssertEqual(audioPlayerState.playbackState, .loading)
-        XCTAssertEqual(audioPlayerState.delayedLoaderPlaybackState, .stopped)
+        XCTAssertEqual(audioPlayerState.playerButtonPlaybackState, .stopped)
         
-        let deferred = deferFulfillment(audioPlayerState.$delayedLoaderPlaybackState) { output in
+        let deferred = deferFulfillment(audioPlayerState.$playerButtonPlaybackState) { output in
             switch output {
             case .loading:
                 return true
@@ -86,15 +86,15 @@ class AudioPlayerStateTests: XCTestCase {
         }
         try await deferred.fulfill()
         
-        XCTAssertEqual(audioPlayerState.delayedLoaderPlaybackState, .loading)
+        XCTAssertEqual(audioPlayerState.playerButtonPlaybackState, .loading)
     }
     
     func testOtherActionsAreNotDelayed() async throws {
         audioPlayerState.attachAudioPlayer(audioPlayerMock)
         XCTAssertEqual(audioPlayerState.playbackState, .loading)
-        XCTAssertEqual(audioPlayerState.delayedLoaderPlaybackState, .stopped)
+        XCTAssertEqual(audioPlayerState.playerButtonPlaybackState, .stopped)
         
-        let deferred = deferFulfillment(audioPlayerState.$delayedLoaderPlaybackState) { output in
+        let deferred = deferFulfillment(audioPlayerState.$playerButtonPlaybackState) { output in
             switch output {
             case .playing:
                 return true
@@ -106,7 +106,7 @@ class AudioPlayerStateTests: XCTestCase {
         audioPlayerActionsSubject.send(.didStartPlaying)
         try await deferred.fulfill()
         XCTAssertEqual(audioPlayerState.playbackState, .playing)
-        XCTAssertEqual(audioPlayerState.delayedLoaderPlaybackState, .playing)
+        XCTAssertEqual(audioPlayerState.playerButtonPlaybackState, .playing)
     }
     
     func testReportError() async throws {

--- a/UnitTests/Sources/AudioPlayerStateTests.swift
+++ b/UnitTests/Sources/AudioPlayerStateTests.swift
@@ -69,6 +69,26 @@ class AudioPlayerStateTests: XCTestCase {
         XCTAssertFalse(audioPlayerState.showProgressIndicator)
     }
     
+    func testDelayedState() async throws {
+        audioPlayerState.attachAudioPlayer(audioPlayerMock)
+        
+        XCTAssert(audioPlayerState.isAttached)
+        XCTAssertEqual(audioPlayerState.playbackState, .loading)
+        XCTAssertEqual(audioPlayerState.delayedLoaderPlaybackState, .stopped)
+        
+        let deferred = deferFulfillment(audioPlayerState.$delayedLoaderPlaybackState) { output in
+            switch output {
+            case .loading:
+                return true
+            default:
+                return false
+            }
+        }
+        try await deferred.fulfill()
+        
+        XCTAssertEqual(audioPlayerState.delayedLoaderPlaybackState, .loading)
+    }
+    
     func testReportError() async throws {
         XCTAssertEqual(audioPlayerState.playbackState, .stopped)
         audioPlayerState.reportError(AudioPlayerError.genericError)

--- a/UnitTests/Sources/AudioPlayerStateTests.swift
+++ b/UnitTests/Sources/AudioPlayerStateTests.swift
@@ -89,6 +89,26 @@ class AudioPlayerStateTests: XCTestCase {
         XCTAssertEqual(audioPlayerState.delayedLoaderPlaybackState, .loading)
     }
     
+    func testOtherActionsAreNotDelayed() async throws {
+        audioPlayerState.attachAudioPlayer(audioPlayerMock)
+        XCTAssertEqual(audioPlayerState.playbackState, .loading)
+        XCTAssertEqual(audioPlayerState.delayedLoaderPlaybackState, .stopped)
+        
+        let deferred = deferFulfillment(audioPlayerState.$delayedLoaderPlaybackState) { output in
+            switch output {
+            case .playing:
+                return true
+            default:
+                return false
+            }
+        }
+        
+        audioPlayerActionsSubject.send(.didStartPlaying)
+        try await deferred.fulfill()
+        XCTAssertEqual(audioPlayerState.playbackState, .playing)
+        XCTAssertEqual(audioPlayerState.delayedLoaderPlaybackState, .playing)
+    }
+    
     func testReportError() async throws {
         XCTAssertEqual(audioPlayerState.playbackState, .stopped)
         audioPlayerState.reportError(AudioPlayerError.genericError)


### PR DESCRIPTION
This PR adds a logic to delay the voice message spinner by two seconds. 
In this way spinners don't show at all when the loading time is less than two seconds.
It also fixes a run time issues caused by the redaction of voice messages.

Tried also to address the problem all in the UI layer [here](https://github.com/vector-im/element-x-ios/compare/alfogrillo/deferred-loader?expand=1).
It works, but maybe the complexity is bigger.