### PR TITLE
Fixes #2001 - Simplify room and user avatar preview screens

### DIFF
--- a/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/View/RoomDetailsScreen.swift
@@ -64,7 +64,7 @@ struct RoomDetailsScreen: View {
             }
         }
         .track(screen: .roomDetails)
-        .interactiveQuickLook(item: $context.mediaPreviewItem)
+        .interactiveQuickLook(item: $context.mediaPreviewItem, shouldHideControls: true)
     }
     
     // MARK: - Private

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
@@ -31,7 +31,7 @@ struct RoomMemberDetailsScreen: View {
         .alert(item: $context.ignoreUserAlert, actions: blockUserAlertActions, message: blockUserAlertMessage)
         .alert(item: $context.alertInfo)
         .track(screen: .user)
-        .interactiveQuickLook(item: $context.mediaPreviewItem)
+        .interactiveQuickLook(item: $context.mediaPreviewItem, shouldHideControls: true)
     }
     
     // MARK: - Private


### PR DESCRIPTION
Removes the navigation bar and bottom toolbar.

https://github.com/vector-im/element-x-ios/assets/637564/9e7a7403-9597-4cfa-ad85-202103986a04