### PR TITLE
Fix a crash when blocking/unblocking a user

### DIFF
--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenViewModel.swift
@@ -254,7 +254,10 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
         state.isProcessingIgnoreRequest = false
         switch result {
         case .success:
-            state.dmRecipient?.isIgnored = true
+            // Mutating the optional in place when built for Release crashes 🤷‍♂️
+            var dmRecipient = state.dmRecipient
+            dmRecipient?.isIgnored = true
+            state.dmRecipient = dmRecipient
         case .failure, .none:
             state.bindings.alertInfo = .init(id: .unknown)
         }
@@ -266,7 +269,10 @@ class RoomDetailsScreenViewModel: RoomDetailsScreenViewModelType, RoomDetailsScr
         state.isProcessingIgnoreRequest = false
         switch result {
         case .success:
-            state.dmRecipient?.isIgnored = false
+            // Mutating the optional in place when built for Release crashes 🤷‍♂️
+            var dmRecipient = state.dmRecipient
+            dmRecipient?.isIgnored = false
+            state.dmRecipient = dmRecipient
         case .failure, .none:
             state.bindings.alertInfo = .init(id: .unknown)
         }

--- a/changelog.d/2140.bugfix
+++ b/changelog.d/2140.bugfix
@@ -1,0 +1,1 @@
+Fix a crash when blocking/unblocking a user from the DM details screen.


### PR DESCRIPTION
The view state doesn't like mutating an optional when built in release mode. Will take a look at making a minimal reproduction example and filing a bug on the compiler.

Fixes #2140.