### PR TITLE
Fixes #1619 - Remove push notification registration on logout

### DIFF
--- a/ElementX/Sources/Application/AppCoordinator.swift
+++ b/ElementX/Sources/Application/AppCoordinator.swift
@@ -527,10 +527,12 @@ class AppCoordinator: AppCoordinatorProtocol, AuthenticationCoordinatorDelegate,
             return
         }
         
-        // The user will log out, clear any existing notifications
+        // The user will log out, clear any existing notifications and unregister from receving new ones
         UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
         UNUserNotificationCenter.current().removeAllDeliveredNotifications()
         UIApplication.shared.applicationIconBadgeNumber = 0
+        
+        unregisterForRemoteNotifications()
         
         Task {
             // First log out from the server

--- a/ElementX/Sources/Other/Logging/MXLogger.swift
+++ b/ElementX/Sources/Other/Logging/MXLogger.swift
@@ -21,7 +21,7 @@ import UIKit
 /// is called. The pool contains 3 files.
 ///
 /// `MXLogger` can track and log uncaught exceptions or crashes.
-class MXLogger {
+enum MXLogger {
     /// stderr so it can be restored.
     static var stderrSave: Int32 = 0
     

--- a/ElementX/Sources/Screens/Authentication/UIConstants.swift
+++ b/ElementX/Sources/Screens/Authentication/UIConstants.swift
@@ -17,7 +17,7 @@
 import SwiftUI
 
 /// Standard constants used across the app's UI.
-struct UIConstants {
+enum UIConstants {
     static let maxContentHeight: CGFloat = 750
     
     /// The padding used between the top of the main content's icon and the navigation bar.

--- a/IntegrationTests/Sources/Application.swift
+++ b/IntegrationTests/Sources/Application.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-struct Application {
+enum Application {
     @discardableResult static func launch() -> XCUIApplication {
         let app = XCUIApplication()
         app.launch()

--- a/NSE/Sources/Other/DataProtectionManager.swift
+++ b/NSE/Sources/Other/DataProtectionManager.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-final class DataProtectionManager {
+enum DataProtectionManager {
     /// Detects after reboot, before unlocked state. Does this by trying to write a file to the filesystem (to the Caches directory) and read it back.
     /// - Parameter containerURL: Container url to write the file.
     /// - Returns: true if the state detected

--- a/NSE/Sources/Other/NSELogger.swift
+++ b/NSE/Sources/Other/NSELogger.swift
@@ -17,7 +17,7 @@
 import Foundation
 import MatrixRustSDK
 
-class NSELogger {
+enum NSELogger {
     private static var isConfigured = false
 
     /// Memory formatter, uses exact 2 fraction digits and no grouping

--- a/UITests/Sources/Application.swift
+++ b/UITests/Sources/Application.swift
@@ -17,7 +17,7 @@
 import SnapshotTesting
 import XCTest
 
-struct Application {
+enum Application {
     static func launch(_ identifier: UITestsScreenIdentifier, disableTimelineAccessibility: Bool = true) -> XCUIApplication {
         let app = XCUIApplication()
         

--- a/changelog.d/1619.bugfix
+++ b/changelog.d/1619.bugfix
@@ -1,0 +1,1 @@
+Remove push notification registration on logout


### PR DESCRIPTION
I believe this should be enough. The app already checks for permissions and re-registers every time it becomes active and I believe that should be more than enough for this edge case