### PR TITLE
Don't show the call button on macOS

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -155,8 +155,10 @@ struct RoomScreen: View {
             RoomHeaderView(context: context)
         }
         
-        ToolbarItem(placement: .primaryAction) {
-            callButton
+        if !ProcessInfo.processInfo.isiOSAppOnMac {
+            ToolbarItem(placement: .primaryAction) {
+                callButton
+            }
         }
     }
     

--- a/changelog.d/pr-2064.bugfix
+++ b/changelog.d/pr-2064.bugfix
@@ -1,0 +1,1 @@
+Don't show the call button on macOS.


### PR DESCRIPTION
Calls don't work in the web view on macOS and currently clicking the button shows you both the error, and for some reason, redirects you to FaceTime 🙃

Note: CI failures handled in #2067.