### PR TITLE
Fix for UI tests now showing the status bar.

### DIFF
--- a/ElementX/Sources/Other/UserIndicator/UserIndicatorController.swift
+++ b/ElementX/Sources/Other/UserIndicator/UserIndicatorController.swift
@@ -42,7 +42,7 @@ class UserIndicatorController: ObservableObject, UserIndicatorControllerProtocol
     
     var window: UIWindow? {
         didSet {
-            let hostingController = UIHostingController(rootView: UserIndicatorPresenter(userIndicatorController: self))
+            let hostingController = UIHostingController(rootView: UserIndicatorPresenter(userIndicatorController: self).statusBarHidden(ProcessInfo.isRunningUITests))
             hostingController.view.backgroundColor = .clear
             window?.rootViewController = hostingController
         }

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -35,7 +35,7 @@ class UITestsAppCoordinator: AppCoordinatorProtocol, WindowManagerDelegate {
         
         windowManager.delegate = self
         
-        ServiceLocator.shared.register(userIndicatorController: UserIndicatorControllerMock.default)
+        ServiceLocator.shared.register(userIndicatorController: UserIndicatorController())
         
         AppSettings.configureWithSuiteName("io.element.elementx.uitests")
         AppSettings.reset()
@@ -63,8 +63,10 @@ class UITestsAppCoordinator: AppCoordinatorProtocol, WindowManagerDelegate {
     }
     
     func windowManagerDidConfigureWindows(_ windowManager: WindowManager) {
-        guard let screenID = ProcessInfo.testScreenID, screenID == .appLockFlow || screenID == .appLockFlowDisabled else { return }
+        ServiceLocator.shared.userIndicatorController.window = windowManager.overlayWindow
         
+        // Set up the alternate window for the App Lock flow coordinator tests.
+        guard let screenID = ProcessInfo.testScreenID, screenID == .appLockFlow || screenID == .appLockFlowDisabled else { return }
         let screen = MockScreen(id: screenID == .appLockFlow ? .appLockFlowAlternateWindow : .appLockFlowDisabledAlternateWindow, windowManager: windowManager)
         windowManager.alternateWindow.rootViewController = UIHostingController(rootView: screen.coordinator.toPresentable().statusBarHidden())
         alternateWindowMockScreen = screen

--- a/changelog.d/pr-2065.bugfix
+++ b/changelog.d/pr-2065.bugfix
@@ -1,0 +1,1 @@
+Fix for the status bar being visible during UI tests.


### PR DESCRIPTION
Now that we've hooked up the window manager, the overlay window is shown in UI tests. This has resulted in all of the screens being presented with the status bar visible. This PR fixes that.

Note: CI failures handled in #2067.