### PR TITLE
Use the custom log level inside the NSE too.

### DIFF
--- a/ElementX/Sources/Other/SharedUserDefaultsKeys.swift
+++ b/ElementX/Sources/Other/SharedUserDefaultsKeys.swift
@@ -15,5 +15,5 @@
 //
 
 enum SharedUserDefaultsKeys: String {
-    case filterNotificationsByPushRulesEnabled
+    case logLevel
 }

--- a/NSE/Sources/NotificationServiceExtension.swift
+++ b/NSE/Sources/NotificationServiceExtension.swift
@@ -46,7 +46,7 @@ class NotificationServiceExtension: UNNotificationServiceExtension {
         handler = contentHandler
         modifiedContent = request.content.mutableCopy() as? UNMutableNotificationContent
 
-        NSELogger.configure()
+        NSELogger.configure(logLevel: settings.logLevel)
 
         NSELogger.logMemory(with: tag)
 

--- a/NSE/Sources/Other/NSELogger.swift
+++ b/NSE/Sources/Other/NSELogger.swift
@@ -75,13 +75,13 @@ class NSELogger {
         return "\(formattedStr) MB"
     }
 
-    static func configure() {
+    static func configure(logLevel: TracingConfiguration.LogLevel) {
         guard !isConfigured else {
             return
         }
         isConfigured = true
 
-        MXLog.configure(target: "nse", logLevel: .info)
+        MXLog.configure(target: "nse", logLevel: logLevel)
     }
 
     static func logMemory(with tag: String) {

--- a/NSE/Sources/Other/NSESettings.swift
+++ b/NSE/Sources/Other/NSESettings.swift
@@ -21,4 +21,8 @@ final class NSESettings {
 
     /// UserDefaults to be used on reads and writes.
     private static var store: UserDefaults! = UserDefaults(suiteName: suiteName)
+
+    /// The log level that should be used by `MXLog`.
+    @UserPreference(key: SharedUserDefaultsKeys.logLevel, defaultValue: TracingConfiguration.LogLevel.info, storageType: .userDefaults(store))
+    var logLevel
 }

--- a/changelog.d/pr-2020.bugfix
+++ b/changelog.d/pr-2020.bugfix
@@ -1,0 +1,1 @@
+Use the custom log level inside the NSE too.


### PR DESCRIPTION
We weren't reading the log level available in Developer Options in the NSE, and instead had it hardcoded to `.info`. This PR fixes that.
