### PR TITLE
Fixes #2005 - Remove rooms from the room list after leaving them

### DIFF
--- a/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
+++ b/ElementX/Sources/Services/Room/RoomSummary/RoomSummaryProvider.swift
@@ -151,7 +151,7 @@ class RoomSummaryProvider: RoomSummaryProviderProtocol {
         case .none:
             _ = listUpdatesSubscriptionResult?.controller.setFilter(kind: .none)
         case .all:
-            _ = listUpdatesSubscriptionResult?.controller.setFilter(kind: .all)
+            _ = listUpdatesSubscriptionResult?.controller.setFilter(kind: .allNonLeft)
         case .normalizedMatchRoomName(let query):
             _ = listUpdatesSubscriptionResult?.controller.setFilter(kind: .normalizedMatchRoomName(pattern: query.lowercased()))
         }

--- a/changelog.d/2005.bugfix
+++ b/changelog.d/2005.bugfix
@@ -1,0 +1,1 @@
+Remove rooms from the room list after leaving them


### PR DESCRIPTION
Left rooms will still be available if seached by name