### PR TITLE
Fix a rendering issue when a message starts with a list (#1915)

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
@@ -33,7 +33,12 @@ struct FormattedBodyText: View {
     }()
         
     private var attributedComponents: [AttributedStringBuilderComponent] {
-        var adjustedAttributedString = AttributedString(layoutDirection.isolateLayoutUnicodeString) + attributedString + AttributedString(additionalWhitespacesSuffix)
+        var adjustedAttributedString = attributedString + AttributedString(additionalWhitespacesSuffix)
+        
+        // If this is not a list, force the writing direction by adding the correct unicode character.
+        if !String(attributedString.characters).starts(with: "\t") {
+            adjustedAttributedString = AttributedString(layoutDirection.isolateLayoutUnicodeString) + adjustedAttributedString
+        }
         
         // Required to allow the underlying TextView to use  body font when no font is specifie in the AttributedString.
         adjustedAttributedString.mergeAttributes(defaultAttributesContainer, mergePolicy: .keepCurrent)
@@ -198,7 +203,8 @@ struct FormattedBodyText_Previews: PreviewProvider, TestablePreview {
             <p>Text</p>
             <code>Hello world</code>
             """,
-            "<p>This is a list</p>\n<ul>\n<li>One</li>\n<li>Two</li>\n<li>And number 3</li>\n</ul>\n"
+            "<p>This is a list</p>\n<ul>\n<li>One</li>\n<li>Two</li>\n<li>And number 3</li>\n</ul>\n",
+            "<ul><li>First item</li><li>Second item</li><li>Third item</li></ul>"
         ]
         
         let attributedStringBuilder = AttributedStringBuilder(permalinkBaseURL: ServiceLocator.shared.settings.permalinkBaseURL, mentionBuilder: MentionBuilder())

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
@@ -41,47 +41,60 @@ struct TextRoomTimelineView_Previews: PreviewProvider, TestablePreview {
     
     static var previews: some View {
         body.environmentObject(viewModel.context)
+            .previewDisplayName("Bubble")
         body
             .environment(\.timelineStyle, .plain)
             .environmentObject(viewModel.context)
+            .previewDisplayName("Plain")
+        body
+            .environmentObject(viewModel.context)
+            .environment(\.layoutDirection, .rightToLeft)
+            .previewDisplayName("Bubble RTL")
+        body
+            .environment(\.timelineStyle, .plain)
+            .environmentObject(viewModel.context)
+            .environment(\.layoutDirection, .rightToLeft)
+            .previewDisplayName("Plain RTL")
     }
     
     static var body: some View {
-        VStack(alignment: .leading, spacing: 20.0) {
-            TextRoomTimelineView(timelineItem: itemWith(text: "Short loin ground round tongue hamburger, fatback salami shoulder. Beef turkey sausage kielbasa strip steak. Alcatra capicola pig tail pancetta chislic.",
-                                                        timestamp: "Now",
-                                                        isOutgoing: false,
-                                                        senderId: "Bob"))
-
-            TextRoomTimelineView(timelineItem: itemWith(text: "Some other text",
-                                                        timestamp: "Later",
-                                                        isOutgoing: true,
-                                                        senderId: "Anne"))
-
-            TextRoomTimelineView(timelineItem: itemWith(text: "Short loin ground round tongue hamburger, fatback salami shoulder. Beef turkey sausage kielbasa strip steak. Alcatra capicola pig tail pancetta chislic.",
-                                                        timestamp: "Now",
-                                                        isOutgoing: false,
-                                                        senderId: "Bob"))
-
-            TextRoomTimelineView(timelineItem: itemWith(text: "Some other text",
-                                                        timestamp: "Later",
-                                                        isOutgoing: true,
-                                                        senderId: "Anne"))
-
-            TextRoomTimelineView(timelineItem: itemWith(text: "טקסט אחר",
-                                                        timestamp: "Later",
-                                                        isOutgoing: true,
-                                                        senderId: "Anne"))
-            
-            TextRoomTimelineView(timelineItem: itemWith(text: "Some other text -- טקסט אחר -- Some other text",
-                                                        timestamp: "Later",
-                                                        isOutgoing: true,
-                                                        senderId: "Anne"))
-
-            TextRoomTimelineView(timelineItem: itemWith(html: "<ol><li>First item</li><li>Second item</li><li>Third item</li></ol>",
-                                                        timestamp: "Later",
-                                                        isOutgoing: true,
-                                                        senderId: "Anne"))
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20.0) {
+                TextRoomTimelineView(timelineItem: itemWith(text: "Short loin ground round tongue hamburger, fatback salami shoulder. Beef turkey sausage kielbasa strip steak. Alcatra capicola pig tail pancetta chislic.",
+                                                            timestamp: "Now",
+                                                            isOutgoing: false,
+                                                            senderId: "Bob"))
+                
+                TextRoomTimelineView(timelineItem: itemWith(text: "Some other text",
+                                                            timestamp: "Later",
+                                                            isOutgoing: true,
+                                                            senderId: "Anne"))
+                
+                TextRoomTimelineView(timelineItem: itemWith(text: "Short loin ground round tongue hamburger, fatback salami shoulder. Beef turkey sausage kielbasa strip steak. Alcatra capicola pig tail pancetta chislic.",
+                                                            timestamp: "Now",
+                                                            isOutgoing: false,
+                                                            senderId: "Bob"))
+                
+                TextRoomTimelineView(timelineItem: itemWith(text: "Some other text",
+                                                            timestamp: "Later",
+                                                            isOutgoing: true,
+                                                            senderId: "Anne"))
+                
+                TextRoomTimelineView(timelineItem: itemWith(text: "טקסט אחר",
+                                                            timestamp: "Later",
+                                                            isOutgoing: true,
+                                                            senderId: "Anne"))
+                
+                TextRoomTimelineView(timelineItem: itemWith(html: "<ol><li>First item</li><li>Second item</li><li>Third item</li></ol>",
+                                                            timestamp: "Later",
+                                                            isOutgoing: true,
+                                                            senderId: "Anne"))
+                
+                TextRoomTimelineView(timelineItem: itemWith(html: "<ol><li>פריט ראשון</li><li>הפריט השני</li><li>פריט שלישי</li></ol>",
+                                                            timestamp: "Later",
+                                                            isOutgoing: true,
+                                                            senderId: "Anne"))
+            }
         }
     }
     

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/TextRoomTimelineView.swift
@@ -67,6 +67,21 @@ struct TextRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                                                         timestamp: "Later",
                                                         isOutgoing: true,
                                                         senderId: "Anne"))
+
+            TextRoomTimelineView(timelineItem: itemWith(text: "טקסט אחר",
+                                                        timestamp: "Later",
+                                                        isOutgoing: true,
+                                                        senderId: "Anne"))
+            
+            TextRoomTimelineView(timelineItem: itemWith(text: "Some other text -- טקסט אחר -- Some other text",
+                                                        timestamp: "Later",
+                                                        isOutgoing: true,
+                                                        senderId: "Anne"))
+
+            TextRoomTimelineView(timelineItem: itemWith(html: "<ol><li>First item</li><li>Second item</li><li>Third item</li></ol>",
+                                                        timestamp: "Later",
+                                                        isOutgoing: true,
+                                                        senderId: "Anne"))
         }
     }
     
@@ -79,5 +94,19 @@ struct TextRoomTimelineView_Previews: PreviewProvider, TestablePreview {
                              isThreaded: false,
                              sender: .init(id: senderId),
                              content: .init(body: text))
+    }
+    
+    private static func itemWith(html: String, timestamp: String, isOutgoing: Bool, senderId: String) -> TextRoomTimelineItem {
+        let builder = AttributedStringBuilder(cacheKey: "preview", permalinkBaseURL: ServiceLocator.shared.settings.permalinkBaseURL, mentionBuilder: MentionBuilder())
+        let attributedString = builder.fromHTML(html)
+        
+        return TextRoomTimelineItem(id: .random,
+                                    timestamp: timestamp,
+                                    isOutgoing: isOutgoing,
+                                    isEditable: isOutgoing,
+                                    canBeRepliedTo: true,
+                                    isThreaded: false,
+                                    sender: .init(id: senderId),
+                                    content: .init(body: "", formattedBody: attributedString))
     }
 }

--- a/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f11312fe9884eb25cc764aaa24e904bcc7f71d680460180e1ba5d34420c2c5f
-size 226813

--- a/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28393ef0e427739046c74311af565ecfc3d1e74696ccaec67a99135f590d58d3
-size 179423
+oid sha256:4f11312fe9884eb25cc764aaa24e904bcc7f71d680460180e1ba5d34420c2c5f
+size 226813

--- a/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.2.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16f110dd908398601d5fd7548c44c3b9cb526b8ff88b0a790484398be2dbc7a9
-size 167600
+oid sha256:f5b1c69eeccf022afb4ae45be0b7097a4e0ed50b607cddaad3b6366140631be1
+size 207431

--- a/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.2.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5b1c69eeccf022afb4ae45be0b7097a4e0ed50b607cddaad3b6366140631be1
-size 207431

--- a/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Bubble-RTL.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Bubble-RTL.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62ac756d6cc4079a8262196872a69fd954b7cb7c6c36d620ef673cb29e03a29a
+size 219583

--- a/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Bubble.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Bubble.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7164e0fbc6e603de32225e7a260caed819c7b081c6ce2c8c56db0776c85b7dc
+size 221052

--- a/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Plain-RTL.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Plain-RTL.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:654156e7f84b79b3f593e9fc28fe73bfbc656d617302cf7428b45e5fc2b90099
+size 198632

--- a/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Plain.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Plain.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7e0e45c9bda3defd344e3762eec47e8cc2da57035fd0460acce9b4b1a790c24
+size 197095

--- a/changelog.d/1915.bugfix
+++ b/changelog.d/1915.bugfix
@@ -1,0 +1,1 @@
+Lists at the beginning of messages were displayed incorrectly.


### PR DESCRIPTION
This PR fixes an issue with the display of messages when they begin with a list (#1915)

Before:
<img width="50%" alt="Screenshot 2023-11-22 at 16 16 18" src="https://github.com/vector-im/element-x-ios/assets/4334885/4a34399a-4d6c-4fd4-9abd-e7786c28450b">

After:
<img width="50%" alt="Screenshot 2023-11-22 at 16 16 45" src="https://github.com/vector-im/element-x-ios/assets/4334885/b249cec5-2a0e-4094-b328-d9c0e8d6c495">
