### PR TITLE
Using thumbnails for notification icons

### DIFF
--- a/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
+++ b/ElementX/Sources/Other/Extensions/UNNotificationContent.swift
@@ -117,7 +117,7 @@ extension UNMutableNotificationContent {
         var fetchedImage: INImage?
         let image: INImage
         if let mediaSource = icon.mediaSource {
-            switch await mediaProvider?.loadImageDataFromSource(mediaSource) {
+            switch await mediaProvider?.loadThumbnailForSource(source: mediaSource, size: .init(width: 50, height: 50)) {
             case .success(let data):
                 fetchedImage = INImage(imageData: data)
             case .failure(let error):

--- a/ElementX/Sources/Services/Media/Provider/MediaProvider.swift
+++ b/ElementX/Sources/Services/Media/Provider/MediaProvider.swift
@@ -104,6 +104,18 @@ struct MediaProvider: MediaProviderProtocol {
         }
     }
     
+    // MARK: Thumbnail
+    
+    func loadThumbnailForSource(source: MediaSourceProxy, size: CGSize) async -> Result<Data, MediaProviderError> {
+        do {
+            let thumbnailData = try await mediaLoader.loadMediaThumbnailForSource(source, width: UInt(size.width), height: UInt(size.height))
+            return .success(thumbnailData)
+        } catch {
+            MXLog.error("Failed retrieving image with error: \(error)")
+            return .failure(.failedRetrievingThumbnail)
+        }
+    }
+    
     // MARK: - Private
     
     private func cacheKeyForURL(_ url: URL, size: CGSize?) -> String {

--- a/ElementX/Sources/Services/Media/Provider/MediaProviderProtocol.swift
+++ b/ElementX/Sources/Services/Media/Provider/MediaProviderProtocol.swift
@@ -21,10 +21,12 @@ enum MediaProviderError: Error {
     case failedRetrievingImage
     case failedRetrievingFile
     case invalidImageData
+    case failedRetrievingThumbnail
 }
 
 protocol MediaProviderProtocol: ImageProviderProtocol {
     func loadFileFromSource(_ source: MediaSourceProxy, body: String?) async -> Result<MediaFileHandleProxy, MediaProviderError>
+    func loadThumbnailForSource(source: MediaSourceProxy, size: CGSize) async -> Result<Data, MediaProviderError>
 }
 
 extension MediaProviderProtocol {

--- a/ElementX/Sources/Services/Media/Provider/MockMediaProvider.swift
+++ b/ElementX/Sources/Services/Media/Provider/MockMediaProvider.swift
@@ -18,6 +18,10 @@ import Foundation
 import UIKit
 
 struct MockMediaProvider: MediaProviderProtocol {
+    func loadThumbnailForSource(source: MediaSourceProxy, size: CGSize) async -> Result<Data, MediaProviderError> {
+        fatalError("Not implemented")
+    }
+    
     func imageFromSource(_ source: MediaSourceProxy?, size: CGSize?) -> UIImage? {
         guard source != nil else {
             return nil


### PR DESCRIPTION
It is technically more efficient to use small thumbnails of 50x50 size for notification icons instead of loading the original image data, since their size would be way less but most importantly the server is also going to handle things like orientation, which seems that with iOS 17 is handled poorly by the Notification Center system.

fixes #2136