### PR TITLE
Artificial delay when a message fails to send

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -24,6 +24,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     @Environment(\.timelineGroupStyle) private var timelineGroupStyle
     
     let timelineItem: EventBasedTimelineItemProtocol
+    var status: TimelineItemDeliveryStatus?
     @ViewBuilder let content: () -> Content
     
     @State private var showItemActionMenu = false
@@ -62,7 +63,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                         if !timelineItem.isOutgoing {
                             Spacer()
                         }
-                        TimelineItemStatusView(timelineItem: timelineItem)
+                        TimelineItemStatusView(timelineItem: timelineItem, status: status)
                             .environmentObject(context)
                             .padding(.top, 8)
                             .padding(.bottom, 3)
@@ -162,7 +163,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
 
     @ViewBuilder
     var interactiveLocalizedSendInfo: some View {
-        if timelineItem.hasFailedToSend {
+        if status == .sendingFailed {
             layoutedLocalizedSendInfo
                 .onTapGesture {
                     context.sendFailedConfirmationDialogInfo = .init(itemID: timelineItem.id)
@@ -203,12 +204,12 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                 Text(timelineItem.timestamp)
             }
 
-            if timelineItem.hasFailedToSend {
+            if status == .sendingFailed {
                 CompoundIcon(\.error, size: .xSmall, relativeTo: .compound.bodyXS)
             }
         }
         .font(.compound.bodyXS)
-        .foregroundColor(timelineItem.hasFailedToSend ? .compound.textCriticalPrimary : .compound.textSecondary)
+        .foregroundColor(status == .sendingFailed ? .compound.textCriticalPrimary : .compound.textSecondary)
     }
     
     @ViewBuilder

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -24,7 +24,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     @Environment(\.timelineGroupStyle) private var timelineGroupStyle
     
     let timelineItem: EventBasedTimelineItemProtocol
-    let deliveryStatus: TimelineItemDeliveryStatus?
+    let adjustedDeliveryStatus: TimelineItemDeliveryStatus?
     @ViewBuilder let content: () -> Content
     
     @State private var showItemActionMenu = false
@@ -63,7 +63,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                         if !timelineItem.isOutgoing {
                             Spacer()
                         }
-                        TimelineItemStatusView(timelineItem: timelineItem, deliveryStatus: deliveryStatus)
+                        TimelineItemStatusView(timelineItem: timelineItem, adjustedDeliveryStatus: adjustedDeliveryStatus)
                             .environmentObject(context)
                             .padding(.top, 8)
                             .padding(.bottom, 3)
@@ -163,7 +163,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
 
     @ViewBuilder
     var interactiveLocalizedSendInfo: some View {
-        if deliveryStatus == .sendingFailed {
+        if adjustedDeliveryStatus == .sendingFailed {
             layoutedLocalizedSendInfo
                 .onTapGesture {
                     context.sendFailedConfirmationDialogInfo = .init(itemID: timelineItem.id)
@@ -204,12 +204,12 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                 Text(timelineItem.timestamp)
             }
 
-            if deliveryStatus == .sendingFailed {
+            if adjustedDeliveryStatus == .sendingFailed {
                 CompoundIcon(\.error, size: .xSmall, relativeTo: .compound.bodyXS)
             }
         }
         .font(.compound.bodyXS)
-        .foregroundColor(deliveryStatus == .sendingFailed ? .compound.textCriticalPrimary : .compound.textSecondary)
+        .foregroundColor(adjustedDeliveryStatus == .sendingFailed ? .compound.textCriticalPrimary : .compound.textSecondary)
     }
     
     @ViewBuilder

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemBubbledStylerView.swift
@@ -24,7 +24,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
     @Environment(\.timelineGroupStyle) private var timelineGroupStyle
     
     let timelineItem: EventBasedTimelineItemProtocol
-    var status: TimelineItemDeliveryStatus?
+    let deliveryStatus: TimelineItemDeliveryStatus?
     @ViewBuilder let content: () -> Content
     
     @State private var showItemActionMenu = false
@@ -63,7 +63,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                         if !timelineItem.isOutgoing {
                             Spacer()
                         }
-                        TimelineItemStatusView(timelineItem: timelineItem, status: status)
+                        TimelineItemStatusView(timelineItem: timelineItem, deliveryStatus: deliveryStatus)
                             .environmentObject(context)
                             .padding(.top, 8)
                             .padding(.bottom, 3)
@@ -163,7 +163,7 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
 
     @ViewBuilder
     var interactiveLocalizedSendInfo: some View {
-        if status == .sendingFailed {
+        if deliveryStatus == .sendingFailed {
             layoutedLocalizedSendInfo
                 .onTapGesture {
                     context.sendFailedConfirmationDialogInfo = .init(itemID: timelineItem.id)
@@ -204,12 +204,12 @@ struct TimelineItemBubbledStylerView<Content: View>: View {
                 Text(timelineItem.timestamp)
             }
 
-            if status == .sendingFailed {
+            if deliveryStatus == .sendingFailed {
                 CompoundIcon(\.error, size: .xSmall, relativeTo: .compound.bodyXS)
             }
         }
         .font(.compound.bodyXS)
-        .foregroundColor(status == .sendingFailed ? .compound.textCriticalPrimary : .compound.textSecondary)
+        .foregroundColor(deliveryStatus == .sendingFailed ? .compound.textCriticalPrimary : .compound.textSecondary)
     }
     
     @ViewBuilder

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
@@ -22,6 +22,7 @@ struct TimelineItemPlainStylerView<Content: View>: View {
     @Environment(\.timelineGroupStyle) private var timelineGroupStyle
     
     let timelineItem: EventBasedTimelineItemProtocol
+    var status: TimelineItemDeliveryStatus?
     @ViewBuilder let content: () -> Content
     
     @State private var showItemActionMenu = false
@@ -36,7 +37,7 @@ struct TimelineItemPlainStylerView<Content: View>: View {
                     supplementaryViews
                 }
             }
-            TimelineItemStatusView(timelineItem: timelineItem)
+            TimelineItemStatusView(timelineItem: timelineItem, status: status)
                 .environmentObject(context)
         }
     }

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
@@ -22,7 +22,7 @@ struct TimelineItemPlainStylerView<Content: View>: View {
     @Environment(\.timelineGroupStyle) private var timelineGroupStyle
     
     let timelineItem: EventBasedTimelineItemProtocol
-    var status: TimelineItemDeliveryStatus?
+    let deliveryStatus: TimelineItemDeliveryStatus?
     @ViewBuilder let content: () -> Content
     
     @State private var showItemActionMenu = false
@@ -37,7 +37,7 @@ struct TimelineItemPlainStylerView<Content: View>: View {
                     supplementaryViews
                 }
             }
-            TimelineItemStatusView(timelineItem: timelineItem, status: status)
+            TimelineItemStatusView(timelineItem: timelineItem, deliveryStatus: deliveryStatus)
                 .environmentObject(context)
         }
     }

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineItemPlainStylerView.swift
@@ -22,7 +22,7 @@ struct TimelineItemPlainStylerView<Content: View>: View {
     @Environment(\.timelineGroupStyle) private var timelineGroupStyle
     
     let timelineItem: EventBasedTimelineItemProtocol
-    let deliveryStatus: TimelineItemDeliveryStatus?
+    let adjustedDeliveryStatus: TimelineItemDeliveryStatus?
     @ViewBuilder let content: () -> Content
     
     @State private var showItemActionMenu = false
@@ -37,7 +37,7 @@ struct TimelineItemPlainStylerView<Content: View>: View {
                     supplementaryViews
                 }
             }
-            TimelineItemStatusView(timelineItem: timelineItem, deliveryStatus: deliveryStatus)
+            TimelineItemStatusView(timelineItem: timelineItem, adjustedDeliveryStatus: adjustedDeliveryStatus)
                 .environmentObject(context)
         }
     }

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyler.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyler.swift
@@ -25,13 +25,13 @@ struct TimelineStyler<Content: View>: View {
     let timelineItem: EventBasedTimelineItemProtocol
     @ViewBuilder let content: () -> Content
     
-    @State private var deliveryStatus: TimelineItemDeliveryStatus?
+    @State private var adjustedDeliveryStatus: TimelineItemDeliveryStatus?
     @State private var task: Task<Void, Never>?
     
     init(timelineItem: EventBasedTimelineItemProtocol, @ViewBuilder content: @escaping () -> Content) {
         self.timelineItem = timelineItem
         self.content = content
-        _deliveryStatus = State(initialValue: timelineItem.properties.deliveryStatus)
+        _adjustedDeliveryStatus = State(initialValue: timelineItem.properties.deliveryStatus)
     }
 
     var body: some View {
@@ -42,28 +42,28 @@ struct TimelineStyler<Content: View>: View {
                         return
                     }
                     task = Task {
-                        try? await Task.sleep(for: .milliseconds(500))
+                        try? await Task.sleep(for: .milliseconds(700))
                         if !Task.isCancelled {
-                            deliveryStatus = newStatus
+                            adjustedDeliveryStatus = newStatus
                         }
                         task = nil
                     }
                 } else {
                     task?.cancel()
                     task = nil
-                    deliveryStatus = newStatus
+                    adjustedDeliveryStatus = newStatus
                 }
             }
-            .animation(.elementDefault, value: deliveryStatus)
+            .animation(.elementDefault, value: adjustedDeliveryStatus)
     }
     
     @ViewBuilder
     var mainContent: some View {
         switch style {
         case .plain:
-            TimelineItemPlainStylerView(timelineItem: timelineItem, deliveryStatus: deliveryStatus, content: content)
+            TimelineItemPlainStylerView(timelineItem: timelineItem, adjustedDeliveryStatus: adjustedDeliveryStatus, content: content)
         case .bubbles:
-            TimelineItemBubbledStylerView(timelineItem: timelineItem, deliveryStatus: deliveryStatus, content: content)
+            TimelineItemBubbledStylerView(timelineItem: timelineItem, adjustedDeliveryStatus: adjustedDeliveryStatus, content: content)
         }
     }
 }

--- a/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyler.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Style/TimelineStyler.swift
@@ -37,6 +37,7 @@ struct TimelineStyler<Content: View>: View {
                         return
                     }
                     task = Task {
+                        // If there was no prior delivery state we show it as sending
                         if status == nil {
                             status = .sending
                         }

--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineItemStatusView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineItemStatusView.swift
@@ -19,7 +19,7 @@ import SwiftUI
 
 struct TimelineItemStatusView: View {
     let timelineItem: EventBasedTimelineItemProtocol
-    var status: TimelineItemDeliveryStatus?
+    let deliveryStatus: TimelineItemDeliveryStatus?
     @Environment(\.timelineStyle) private var style
     @Environment(\.readReceiptsEnabled) private var readReceiptsEnabled
     @EnvironmentObject private var context: RoomScreenViewModel.Context
@@ -37,13 +37,13 @@ struct TimelineItemStatusView: View {
         if !timelineItem.properties.orderedReadReceipts.isEmpty, readReceiptsEnabled {
             readReceipts
         } else {
-            deliveryStatus
+            deliveryStatusBadge
         }
     }
 
     @ViewBuilder
-    var deliveryStatus: some View {
-        switch status {
+    var deliveryStatusBadge: some View {
+        switch deliveryStatus {
         case .sending:
             TimelineDeliveryStatusView(deliveryStatus: .sending)
         case .sent, .none:

--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineItemStatusView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineItemStatusView.swift
@@ -19,6 +19,7 @@ import SwiftUI
 
 struct TimelineItemStatusView: View {
     let timelineItem: EventBasedTimelineItemProtocol
+    var status: TimelineItemDeliveryStatus?
     @Environment(\.timelineStyle) private var style
     @Environment(\.readReceiptsEnabled) private var readReceiptsEnabled
     @EnvironmentObject private var context: RoomScreenViewModel.Context
@@ -42,7 +43,7 @@ struct TimelineItemStatusView: View {
 
     @ViewBuilder
     var deliveryStatus: some View {
-        switch timelineItem.properties.deliveryStatus {
+        switch status {
         case .sending:
             TimelineDeliveryStatusView(deliveryStatus: .sending)
         case .sent, .none:

--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineItemStatusView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineItemStatusView.swift
@@ -19,7 +19,7 @@ import SwiftUI
 
 struct TimelineItemStatusView: View {
     let timelineItem: EventBasedTimelineItemProtocol
-    let deliveryStatus: TimelineItemDeliveryStatus?
+    let adjustedDeliveryStatus: TimelineItemDeliveryStatus?
     @Environment(\.timelineStyle) private var style
     @Environment(\.readReceiptsEnabled) private var readReceiptsEnabled
     @EnvironmentObject private var context: RoomScreenViewModel.Context
@@ -43,7 +43,7 @@ struct TimelineItemStatusView: View {
 
     @ViewBuilder
     var deliveryStatusBadge: some View {
-        switch deliveryStatus {
+        switch adjustedDeliveryStatus {
         case .sending:
             TimelineDeliveryStatusView(deliveryStatus: .sending)
         case .sent, .none:

--- a/changelog.d/1352.bugfix
+++ b/changelog.d/1352.bugfix
@@ -1,0 +1,1 @@
+Added a small artificial delay when resending a failed message if it fails instantly, for better UX.

--- a/changelog.d/2078.feature
+++ b/changelog.d/2078.feature
@@ -1,0 +1,1 @@
+Added a disclaimer on the Mentions Only option for notifications, so that the user will know if it will work properly or not on their home server.


### PR DESCRIPTION
fixes #1352 

Since in poor internet conditions (or when completely offline) the resend action fails pretty much immediately there is no visual indication that it has failed again. so the idea is to create an artificial delay of about 0.5 seconds when the status transitions to `sendingFailed` to make it look like for a brief moment that is being sent to give a visual cue that the user that the app has actively tried to resend the message

https://github.com/vector-im/element-x-ios/assets/34335419/c15c6dfa-9a64-4acd-b327-9acbe9bbad4c


