### PR TITLE
Fix an inconsistency in the App Lock screen's background colour.

### DIFF
--- a/ElementX/Sources/Screens/AppLock/AppLockScreen/View/AppLockScreen.swift
+++ b/ElementX/Sources/Screens/AppLock/AppLockScreen/View/AppLockScreen.swift
@@ -56,7 +56,8 @@ struct AppLockScreen: View {
             }
             .font(.compound.bodyMDSemibold)
         }
-        .background(Color.compound.bgCanvasDefault.ignoresSafeArea())
+        .background()
+        .environment(\.backgroundStyle, AnyShapeStyle(Color.compound.bgCanvasDefault))
         .alert(item: $context.alertInfo)
     }
     

--- a/changelog.d/2029.bugfix
+++ b/changelog.d/2029.bugfix
@@ -1,0 +1,1 @@
+Fix an inconsistency in the App Lock screen's background colour.


### PR DESCRIPTION
The bottom content derives its background colour from the environment, but I forgot to inject it. Fixes #2029.

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 14 - 2023-11-06 at 11 12 02](https://github.com/vector-im/element-x-ios/assets/6060466/5e400314-0075-4d7a-adc7-25563c973cd4) | ![Simulator Screenshot - iPhone 14 - 2023-11-06 at 11 12 23](https://github.com/vector-im/element-x-ios/assets/6060466/eeca312b-2477-42d7-bf93-5d38ce6af362) |
