### PR TITLE
Secure backup tweaks

### DIFF
--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenViewModel.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/SecureBackupRecoveryKeyScreenViewModel.swift
@@ -72,6 +72,9 @@ class SecureBackupRecoveryKeyScreenViewModel: SecureBackupRecoveryKeyScreenViewM
             state.doneButtonEnabled = true
         case .confirmKey:
             Task {
+                let loadingIndicatorIdentifier = "SecureBackupRecoveryKeyScreen"
+                userIndicatorController.submitIndicator(.init(id: loadingIndicatorIdentifier, type: .modal, title: L10n.commonLoading, persistent: true))
+                
                 switch await secureBackupController.confirmRecoveryKey(state.bindings.confirmationRecoveryKey) {
                 case .success:
                     actionsSubject.send(.done(mode: context.viewState.mode))
@@ -79,6 +82,8 @@ class SecureBackupRecoveryKeyScreenViewModel: SecureBackupRecoveryKeyScreenViewM
                     MXLog.error("Failed confirming recovery key with error: \(error)")
                     state.bindings.alertInfo = .init(id: .init())
                 }
+                
+                userIndicatorController.retractIndicatorWithId(loadingIndicatorIdentifier)
             }
         case .cancel:
             actionsSubject.send(.cancel)

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/View/SecureBackupRecoveryKeyScreen.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupRecoveryKeyScreen/View/SecureBackupRecoveryKeyScreen.swift
@@ -179,7 +179,7 @@ struct SecureBackupRecoveryKeyScreen: View {
                 .foregroundColor(.compound.textPrimary)
                 .font(.compound.bodySM)
             
-            TextField(L10n.screenRecoveryKeyConfirmKeyPlaceholder, text: $context.confirmationRecoveryKey)
+            SecureField(L10n.screenRecoveryKeyConfirmKeyPlaceholder, text: $context.confirmationRecoveryKey)
                 .textContentType(.password) // Not ideal but stops random suggestions
                 .autocapitalization(.none)
                 .disableAutocorrection(true)

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenModels.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/SettingsScreenModels.swift
@@ -41,7 +41,7 @@ struct SettingsScreenViewState: BindableState {
     var accountSessionsListURL: URL?
     var userAvatarURL: URL?
     var userDisplayName: String?
-    var isSessionVerified = false
+    var isSessionVerified: Bool?
     var chatBackupEnabled = false
     var showSecureBackupBadge = false
     var showDeveloperOptions: Bool

--- a/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/SettingsScreen/View/SettingsScreen.swift
@@ -84,9 +84,9 @@ struct SettingsScreen: View {
     
     @ViewBuilder
     private var accountSecuritySection: some View {
-        if !context.viewState.isSessionVerified || context.viewState.chatBackupEnabled {
-            Section {
-                if !context.viewState.isSessionVerified {
+        Section {
+            if let isSessionVerified = context.viewState.isSessionVerified {
+                if !isSessionVerified {
                     ListRow(label: .default(title: L10n.actionCompleteVerification,
                                             icon: \.checkCircle),
                             kind: .button { context.send(viewAction: .sessionVerification) })

--- a/UnitTests/__Snapshots__/PreviewTests/test_secureBackupRecoveryKeyScreen.Incomplete.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_secureBackupRecoveryKeyScreen.Incomplete.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d008d9474ae107ca66f04a476377fdcc310ba5b8af127b6ee93469c67ec0f789
-size 106279
+oid sha256:c1c8b8ebdb1abc2ed1be215b68a63000cd48d6d6ac2f7ff57824bb6536c30d81
+size 106300

--- a/UnitTests/__Snapshots__/PreviewTests/test_settingsScreen.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_settingsScreen.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:895dd83310e0768ff726fb0b737272370700a87c7e1d12bf0588ed63f700b266
-size 175844
+oid sha256:1fb0f5f22637712c94016f1eaebc9e1460a873dfe954df70fd555b6eaff1f131
+size 170780


### PR DESCRIPTION
* Show a loading indicator when confirming the recovery key
* Hide the passphrase characters when confirming the recovery key
* Don't show the settings security section until session verification state is retrieved (async)