### PR TITLE
Add UI tests for mandatory PIN setup flow.

### DIFF
--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/View/SecureBackupScreen.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/View/SecureBackupScreen.swift
@@ -150,7 +150,7 @@ struct SecureBackupScreen_Previews: PreviewProvider, TestablePreview {
             }
             .previewDisplayName("Recovery incomplete")
         }
-        .snapshot(delay: 0.25)
+        .snapshot(delay: 0.5)
     }
     
     static func viewModel(keyBackupState: SecureBackupKeyBackupState,

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -162,7 +162,7 @@ class MockScreen: Identifiable {
             let appLockService = AppLockService(keychainController: KeychainControllerMock(), appSettings: ServiceLocator.shared.settings)
             let coordinator = AppLockScreenCoordinator(parameters: .init(appLockService: appLockService))
             return coordinator
-        case .appLockSetupFlow, .appLockSetupFlowUnlock:
+        case .appLockSetupFlow, .appLockSetupFlowUnlock, .appLockSetupFlowMandatory:
             let navigationStackCoordinator = NavigationStackCoordinator()
             // The flow expects an existing root coordinator, use the placeholder as a placeholder 😅
             navigationStackCoordinator.setRootCoordinator(BlankFormCoordinator())
@@ -186,7 +186,8 @@ class MockScreen: Identifiable {
                                                 appSettings: ServiceLocator.shared.settings,
                                                 context: context)
             
-            let coordinator = AppLockSetupFlowCoordinator(presentingFlow: .settings,
+            let flow: AppLockSetupFlowCoordinator.PresentationFlow = id == .appLockSetupFlowMandatory ? .onboarding : .settings
+            let coordinator = AppLockSetupFlowCoordinator(presentingFlow: flow,
                                                           appLockService: appLockService,
                                                           navigationStackCoordinator: navigationStackCoordinator)
             coordinator.start()

--- a/ElementX/Sources/UITests/UITestsScreenIdentifier.swift
+++ b/ElementX/Sources/UITests/UITestsScreenIdentifier.swift
@@ -32,6 +32,7 @@ enum UITestsScreenIdentifier: String {
     case appLockScreen
     case appLockSetupFlow
     case appLockSetupFlowUnlock
+    case appLockSetupFlowMandatory
     case home
     case settings
     case bugReport

--- a/UITests/Sources/AppLockSetupUITests.swift
+++ b/UITests/Sources/AppLockSetupUITests.swift
@@ -82,6 +82,30 @@ class AppLockSetupUITests: XCTestCase {
         try await app.assertScreenshot(.appLockSetupFlow, step: Step.clearedStack)
     }
     
+    func testMandatoryCreateFlow() async throws {
+        app = Application.launch(.appLockSetupFlowMandatory)
+        
+        // Create PIN screen (non-modal and no cancellation button).
+        try await app.assertScreenshot(.appLockSetupFlowMandatory, step: Step.createPIN)
+        
+        enterPIN()
+        
+        // Confirm PIN screen (non-modal and no cancellation button).
+        try await app.assertScreenshot(.appLockSetupFlowMandatory, step: Step.confirmPIN)
+        
+        enterPIN()
+        
+        // Setup biometrics screen (non-modal).
+        try await app.assertScreenshot(.appLockSetupFlowMandatory, step: Step.setupBiometrics)
+        
+        let allowButton = app.buttons[A11yIdentifiers.appLockSetupBiometricsScreen.allow]
+        XCTAssertTrue(allowButton.exists, "The biometrics screen should be shown.")
+        allowButton.tap()
+        
+        // The stack should remain on biometrics for the presenting flow to take over navigation.
+        try await app.assertScreenshot(.appLockSetupFlowMandatory, step: Step.setupBiometrics)
+    }
+    
     func testUnlockFlow() async throws {
         app = Application.launch(.appLockSetupFlowUnlock)
         

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.appLockSetupFlowMandatory-0.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.appLockSetupFlowMandatory-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74c1eef2dee3b8ebf4f913129cf674c17e21a6d12a20d6c2eae8d699966d8040
+size 146418

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.appLockSetupFlowMandatory-1.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.appLockSetupFlowMandatory-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33b9be6c12c0001b6b3c2115a268a39462f44dbb9b518fc32ee1a973166d7786
+size 146102

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.appLockSetupFlowMandatory-2.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.appLockSetupFlowMandatory-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8feec0af9037c406c401a57e26d03e26f4eff43e7a3f43ba34221356c1b722af
+size 90720

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.appLockSetupFlowMandatory-0.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.appLockSetupFlowMandatory-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ea0c189224d0c048d385966c9a5e2d911cc9176379014adefa9b62cbad462db
+size 128199

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.appLockSetupFlowMandatory-1.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.appLockSetupFlowMandatory-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c65a6e90789c3bf126aebe2adf6bef05f0546da9a467f3cb04da2dad98cd52dd
+size 127762

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.appLockSetupFlowMandatory-2.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.appLockSetupFlowMandatory-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a036f0c6082f5d267d4359b42af3d38e0119ef533cb556ef049871f5e1618629
+size 91826

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.appLockSetupFlowMandatory-0.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.appLockSetupFlowMandatory-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70f114ac9bd51da1095b352d1fcf9a16e018e5ac529c8d3bf2d9780bf2525109
+size 164955

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.appLockSetupFlowMandatory-1.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.appLockSetupFlowMandatory-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e720812f57e7f5f29be0d33c52a8a6628a95985c52172e08a2d1f5162d0bd9c
+size 164530

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.appLockSetupFlowMandatory-2.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.appLockSetupFlowMandatory-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59e577b405c86f7bef34d7e244696de5a84a092d5dcff9b0c034edcfd293d55d
+size 105390

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.appLockSetupFlowMandatory-0.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.appLockSetupFlowMandatory-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec887b50b32e86584eabe49019c387eb506c7f619f96239ea3ace251411e03f2
+size 158026

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.appLockSetupFlowMandatory-1.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.appLockSetupFlowMandatory-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2501a44a9cb3457ec861016f5ab3fdcd8a8c2e9b00d2299f1ad902d366ac0b76
+size 157869

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.appLockSetupFlowMandatory-2.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.appLockSetupFlowMandatory-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aab47ddc65fc91df13162586382d94beb77c7391e4481eb4593a265b4179158
+size 115892


### PR DESCRIPTION
Adds the tests for the flow coordinator configuration where the presenting flow is `.onboarding`.