### PR TITLE
Fix an animation glitch when signing in on iOS 16.

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
+++ b/ElementX/Sources/Screens/HomeScreen/View/HomeScreen.swift
@@ -40,9 +40,9 @@ struct HomeScreen: View {
                         ForEach(context.viewState.visibleRooms) { room in
                             HomeScreenRoomCell(room: room, context: context, isSelected: false)
                                 .redacted(reason: .placeholder)
+                                .shimmer() // Putting this directly on the LazyVStack creates an accordion animation on iOS 16.
                         }
                     }
-                    .shimmer()
                     .disabled(true)
                 case .empty:
                     HomeScreenEmptyStateLayout(minHeight: geometry.size.height) {

--- a/changelog.d/1807.bugfix
+++ b/changelog.d/1807.bugfix
@@ -1,0 +1,1 @@
+Fix an animation glitch when signing in on iOS 16.


### PR DESCRIPTION
Fixes #1807 which only seems to occur on iOS 16. Maybe building with Xcode 15 will also back-deploy the fix, but this seems good enough for now (there is a small chance that the individual cell animations could become out of sync as they're not coordinated this way).
