### PR TITLE
Read Receipts sheet + enabled RR by default

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -643,6 +643,8 @@
 		A722F426FD81FC67706BB1E0 /* CustomLayoutLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42236480CF0431535EBE8387 /* CustomLayoutLabelStyle.swift */; };
 		A743841F91B62B0E56217B04 /* SecureBackupKeyBackupScreenUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DCB219D7B7B0299358FF81 /* SecureBackupKeyBackupScreenUITests.swift */; };
 		A74438ED16F8683A4B793E6A /* AnalyticsSettingsScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCE3FAF40932AC7C7639AC4 /* AnalyticsSettingsScreenViewModel.swift */; };
+		A7609C5F2B0BAB9700E40AF2 /* ReadReceiptCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7609C5E2B0BAB9700E40AF2 /* ReadReceiptCell.swift */; };
+		A7609C612B0BB7C100E40AF2 /* ReadReceiptsSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7609C602B0BB7C100E40AF2 /* ReadReceiptsSummaryView.swift */; };
 		A7D48E44D485B143AADDB77D /* Strings+Untranslated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A18F6CE4D694D21E4EA9B25 /* Strings+Untranslated.swift */; };
 		A7FD7B992E6EE6E5A8429197 /* RoomSummaryDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142808B69851451AC32A2CEA /* RoomSummaryDetails.swift */; };
 		A816F7087C495D85048AC50E /* RoomMemberDetailsScreenModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6E30BB748F3F480F077969 /* RoomMemberDetailsScreenModels.swift */; };
@@ -1042,7 +1044,7 @@
 		033DB41C51865A2E83174E87 /* target.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = target.yml; sourceTree = "<group>"; };
 		035177BCD8E8308B098AC3C2 /* WindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManager.swift; sourceTree = "<group>"; };
 		0376C429FAB1687C3D905F3E /* MockCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCoder.swift; sourceTree = "<group>"; };
-		0392E3FDE372C9B56FEEED8B /* test_voice_message.m4a */ = {isa = PBXFileReference; path = test_voice_message.m4a; sourceTree = "<group>"; };
+		0392E3FDE372C9B56FEEED8B /* test_voice_message.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = test_voice_message.m4a; sourceTree = "<group>"; };
 		03DD998E523D4EC93C7ED703 /* RoomNotificationSettingsScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomNotificationSettingsScreenViewModelProtocol.swift; sourceTree = "<group>"; };
 		03FABD73FD8086EFAB699F42 /* MediaUploadPreviewScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUploadPreviewScreenViewModelTests.swift; sourceTree = "<group>"; };
 		044E501B8331B339874D1B96 /* CompoundIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundIcon.swift; sourceTree = "<group>"; };
@@ -1103,7 +1105,7 @@
 		127C8472672A5BA09EF1ACF8 /* CurrentValuePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValuePublisher.swift; sourceTree = "<group>"; };
 		12EDAFB64FA5F6812D54F39A /* MigrationScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationScreenViewModel.swift; sourceTree = "<group>"; };
 		12F1E7F9C2BE8BB751037826 /* WaitlistScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitlistScreenCoordinator.swift; sourceTree = "<group>"; };
-		1304D9191300873EADA52D6E /* IntegrationTests.xctestplan */ = {isa = PBXFileReference; path = IntegrationTests.xctestplan; sourceTree = "<group>"; };
+		1304D9191300873EADA52D6E /* IntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = IntegrationTests.xctestplan; sourceTree = "<group>"; };
 		130ED565A078F7E0B59D9D25 /* UNTextInputNotificationResponse+Creator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNTextInputNotificationResponse+Creator.swift"; sourceTree = "<group>"; };
 		13802897C7AFA360EA74C0B0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		1423AB065857FA546444DB15 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
@@ -1523,7 +1525,7 @@
 		8D55702474F279D910D2D162 /* RoomStateEventStringBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStateEventStringBuilder.swift; sourceTree = "<group>"; };
 		8D8169443E5AC5FF71BFB3DB /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8DC2C9E0E15C79BBDA80F0A2 /* TimelineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineStyle.swift; sourceTree = "<group>"; };
-		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; path = UITests.xctestplan; sourceTree = "<group>"; };
+		8E088F2A1B9EC529D3221931 /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
 		8E1BBA73B611EDEEA6E20E05 /* InvitesScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitesScreenModels.swift; sourceTree = "<group>"; };
 		8EC57A32ABC80D774CC663DB /* SettingsScreenUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreenUITests.swift; sourceTree = "<group>"; };
 		8F21ED7205048668BEB44A38 /* AppActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityView.swift; sourceTree = "<group>"; };
@@ -1604,6 +1606,8 @@
 		A6B891A6DA826E2461DBB40F /* PHGPostHogConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHGPostHogConfiguration.swift; sourceTree = "<group>"; };
 		A6C11AD9813045E44F950410 /* ElementCallWidgetDriverProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementCallWidgetDriverProtocol.swift; sourceTree = "<group>"; };
 		A73A07BAEDD74C48795A996A /* AsyncSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncSequence.swift; sourceTree = "<group>"; };
+		A7609C5E2B0BAB9700E40AF2 /* ReadReceiptCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadReceiptCell.swift; sourceTree = "<group>"; };
+		A7609C602B0BB7C100E40AF2 /* ReadReceiptsSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadReceiptsSummaryView.swift; sourceTree = "<group>"; };
 		A7C4EA55DA62F9D0F984A2AE /* CollapsibleTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleTimelineItem.swift; sourceTree = "<group>"; };
 		A861DA5932B128FE1DCB5CE2 /* InviteUsersScreenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteUsersScreenCoordinator.swift; sourceTree = "<group>"; };
 		A8903A9F615BBD0E6D7CD133 /* ApplicationProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationProtocol.swift; sourceTree = "<group>"; };
@@ -1659,7 +1663,7 @@
 		B4CFE236419E830E8946639C /* Analytics+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+SwiftUI.swift"; sourceTree = "<group>"; };
 		B590BD4507D4F0A377FDE01A /* LoadableAvatarImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableAvatarImage.swift; sourceTree = "<group>"; };
 		B5B243E7818E5E9F6A4EDC7A /* NoticeRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeRoomTimelineView.swift; sourceTree = "<group>"; };
-		B61C339A2FDDBD067FF6635C /* ConfettiScene.scn */ = {isa = PBXFileReference; path = ConfettiScene.scn; sourceTree = "<group>"; };
+		B61C339A2FDDBD067FF6635C /* ConfettiScene.scn */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = ConfettiScene.scn; sourceTree = "<group>"; };
 		B6311F21F911E23BE4DF51B4 /* ReadMarkerRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadMarkerRoomTimelineView.swift; sourceTree = "<group>"; };
 		B63B69F9A2BC74DD40DC75C8 /* AdvancedSettingsScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsScreenViewModel.swift; sourceTree = "<group>"; };
 		B697816AF93DA06EC58C5D70 /* WaitlistScreenViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitlistScreenViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -1764,7 +1768,7 @@
 		CD95B3714F806AC9CF9A557B /* ComposerToolbarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerToolbarViewModel.swift; sourceTree = "<group>"; };
 		CDB3227C7A74B734924942E9 /* RoomSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomSummaryProvider.swift; sourceTree = "<group>"; };
 		CEE0E6043EFCF6FD2A341861 /* TimelineReplyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineReplyView.swift; sourceTree = "<group>"; };
-		CEE41494C837AA403A06A5D9 /* UnitTests.xctestplan */ = {isa = PBXFileReference; path = UnitTests.xctestplan; sourceTree = "<group>"; };
+		CEE41494C837AA403A06A5D9 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		CF48AF076424DBC1615C74AD /* AuthenticationServiceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceProxy.swift; sourceTree = "<group>"; };
 		D0140615D2232612C813FD6C /* EncryptedHistoryRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedHistoryRoomTimelineItem.swift; sourceTree = "<group>"; };
 		D071F86CD47582B9196C9D16 /* UserDiscoverySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDiscoverySection.swift; sourceTree = "<group>"; };
@@ -1868,7 +1872,7 @@
 		ECF79FB25E2D4BD6F50CE7C9 /* RoomMembersListScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMembersListScreenViewModel.swift; sourceTree = "<group>"; };
 		ED044D00F2176681CC02CD54 /* HomeScreenRoomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenRoomCell.swift; sourceTree = "<group>"; };
 		ED1D792EB82506A19A72C8DE /* RoomTimelineItemProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTimelineItemProtocol.swift; sourceTree = "<group>"; };
-		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; path = message.caf; sourceTree = "<group>"; };
+		ED482057AE39D5C6D9C5F3D8 /* message.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = message.caf; sourceTree = "<group>"; };
 		ED983D4DCA5AFA6E1ED96099 /* StateRoomTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRoomTimelineView.swift; sourceTree = "<group>"; };
 		EDAA4472821985BF868CC21C /* ServerSelectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionViewModelTests.swift; sourceTree = "<group>"; };
 		EE378083653EF0C9B5E9D580 /* EmoteRoomTimelineItemContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoteRoomTimelineItemContent.swift; sourceTree = "<group>"; };
@@ -1883,7 +1887,7 @@
 		F174A5627CDB3CAF280D1880 /* EmojiPickerScreenModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerScreenModels.swift; sourceTree = "<group>"; };
 		F17EFA1D3D09FC2F9C5E1CB2 /* MediaProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProvider.swift; sourceTree = "<group>"; };
 		F1B8500C152BC59445647DA8 /* UnsupportedRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedRoomTimelineItem.swift; sourceTree = "<group>"; };
-		F2D513D2477B57F90E98EEC0 /* portrait_test_video.mp4 */ = {isa = PBXFileReference; path = portrait_test_video.mp4; sourceTree = "<group>"; };
+		F2D513D2477B57F90E98EEC0 /* portrait_test_video.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = portrait_test_video.mp4; sourceTree = "<group>"; };
 		F31F59030205A6F65B057E1A /* MatrixEntityRegexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixEntityRegexTests.swift; sourceTree = "<group>"; };
 		F348B5F2C12F9D4F4B4D3884 /* VideoRoomTimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRoomTimelineItem.swift; sourceTree = "<group>"; };
 		F36C0A6D59717193F49EA986 /* UserSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionTests.swift; sourceTree = "<group>"; };
@@ -3395,6 +3399,7 @@
 		79023E5904B155E8E2B8B502 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				A7609C5D2B0BAB8400E40AF2 /* ReadReceipts */,
 				422724361B6555364C43281E /* RoomHeaderView.swift */,
 				5221DFDF809142A2D6AC82B9 /* RoomScreen.swift */,
 				4552D3466B1453F287223ADA /* SwipeRightAction.swift */,
@@ -3931,6 +3936,15 @@
 				BC8AA23D4F37CC26564F63C5 /* LayoutMocks.swift */,
 			);
 			path = LayoutTests;
+			sourceTree = "<group>";
+		};
+		A7609C5D2B0BAB8400E40AF2 /* ReadReceipts */ = {
+			isa = PBXGroup;
+			children = (
+				A7609C5E2B0BAB9700E40AF2 /* ReadReceiptCell.swift */,
+				A7609C602B0BB7C100E40AF2 /* ReadReceiptsSummaryView.swift */,
+			);
+			path = ReadReceipts;
 			sourceTree = "<group>";
 		};
 		A78C2592419CA4C76FBA8FD2 /* Application */ = {
@@ -5590,6 +5604,7 @@
 				B721125D17A0BA86794F29FB /* MockServerSelectionScreenState.swift in Sources */,
 				AF2ABA2794E376B64104C964 /* MockSoftLogoutScreenState.swift in Sources */,
 				D8359F67AF3A83516E9083C1 /* MockUserSession.swift in Sources */,
+				A7609C5F2B0BAB9700E40AF2 /* ReadReceiptCell.swift in Sources */,
 				F9842667B68DC6FA1F9ECCBB /* NSItemProvider.swift in Sources */,
 				EA01A06EEDFEF4AE7652E5F3 /* NSRegularExpresion.swift in Sources */,
 				FA2BBAE9FC5E2E9F960C0980 /* NavigationCoordinators.swift in Sources */,
@@ -5769,6 +5784,7 @@
 				E84ADFE9696936C18C2424B5 /* SecureBackupScreen.swift in Sources */,
 				E77FE06B165A38BF1735509F /* SecureBackupScreenCoordinator.swift in Sources */,
 				DA7E867F5EAFF8E20B2EE3B6 /* SecureBackupScreenModels.swift in Sources */,
+				A7609C612B0BB7C100E40AF2 /* ReadReceiptsSummaryView.swift in Sources */,
 				7BF368A78E6D9AFD222F25AF /* SecureBackupScreenViewModel.swift in Sources */,
 				AC90434798E7894370E80E66 /* SecureBackupScreenViewModelProtocol.swift in Sources */,
 				14E99D27628B1A6F0CB46FEA /* SeparatorRoomTimelineItem.swift in Sources */,
@@ -6140,9 +6156,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = (
-					"-DIS_NSE",
-				);
+				OTHER_SWIFT_FLAGS = "-DIS_NSE";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BASE_BUNDLE_IDENTIFIER}.nse";
 				PRODUCT_DISPLAY_NAME = "$(APP_DISPLAY_NAME)";
 				PRODUCT_NAME = NSE;
@@ -6167,9 +6181,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = (
-					"-DIS_MAIN_APP",
-				);
+				OTHER_SWIFT_FLAGS = "-DIS_MAIN_APP";
 				PILLS_UT_TYPE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER).pills";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(APP_NAME)";
@@ -6195,9 +6207,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = (
-					"-DIS_MAIN_APP",
-				);
+				OTHER_SWIFT_FLAGS = "-DIS_MAIN_APP";
 				PILLS_UT_TYPE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER).pills";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BASE_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(APP_NAME)";
@@ -6438,9 +6448,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
-				OTHER_SWIFT_FLAGS = (
-					"-DIS_NSE",
-				);
+				OTHER_SWIFT_FLAGS = "-DIS_NSE";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BASE_BUNDLE_IDENTIFIER}.nse";
 				PRODUCT_DISPLAY_NAME = "$(APP_DISPLAY_NAME)";
 				PRODUCT_NAME = NSE;

--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -10,6 +10,7 @@
 "a11y_poll_end" = "Ended poll";
 "a11y_read_receipts_multiple" = "Read by %1$@ and %2$@";
 "a11y_read_receipts_single" = "Read by %1$@";
+"a11y_read_receipts_tap_to_show_all" = "Tap to show all";
 "a11y_send_files" = "Send files";
 "a11y_show_password" = "Show password";
 "a11y_start_call" = "Start a call";

--- a/ElementX/Sources/Application/AppSettings.swift
+++ b/ElementX/Sources/Application/AppSettings.swift
@@ -266,7 +266,7 @@ final class AppSettings {
     @UserPreference(key: UserDefaultsKeys.userSuggestionsEnabled, defaultValue: false, storageType: .volatile)
     var userSuggestionsEnabled
 
-    @UserPreference(key: UserDefaultsKeys.readReceiptsEnabled, defaultValue: false, storageType: .userDefaults(store))
+    @UserPreference(key: UserDefaultsKeys.readReceiptsEnabled, defaultValue: true, storageType: .userDefaults(store))
     var readReceiptsEnabled
     
     @UserPreference(key: UserDefaultsKeys.swiftUITimelineEnabled, defaultValue: false, storageType: .volatile)

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -44,6 +44,8 @@ public enum L10n {
   public static func a11yReadReceiptsSingle(_ p1: Any) -> String {
     return L10n.tr("Localizable", "a11y_read_receipts_single", String(describing: p1))
   }
+  /// Tap to show all
+  public static var a11yReadReceiptsTapToShowAll: String { return L10n.tr("Localizable", "a11y_read_receipts_tap_to_show_all") }
   /// Send files
   public static var a11ySendFiles: String { return L10n.tr("Localizable", "a11y_send_files") }
   /// Show password

--- a/ElementX/Sources/Other/AvatarSize.swift
+++ b/ElementX/Sources/Other/AvatarSize.swift
@@ -50,6 +50,7 @@ enum UserAvatarSizeOnScreen {
     case memberDetails
     case inviteUsers
     case readReceipt
+    case readReceiptSheet
     case editUserDetails
     case suggestions
 
@@ -57,6 +58,8 @@ enum UserAvatarSizeOnScreen {
         switch self {
         case .readReceipt:
             return 16
+        case .readReceiptSheet:
+            return 32
         case .timeline:
             return 32
         case .home:

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenModels.swift
@@ -96,6 +96,8 @@ enum RoomScreenViewAction {
     case retrySend(itemID: TimelineItemIdentifier)
     case cancelSend(itemID: TimelineItemIdentifier)
     
+    case showReadReceipts(itemID: TimelineItemIdentifier)
+    
     case scrolledToBottom
     
     case poll(RoomScreenViewPollAction)
@@ -160,6 +162,8 @@ struct RoomScreenViewStateBindings {
     var sendFailedConfirmationDialogInfo: SendFailedConfirmationDialogInfo?
     
     var reactionSummaryInfo: ReactionSummaryInfo?
+    
+    var readReceiptsSummaryInfo: ReadReceiptSummaryInfo?
 }
 
 struct TimelineItemActionMenuInfo: Equatable, Identifiable {
@@ -187,6 +191,11 @@ struct ReactionSummaryInfo: Identifiable {
     var id: String {
         selectedKey
     }
+}
+
+struct ReadReceiptSummaryInfo: Identifiable {
+    let orderedReceipts: [ReadReceipt]
+    let id: TimelineItemIdentifier
 }
 
 enum RoomScreenErrorType: Hashable {

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -166,6 +166,8 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
             processAudioAction(audioAction)
         case .presentCall:
             actionsSubject.send(.displayCallScreen)
+        case .showReadReceipts(itemID: let itemID):
+            showReadReceipts(for: itemID)
         }
     }
 
@@ -653,6 +655,17 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
         }
         
         state.bindings.reactionSummaryInfo = .init(reactions: eventTimelineItem.properties.reactions, selectedKey: selectedKey)
+    }
+    
+    // MARK: - Read Receipts
+
+    private func showReadReceipts(for itemID: TimelineItemIdentifier) {
+        guard let timelineItem = timelineController.timelineItems.firstUsingStableID(itemID),
+              let eventTimelineItem = timelineItem as? EventBasedTimelineItemProtocol else {
+            return
+        }
+        
+        state.bindings.readReceiptsSummaryInfo = .init(orderedReceipts: eventTimelineItem.properties.orderedReadReceipts, id: eventTimelineItem.id)
     }
     
     // MARK: - User Indicators

--- a/ElementX/Sources/Screens/RoomScreen/View/ReadReceipts/ReadReceiptCell.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/ReadReceipts/ReadReceiptCell.swift
@@ -40,13 +40,12 @@ struct ReadReceiptCell: View {
                                 avatarSize: .user(on: .readReceiptSheet),
                                 imageProvider: imageProvider)
             VStack(alignment: .leading, spacing: 0) {
-                HStack(spacing: 0) {
+                HStack(spacing: 12) {
                     Text(title)
                         .font(.compound.bodyMDSemibold)
                         .foregroundColor(.compound.textPrimary)
                         .lineLimit(1)
-                    Spacer()
-                        .frame(minWidth: 12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     if let formattedTimestamp = readReceipt.formattedTimestamp {
                         Text(formattedTimestamp)
                             .font(.compound.bodyXS)

--- a/ElementX/Sources/Screens/RoomScreen/View/ReadReceipts/ReadReceiptCell.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/ReadReceipts/ReadReceiptCell.swift
@@ -1,0 +1,87 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+struct ReadReceiptCell: View {
+    let readReceipt: ReadReceipt
+    let memberState: RoomMemberState?
+    let imageProvider: ImageProviderProtocol?
+    
+    private var title: String {
+        memberState?.displayName ?? readReceipt.userID
+    }
+    
+    private var subtitle: String {
+        guard title != readReceipt.userID else {
+            return ""
+        }
+        return readReceipt.userID
+    }
+        
+    var body: some View {
+        HStack(spacing: 12) {
+            LoadableAvatarImage(url: memberState?.avatarURL,
+                                name: memberState?.displayName,
+                                contentID: readReceipt.userID,
+                                avatarSize: .user(on: .readReceiptSheet),
+                                imageProvider: imageProvider)
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 0) {
+                    Text(title)
+                        .font(.compound.bodyMDSemibold)
+                        .foregroundColor(.compound.textPrimary)
+                        .lineLimit(1)
+                    Spacer()
+                    if let formattedTimestamp = readReceipt.formattedTimestamp {
+                        Text(formattedTimestamp)
+                            .font(.compound.bodyXS)
+                            .foregroundColor(.compound.textSecondary)
+                            .lineLimit(1)
+                    }
+                }
+                Text(subtitle)
+                    .font(.compound.bodySM)
+                    .foregroundColor(.compound.textSecondary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 16)
+    }
+}
+
+struct ReadReceiptCell_Previews: PreviewProvider, TestablePreview {
+    static var previews: some View {
+        ReadReceiptCell(readReceipt: .init(userID: "@test:matrix.org",
+                                           formattedTimestamp: "10:00"),
+                        memberState: .init(displayName: "Test",
+                                           avatarURL: nil),
+                        imageProvider: MockMediaProvider())
+            .previewDisplayName("No Image")
+        ReadReceiptCell(readReceipt: .init(userID: "@test:matrix.org",
+                                           formattedTimestamp: "10:00"),
+                        memberState: .init(displayName: "Test",
+                                           avatarURL: URL.documentsDirectory),
+                        imageProvider: MockMediaProvider())
+            .previewDisplayName("With Image")
+        ReadReceiptCell(readReceipt: .init(userID: "@test:matrix.org",
+                                           formattedTimestamp: "10:00"),
+                        memberState: nil,
+                        imageProvider: MockMediaProvider())
+            .previewDisplayName("Loading Member")
+    }
+}

--- a/ElementX/Sources/Screens/RoomScreen/View/ReadReceipts/ReadReceiptCell.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/ReadReceipts/ReadReceiptCell.swift
@@ -46,6 +46,7 @@ struct ReadReceiptCell: View {
                         .foregroundColor(.compound.textPrimary)
                         .lineLimit(1)
                     Spacer()
+                        .frame(minWidth: 12)
                     if let formattedTimestamp = readReceipt.formattedTimestamp {
                         Text(formattedTimestamp)
                             .font(.compound.bodyXS)

--- a/ElementX/Sources/Screens/RoomScreen/View/ReadReceipts/ReadReceiptsSummaryView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/ReadReceipts/ReadReceiptsSummaryView.swift
@@ -1,0 +1,80 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+struct ReadReceiptsSummaryView: View {
+    let orderedReadReceipts: [ReadReceipt]
+    @EnvironmentObject private var context: RoomScreenViewModel.Context
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(L10n.commonSeenBy)
+                .font(.compound.bodyLGSemibold)
+                .foregroundColor(.compound.textPrimary)
+                .padding(.horizontal, 16)
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(orderedReadReceipts) { receipt in
+                        ReadReceiptCell(readReceipt: receipt,
+                                        memberState: context.viewState.members[receipt.userID],
+                                        imageProvider: context.imageProvider)
+                    }
+                }
+            }
+        }
+        .padding(.top, 24)
+        .presentationDetents([.medium, .large])
+        .presentationBackground(Color.compound.bgCanvasDefault)
+        .presentationDragIndicator(.visible)
+    }
+}
+
+struct ReadReceiptsSummaryView_Previews: PreviewProvider, TestablePreview {
+    static let viewModel = {
+        let members: [RoomMemberProxyMock] = [
+            .mockAlice,
+            .mockBob,
+            .mockCharlie,
+            .mockDan
+        ]
+        let roomProxyMock = RoomProxyMock(with: .init(displayName: "Room", members: members))
+        let mock = RoomScreenViewModel(roomProxy: roomProxyMock,
+                                       timelineController: MockRoomTimelineController(),
+                                       mediaProvider: MockMediaProvider(),
+                                       mediaPlayerProvider: MediaPlayerProviderMock(),
+                                       voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
+                                       userIndicatorController: UserIndicatorControllerMock(),
+                                       application: ApplicationMock(),
+                                       appSettings: ServiceLocator.shared.settings,
+                                       analyticsService: ServiceLocator.shared.analytics,
+                                       notificationCenter: NotificationCenterMock())
+        return mock
+    }()
+    
+    static let orderedReadReceipts: [ReadReceipt] = [
+        .init(userID: "@alice:matrix.org", formattedTimestamp: "10:00"),
+        .init(userID: "@bob:matrix.org", formattedTimestamp: "9:30"),
+        .init(userID: "@charlie:matrix.org", formattedTimestamp: "9:00"),
+        .init(userID: "@dan:matrix.org", formattedTimestamp: "8:30"),
+        .init(userID: "@loading:matrix.org", formattedTimestamp: "Long time ago")
+    ]
+    
+    static var previews: some View {
+        ReadReceiptsSummaryView(orderedReadReceipts: orderedReadReceipts)
+            .environmentObject(viewModel.context)
+    }
+}

--- a/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/RoomScreen.swift
@@ -65,6 +65,10 @@ struct RoomScreen: View {
                 ReactionsSummaryView(reactions: $0.reactions, members: context.viewState.members, imageProvider: context.imageProvider, selectedReactionKey: $0.selectedKey)
                     .edgesIgnoringSafeArea([.bottom])
             }
+            .sheet(item: $context.readReceiptsSummaryInfo) {
+                ReadReceiptsSummaryView(orderedReadReceipts: $0.orderedReceipts)
+                    .environmentObject(context)
+            }
             .interactiveQuickLook(item: $context.mediaPreviewItem)
             .track(screen: .room)
             .onDrop(of: ["public.item", "public.file-url"], isTargeted: $dragOver) { providers -> Bool in

--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReadReceiptsView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReadReceiptsView.swift
@@ -50,6 +50,7 @@ struct TimelineReadReceiptsView: View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(L10n.a11yReadReceiptsTapToShowAll)
     }
     
     private var remaining: Int {

--- a/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReadReceiptsView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Supplementary/TimelineReadReceiptsView.swift
@@ -45,6 +45,9 @@ struct TimelineReadReceiptsView: View {
                     .foregroundColor(.compound.textPrimary)
             }
         }
+        .onTapGesture {
+            context.send(viewAction: .showReadReceipts(itemID: timelineItem.id))
+        }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
     }

--- a/UnitTests/Sources/RoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomScreenViewModelTests.swift
@@ -527,7 +527,7 @@ class RoomScreenViewModelTests: XCTestCase {
         // Then the second call should be ignored.
         XCTAssertEqual(roomProxy.sendReadReceiptForCallsCount, 1)
     }
-        
+    
     // swiftlint:enable force_unwrapping
     // swiftlint:disable:next large_tuple
     private func readReceiptsConfiguration(with items: [RoomTimelineItemProtocol]) -> (RoomScreenViewModel,

--- a/UnitTests/Sources/RoomScreenViewModelTests.swift
+++ b/UnitTests/Sources/RoomScreenViewModelTests.swift
@@ -527,7 +527,7 @@ class RoomScreenViewModelTests: XCTestCase {
         // Then the second call should be ignored.
         XCTAssertEqual(roomProxy.sendReadReceiptForCallsCount, 1)
     }
-    
+        
     // swiftlint:enable force_unwrapping
     // swiftlint:disable:next large_tuple
     private func readReceiptsConfiguration(with items: [RoomTimelineItemProtocol]) -> (RoomScreenViewModel,
@@ -556,10 +556,42 @@ class RoomScreenViewModelTests: XCTestCase {
         
         return (viewModel, roomProxy, timelineController, notificationCenter)
     }
+    
+    func testShowReadReceipts() async throws {
+        let receipts: [ReadReceipt] = [.init(userID: "@alice:matrix.org", formattedTimestamp: "12:00"),
+                                       .init(userID: "@charlie:matrix.org", formattedTimestamp: "11:00")]
+        // Given 3 messages from Bob where the middle message has a reaction.
+        let message = TextRoomTimelineItem(text: "Test",
+                                           sender: "bob",
+                                           addReadReceipts: receipts)
+        let id = message.id
+        
+        // When showing them in a timeline.
+        let timelineController = MockRoomTimelineController()
+        timelineController.timelineItems = [message]
+        let viewModel = RoomScreenViewModel(roomProxy: RoomProxyMock(with: .init(displayName: "",
+                                                                                 members: [RoomMemberProxyMock.mockAlice, RoomMemberProxyMock.mockCharlie])),
+                                            timelineController: timelineController,
+                                            mediaProvider: MockMediaProvider(),
+                                            mediaPlayerProvider: MediaPlayerProviderMock(),
+                                            voiceMessageMediaManager: VoiceMessageMediaManagerMock(),
+                                            userIndicatorController: userIndicatorControllerMock,
+                                            application: ApplicationMock.default,
+                                            appSettings: ServiceLocator.shared.settings,
+                                            analyticsService: ServiceLocator.shared.analytics,
+                                            notificationCenter: NotificationCenterMock())
+        
+        let deferred = deferFulfillment(viewModel.context.$viewState) { value in
+            value.bindings.readReceiptsSummaryInfo?.orderedReceipts == receipts
+        }
+        
+        viewModel.context.send(viewAction: .showReadReceipts(itemID: id))
+        try await deferred.fulfill()
+    }
 }
 
 private extension TextRoomTimelineItem {
-    init(text: String, sender: String, addReactions: Bool = false) {
+    init(text: String, sender: String, addReactions: Bool = false, addReadReceipts: [ReadReceipt] = []) {
         let reactions = addReactions ? [AggregatedReaction(accountOwnerID: "bob", key: "🦄", senders: [ReactionSender(senderID: sender, timestamp: Date())])] : []
         self.init(id: .random,
                   timestamp: "10:47 am",
@@ -569,7 +601,7 @@ private extension TextRoomTimelineItem {
                   isThreaded: false,
                   sender: .init(id: "@\(sender):server.com", displayName: sender),
                   content: .init(body: text),
-                  properties: RoomTimelineItemProperties(reactions: reactions))
+                  properties: RoomTimelineItemProperties(reactions: reactions, orderedReadReceipts: addReadReceipts))
     }
 }
 

--- a/UnitTests/__Snapshots__/PreviewTests/test_readReceiptCell.Loading-Member.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_readReceiptCell.Loading-Member.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2431b131a71e3ecc537771ac267f6a3c613fe469fd28cb78cb79af628e1205d6
+size 65811

--- a/UnitTests/__Snapshots__/PreviewTests/test_readReceiptCell.No-Image.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_readReceiptCell.No-Image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf54a03ff167095cc424d2578fdf9c94274f22d9a172a93e04628bb5cbf504b7
+size 66209

--- a/UnitTests/__Snapshots__/PreviewTests/test_readReceiptCell.With-Image.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_readReceiptCell.With-Image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbf4d823916f3dad79f996cf00380ac17df33c2774a65bc6a75bdaad534c3b32
+size 68826

--- a/UnitTests/__Snapshots__/PreviewTests/test_readReceiptsSummaryView.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_readReceiptsSummaryView.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:098b0a6b4b4afea40281b37c0fa173f15ee28b05332050d045fe3b8bbb08b42d
+size 111724

--- a/UnitTests/__Snapshots__/PreviewTests/test_roomScreen.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_roomScreen.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:610e0a0946e4bb26642f84c5dfb6fd91caf7d623290c501e70fbd83073a7e191
-size 318638
+oid sha256:349cab6a64a17c9c0ed6d76c902f06edec4763cd4b7a3304178efba6b733a321
+size 311524

--- a/UnitTests/__Snapshots__/PreviewTests/test_timelineView.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_timelineView.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf7addca5dd6f7347d38227a5b03e36a3ff9430e24bafc06976ffe7e478baa67
-size 315120
+oid sha256:265541e4885dd109da0212857cbb43393784782e54b6608851b7da1385a59f4c
+size 308464

--- a/UnitTests/__Snapshots__/PreviewTests/test_uITimelineView.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_uITimelineView.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf7addca5dd6f7347d38227a5b03e36a3ff9430e24bafc06976ffe7e478baa67
-size 315120
+oid sha256:265541e4885dd109da0212857cbb43393784782e54b6608851b7da1385a59f4c
+size 308464

--- a/changelog.d/1053.feature
+++ b/changelog.d/1053.feature
@@ -1,0 +1,1 @@
+Tapping on read receipts will open a detailed sheet of all the receipts.

--- a/changelog.d/pr-2123.change
+++ b/changelog.d/pr-2123.change
@@ -1,0 +1,1 @@
+Read Receipts are enabled by default.


### PR DESCRIPTION
Added a sheet that displays read receipts of that message in more detal when they are tapped
fixes #1053 

Also enabled the FF for Read Receipts as true by default. If no problems are detected anymore we can safely then remove this FF once and for all.