### PR TITLE
Secure backup tweaks

### DIFF
--- a/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
+++ b/ElementX/Sources/Screens/HomeScreen/HomeScreenViewModel.swift
@@ -85,7 +85,7 @@ class HomeScreenViewModel: HomeScreenViewModelType, HomeScreenViewModelProtocol 
             .sink { [weak self] recoveryKeyState in
                 guard let self, appSettings.chatBackupEnabled else { return }
                 
-                let requiresSecureBackupSetup = recoveryKeyState == .unknown || recoveryKeyState == .disabled || recoveryKeyState == .incomplete
+                let requiresSecureBackupSetup = recoveryKeyState == .disabled || recoveryKeyState == .incomplete
                 
                 state.showUserMenuBadge = requiresSecureBackupSetup
                 state.showSettingsMenuOptionBadge = requiresSecureBackupSetup

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/View/SecureBackupScreen.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/View/SecureBackupScreen.swift
@@ -77,10 +77,12 @@ struct SecureBackupScreen: View {
             ListRow(label: .plain(title: L10n.screenChatBackupKeyBackupActionDisable, role: .destructive), kind: .navigationLink {
                 context.send(viewAction: .keyBackup)
             })
-        case .disabled, .enabling, .unknown:
+        case .disabled, .enabling:
             ListRow(label: .plain(title: L10n.screenChatBackupKeyBackupActionEnable), kind: .navigationLink {
                 context.send(viewAction: .keyBackup)
             })
+        case .unknown:
+            EmptyView()
         }
     }
     

--- a/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/View/SecureBackupScreen.swift
+++ b/ElementX/Sources/Screens/SecureBackup/SecureBackupScreen/View/SecureBackupScreen.swift
@@ -23,7 +23,7 @@ struct SecureBackupScreen: View {
     
     var body: some View {
         Form {
-            if context.viewState.keyBackupState != .enabled {
+            if context.viewState.keyBackupState == .disabled {
                 keyBackupSection
             } else {
                 keyBackupSection


### PR DESCRIPTION
This PR can be reviewed commit by commit

Tweaks how we use rust apis and how we power the UI states:
* if the keybackup state is unknown then we first need to go check if a backup exists remotely
* if unknown we shouldn't present the user with an option to enable backup
* if unknown and recovery key state is incomplete then we should still show the confirm recovery key section
* we shouldn't show avatar badges while states are unknown