### PR TITLE
Fixes the keyboard being shown when opening an Element call link.

### DIFF
--- a/ElementX/Sources/Application/Windowing/WindowManager.swift
+++ b/ElementX/Sources/Application/Windowing/WindowManager.swift
@@ -66,5 +66,10 @@ class WindowManager {
         alternateWindow.isHidden = false
         overlayWindow.isHidden = true
         mainWindow.isHidden = true
+        
+        // We don't know what route the app will use when returning back
+        // to the main window, so end any editing operation now to avoid
+        // e.g. the keyboard being displayed on top of a call sheet.
+        mainWindow.endEditing(true)
     }
 }

--- a/changelog.d/2025.bugfix
+++ b/changelog.d/2025.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where tapping a call link could open the call with a keyboard obscuring the sheet.


### PR DESCRIPTION
Whilst #2032 fixed an issue on the lockscreen, it was no help with #2025 which turned out to only be a bug with the lockscreen enabled. This PR forces the keyboard to be dismissed every time the main window is hidden, ensuring that whatever route is setup on the next launch, the keyboard will never randomly appear.

Note: There is the possibility of it being annoying that backgrounding the app to copy something and return to paste it requires one extra tap, but as the Screen Lock isn't enabled by default this seems low risk overall.

Fixes #2025.