### PR TITLE
Fix: Long replies overlay the replied message (#1832)

### DIFF
--- a/ElementX/Sources/Screens/ComposerToolbar/View/MessageComposer.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/MessageComposer.swift
@@ -70,6 +70,7 @@ struct MessageComposer: View {
             Color.clear
                 .overlay(alignment: .top) {
                     composerView
+                        .clipped()
                         .readFrame($composerFrame)
                 }
                 .frame(minHeight: ComposerConstant.minHeight, maxHeight: max(composerHeight, composerFrame.height),

--- a/changelog.d/1832.bugfix
+++ b/changelog.d/1832.bugfix
@@ -1,0 +1,1 @@
+Long replies no longer overlay the replied message.


### PR DESCRIPTION
This PR fixes #1832 