### PR TITLE
Update rust sdk to 0.0.6-november23

### DIFF
--- a/ElementX.xcodeproj/project.pbxproj
+++ b/ElementX.xcodeproj/project.pbxproj
@@ -6652,7 +6652,7 @@
 			repositoryURL = "https://github.com/matrix-org/matrix-rust-components-swift";
 			requirement = {
 				kind = exactVersion;
-				version = "0.0.5-november23";
+				version = "0.0.6-november23";
 			};
 		};
 		821C67C9A7F8CC3FD41B28B4 /* XCRemoteSwiftPackageReference "emojibase-bindings" */ = {

--- a/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ElementX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -130,8 +130,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "415201caf63d5338c6007d4ed61978011a95bcb1",
-        "version" : "0.0.5-november23"
+        "revision" : "42274cc2414e675b246432b037e7fa82b587fd97",
+        "version" : "0.0.6-november23"
       }
     },
     {

--- a/ElementX/Sources/Services/Timeline/TimelineItems/Items/Other/PollRoomTimelineItem.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/Items/Other/PollRoomTimelineItem.swift
@@ -41,10 +41,6 @@ struct Poll: Hashable {
     var hasEnded: Bool {
         endDate != nil
     }
-    
-    var hasVotes: Bool {
-        votes.values.contains(where: { !$0.isEmpty })
-    }
 
     enum Kind: Hashable {
         case disclosed

--- a/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
+++ b/ElementX/Sources/Services/Timeline/TimelineItems/RoomTimelineItemFactory.swift
@@ -411,8 +411,7 @@ struct RoomTimelineItemFactory: RoomTimelineItemFactoryProtocol {
                                     body: poll.question,
                                     timestamp: eventItemProxy.timestamp.formatted(date: .omitted, time: .shortened),
                                     isOutgoing: isOutgoing,
-                                    // FIX ME: `eventItemProxy.isEditable` needs to be fixed on the rust side (now returns always false)
-                                    isEditable: eventItemProxy.isOwn && !poll.hasVotes && !poll.hasEnded,
+                                    isEditable: eventItemProxy.isEditable,
                                     canBeRepliedTo: eventItemProxy.canBeRepliedTo,
                                     sender: eventItemProxy.sender,
                                     properties: RoomTimelineItemProperties(isEdited: edited,

--- a/project.yml
+++ b/project.yml
@@ -45,7 +45,7 @@ packages:
   # Element/Matrix dependencies
   MatrixRustSDK:
     url: https://github.com/matrix-org/matrix-rust-components-swift
-    exactVersion: 0.0.5-november23
+    exactVersion: 0.0.6-november23
     # path: ../matrix-rust-sdk
   Compound:
     url: https://github.com/vector-im/compound-ios


### PR DESCRIPTION
This PR updates the rust sdk to ` 0.0.6-november23`.
It also uses the sdk `isEditable` logic for polls ([context](https://github.com/matrix-org/matrix-rust-sdk/pull/2875)).