### PR TITLE
Fixes #2117 - Disable underlining for links defined in the html body:

### DIFF
--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -92,7 +92,8 @@ struct AttributedStringBuilder: AttributedStringBuilderProtocol {
             DTDefaultFontFamily: defaultFont.familyName,
             DTDefaultFontName: defaultFont.fontName,
             DTDefaultFontSize: defaultFont.pointSize,
-            DTDefaultStyleSheet: DTCSSStylesheet(styleBlock: defaultCSS) as Any
+            DTDefaultStyleSheet: DTCSSStylesheet(styleBlock: defaultCSS) as Any,
+            DTDefaultLinkDecoration: false
         ]
         
         guard let builder = DTHTMLAttributedStringBuilder(html: data, options: parsingOptions, documentAttributes: nil) else {

--- a/UnitTests/__Snapshots__/PreviewTests/test_formattedBodyText.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_formattedBodyText.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b689d76c95de930e792bfbe6ffb86bb9e006958fa77a55ed0aba7ad69432530f
-size 212484
+oid sha256:8388baf6d6dff565d85ce4e75053f465a923e3e3216649e860f8103fe2bf2293
+size 212392

--- a/UnitTests/__Snapshots__/PreviewTests/test_formattedBodyText.2.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_formattedBodyText.2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16ca3e2a15fd004ff1372409fac07bac16ff8b053c72a8e2acc9975afbe9957f
-size 185944
+oid sha256:9995de3534f0a609805d432a56b687debebf954972982d32a4436c335ce66c7a
+size 185873

--- a/changelog.d/2117.bugfix
+++ b/changelog.d/2117.bugfix
@@ -1,0 +1,1 @@
+Disable underlining for links defined in the html body


### PR DESCRIPTION
- https://github.com/Cocoanetics/DTCoreText/issues/898