### PR TITLE
Add a state machine to AppLockFlowCoordinator.

### DIFF
--- a/ElementX/Sources/FlowCoordinators/AppLockFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AppLockFlowCoordinator.swift
@@ -90,14 +90,15 @@ class AppLockFlowCoordinator: CoordinatorProtocol {
         actionsSubject.eraseToAnyPublisher()
     }
     
-    init(appLockService: AppLockServiceProtocol,
+    init(initialState: State = .initial,
+         appLockService: AppLockServiceProtocol,
          navigationCoordinator: NavigationRootCoordinator,
          notificationCenter: NotificationCenter = .default) {
         self.appLockService = appLockService
         self.navigationCoordinator = navigationCoordinator
         
-        // The app starts off in the background (with the placeholder screen in the flow.)
-        stateMachine = .init(state: .initial)
+        // Set the initial state and start with the placeholder screen as the root view.
+        stateMachine = .init(state: initialState)
         showPlaceholder()
         
         notificationCenter.publisher(for: UIApplication.willResignActiveNotification)

--- a/ElementX/Sources/FlowCoordinators/AppLockFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AppLockFlowCoordinator.swift
@@ -15,6 +15,7 @@
 //
 
 import Combine
+import SwiftState
 import SwiftUI
 
 enum AppLockFlowCoordinatorAction: Equatable {
@@ -31,9 +32,52 @@ class AppLockFlowCoordinator: CoordinatorProtocol {
     let appLockService: AppLockServiceProtocol
     let navigationCoordinator: NavigationRootCoordinator
     
+    /// States the flow can find itself in
+    enum State: StateType {
+        /// The app is in the foreground and visible to the user.
+        case unlocked
+        /// The app has resigned active but is not yet in the background. This state
+        /// shows the placeholder, but doesn't require an unlock on becoming active.
+        case obscuringApp
+        /// The app is in the background.
+        case backgrounded
+        /// The app is presenting biometric unlock to the user.
+        case biometricUnlock
+        /// Biometric unlock has completed but the system UI is still the active input.
+        /// Once the app becomes active again, it will trigger the next state.
+        case biometricUnlockDismissing(AppLockServiceBiometricResult)
+        /// The app is presenting the unlock screen for PIN code entry.
+        case pinCodeUnlock
+        /// The user failed to unlock the app (or forgot their PIN) and is being logged out.
+        case loggingOut
+    }
+
+    /// Events that can be triggered on the flow state machine
+    enum Event: EventType {
+        /// The app is resigning active (going into the app switcher, showing system UI like Face ID, permissions prompt etc).
+        case willResignActive
+        /// The app is now backgrounded and not visible to the user.
+        case didEnterBackground
+        /// The app is in the foreground and has been given focus.
+        case didBecomeActive
+        /// Biometric unlock has completed with the following result.
+        case biometricResult(AppLockServiceBiometricResult)
+        /// The entered PIN code was accepted.
+        case pinSuccess
+        /// The user failed to unlock the app (or forgot their PIN).
+        case forceLogout
+    }
+    
+    private let stateMachine: StateMachine<State, Event>
+    
     /// A task used to await biometric unlock before showing the PIN screen.
     @CancellableTask private var unlockTask: Task<Void, Never>?
     private var cancellables: Set<AnyCancellable> = []
+    
+    /// Whether or not biometric unlock should be attempted instead of asking for a PIN.
+    private var biometricUnlockIsAvailable: Bool {
+        appLockService.biometricUnlockEnabled && appLockService.biometricUnlockTrusted
+    }
     
     private let actionsSubject: PassthroughSubject<AppLockFlowCoordinatorAction, Never> = .init()
     var actions: AnyPublisher<AppLockFlowCoordinatorAction, Never> {
@@ -46,83 +90,131 @@ class AppLockFlowCoordinator: CoordinatorProtocol {
         self.appLockService = appLockService
         self.navigationCoordinator = navigationCoordinator
         
-        // Set the initial background state.
+        // The app starts off in the background (with the placeholder screen in the flow.)
+        stateMachine = .init(state: .backgrounded)
         showPlaceholder()
         
         notificationCenter.publisher(for: UIApplication.willResignActiveNotification)
             .sink { [weak self] _ in
-                self?.applicationWillResignActive()
+                self?.stateMachine.tryEvent(.willResignActive)
             }
             .store(in: &cancellables)
         
         notificationCenter.publisher(for: UIApplication.didEnterBackgroundNotification)
             .sink { [weak self] _ in
-                self?.applicationDidEnterBackground()
+                self?.stateMachine.tryEvent(.didEnterBackground)
             }
             .store(in: &cancellables)
         
         notificationCenter.publisher(for: UIApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in
-                self?.applicationDidBecomeActive()
+                self?.stateMachine.tryEvent(.didBecomeActive)
             }
             .store(in: &cancellables)
+        
+        configureStateMachine()
     }
     
     func toPresentable() -> AnyView {
         AnyView(navigationCoordinator.toPresentable())
     }
     
-    // MARK: - App unlock
+    // MARK: - State machine
     
-    private func applicationWillResignActive() {
-        unlockTask = nil
-        
-        guard appLockService.isEnabled else { return }
-        showPlaceholder()
-    }
-    
-    private func applicationDidEnterBackground() {
-        guard appLockService.isEnabled else { return }
-        appLockService.applicationDidEnterBackground()
-        showPlaceholder() // Double call but just to be safe
-    }
-    
-    private func applicationDidBecomeActive() {
-        guard appLockService.isEnabled else { return }
-        
-        guard appLockService.computeNeedsUnlock(didBecomeActiveAt: .now) else {
-            // Reveal the app again if within the grace period.
-            actionsSubject.send(.unlockApp)
-            return
-        }
-        
-        // Show the relevant unlock mechanism.
-        unlockTask = Task { [weak self] in
-            guard let self else { return }
-            await startUnlockFlow()
-        }
-    }
-    
-    /// Runs the unlock flow, showing Touch ID/Face ID if available, transitioning to PIN unlock if it fails or isn't available.
-    private func startUnlockFlow() async {
-        if appLockService.biometricUnlockEnabled, appLockService.biometricUnlockTrusted {
-            showPlaceholder() // For the unlock background.
+    private func configureStateMachine() {
+        stateMachine.addRouteMapping { [weak self] event, fromState, _ in
+            guard let self, appLockService.isEnabled else { return fromState }
             
-            if await appLockService.unlockWithBiometrics(), UIApplication.shared.applicationState == .active {
-                actionsSubject.send(.unlockApp)
-                return
+            switch (fromState, event) {
+            case (.backgrounded, .willResignActive): // This is wrong, we should get a signal that its enabled and transition to unlocked.
+                return .obscuringApp
+            case (.unlocked, .willResignActive):
+                return .obscuringApp
+            case (.obscuringApp, .didBecomeActive):
+                return .unlocked
+            case (_, .didEnterBackground):
+                return .backgrounded
+            case (.backgrounded, .didBecomeActive):
+                guard appLockService.computeNeedsUnlock(didBecomeActiveAt: .now) else { return .unlocked }
+                return biometricUnlockIsAvailable ? .biometricUnlock : .pinCodeUnlock
+            case (.biometricUnlock, .biometricResult(let result)):
+                return .biometricUnlockDismissing(result)
+            case (.biometricUnlockDismissing(let result), .didBecomeActive):
+                return switch result {
+                case .unlocked: .unlocked
+                case .failed: .pinCodeUnlock
+                case .interrupted: .biometricUnlock
+                }
+            case (.pinCodeUnlock, .pinSuccess):
+                return .unlocked
+            case (.pinCodeUnlock, .forceLogout):
+                return .loggingOut
+            case (.loggingOut, .willResignActive): // This state is wrong, it should go to unlocked when logout was successful.
+                return .obscuringApp
+            default:
+                return fromState
             }
         }
         
-        guard !Task.isCancelled else { return }
+        stateMachine.addAnyHandler(.any => .any) { [weak self] context in
+            guard let self, context.fromState != context.toState else { return }
+            
+            MXLog.info("Transitioning from `\(context.fromState)` to `\(context.toState)` with event `\(String(describing: context.event))`.")
+            
+            switch (context.fromState, context.toState) {
+            case (.backgrounded, .obscuringApp):
+                showPlaceholder()
+            case (.unlocked, .obscuringApp):
+                showPlaceholder()
+            case (.obscuringApp, .unlocked):
+                actionsSubject.send(.unlockApp)
+            case (_, .backgrounded):
+                appLockService.applicationDidEnterBackground()
+                showPlaceholder() // Double call but just to be safe.
+            case (.backgrounded, .unlocked):
+                actionsSubject.send(.unlockApp)
+            case (.backgrounded, .biometricUnlock):
+                showPlaceholder() // For the unlock background.
+                Task { await self.attemptBiometricUnlock() }
+            case (.backgrounded, .pinCodeUnlock):
+                showUnlockScreen()
+            case (.biometricUnlock, .biometricUnlockDismissing):
+                break // nothing to change in presentation here?
+            case (.biometricUnlockDismissing(.unlocked), .unlocked):
+                actionsSubject.send(.unlockApp)
+            case (.biometricUnlockDismissing(.failed), .pinCodeUnlock):
+                showUnlockScreen()
+            case (.biometricUnlockDismissing(.interrupted), .biometricUnlock):
+                // nothing to change in presentation here?
+                Task { await self.attemptBiometricUnlock() }
+            case (.pinCodeUnlock, .unlocked):
+                actionsSubject.send(.unlockApp)
+            case (.pinCodeUnlock, .loggingOut):
+                actionsSubject.send(.forceLogout)
+            case (.loggingOut, .obscuringApp):
+                showPlaceholder()
+            default:
+                fatalError("Unhandled transition.")
+            }
+        }
         
-        showUnlockScreen()
+        stateMachine.addErrorHandler { context in
+            fatalError("Unexpected transition from `\(context.fromState)` to `\(context.toState)` with event `\(String(describing: context.event))`.")
+        }
     }
+    
+    // MARK: - App unlock
     
     /// Displays the unlock flow with the app's placeholder view to hide obscure the view hierarchy in the app switcher.
     private func showPlaceholder() {
         navigationCoordinator.setRootCoordinator(PlaceholderScreenCoordinator(showsBackgroundGradient: true), animated: false)
         actionsSubject.send(.lockApp)
+    }
+    
+    /// Attempts to authenticate the user using Face ID, Touch ID or (possibly) Optic ID.
+    private func attemptBiometricUnlock() async {
+        let result = await appLockService.unlockWithBiometrics()
+        stateMachine.tryEvent(.biometricResult(result))
     }
     
     /// Displays the unlock flow with the main unlock screen.
@@ -132,10 +224,9 @@ class AppLockFlowCoordinator: CoordinatorProtocol {
             guard let self else { return }
             switch action {
             case .appUnlocked:
-                guard UIApplication.shared.applicationState == .active else { return }
-                actionsSubject.send(.unlockApp)
+                stateMachine.tryEvent(.pinSuccess)
             case .forceLogout:
-                actionsSubject.send(.forceLogout)
+                stateMachine.tryEvent(.forceLogout)
             }
         }
         .store(in: &cancellables)

--- a/ElementX/Sources/FlowCoordinators/AppLockFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AppLockFlowCoordinator.swift
@@ -149,7 +149,7 @@ class AppLockFlowCoordinator: CoordinatorProtocol {
                 guard appLockService.computeNeedsUnlock(didBecomeActiveAt: .now) else { return .unlocked }
                 return biometricUnlockIsAvailable ? .biometricUnlock : .pinCodeUnlock
             case (.biometricUnlock, .biometricResult(let result)):
-                return .biometricUnlockDismissing(result)
+                return .biometricUnlockDismissing(result) // Transitional state until the app becomes active again.
             case (.biometricUnlockDismissing(let result), .didBecomeActive):
                 return switch result {
                 case .unlocked: .unlocked

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -128,6 +128,11 @@ class AppLockServiceMock: AppLockServiceProtocol {
         set(value) { underlyingIsEnabled = value }
     }
     var underlyingIsEnabled: Bool!
+    var isEnabledPublisher: AnyPublisher<Bool, Never> {
+        get { return underlyingIsEnabledPublisher }
+        set(value) { underlyingIsEnabledPublisher = value }
+    }
+    var underlyingIsEnabledPublisher: AnyPublisher<Bool, Never>!
     var biometryType: LABiometryType {
         get { return underlyingBiometryType }
         set(value) { underlyingBiometryType = value }

--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -292,10 +292,10 @@ class AppLockServiceMock: AppLockServiceProtocol {
     var unlockWithBiometricsCalled: Bool {
         return unlockWithBiometricsCallsCount > 0
     }
-    var unlockWithBiometricsReturnValue: Bool!
-    var unlockWithBiometricsClosure: (() async -> Bool)?
+    var unlockWithBiometricsReturnValue: AppLockServiceBiometricResult!
+    var unlockWithBiometricsClosure: (() async -> AppLockServiceBiometricResult)?
 
-    func unlockWithBiometrics() async -> Bool {
+    func unlockWithBiometrics() async -> AppLockServiceBiometricResult {
         unlockWithBiometricsCallsCount += 1
         if let unlockWithBiometricsClosure = unlockWithBiometricsClosure {
             return await unlockWithBiometricsClosure()

--- a/ElementX/Sources/Screens/AppLock/AppLockSetupBiometricsScreen/AppLockSetupBiometricsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/AppLock/AppLockSetupBiometricsScreen/AppLockSetupBiometricsScreenViewModel.swift
@@ -56,7 +56,7 @@ class AppLockSetupBiometricsScreenViewModel: AppLockSetupBiometricsScreenViewMod
         
         // Attempt unlock to trigger Face ID permissions alert.
         if appLockService.biometryType == .faceID,
-           await !appLockService.unlockWithBiometrics() {
+           await appLockService.unlockWithBiometrics() != .unlocked {
             MXLog.info("Confirmation failed. Disabling biometric unlock.")
             appLockService.disableBiometricUnlock()
         }

--- a/ElementX/Sources/Screens/AppLock/AppLockSetupSettingsScreen/AppLockSetupSettingsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/AppLock/AppLockSetupSettingsScreen/AppLockSetupSettingsScreenViewModel.swift
@@ -62,7 +62,7 @@ class AppLockSetupSettingsScreenViewModel: AppLockSetupSettingsScreenViewModelTy
             
             // Attempt unlock to trigger Face ID permissions alert.
             if appLockService.biometryType == .faceID,
-               await !appLockService.unlockWithBiometrics() {
+               await appLockService.unlockWithBiometrics() != .unlocked {
                 MXLog.info("Confirmation failed. Disabling biometric unlock.")
                 state.bindings.enableBiometrics = false
                 appLockService.disableBiometricUnlock()

--- a/ElementX/Sources/Services/AppLock/AppLockService.swift
+++ b/ElementX/Sources/Services/AppLock/AppLockService.swift
@@ -38,6 +38,9 @@ class AppLockService: AppLockServiceProtocol {
         }
     }
     
+    private var isEnabledSubject: PassthroughSubject<Bool, Never> = .init()
+    var isEnabledPublisher: AnyPublisher<Bool, Never> { isEnabledSubject.eraseToAnyPublisher() }
+    
     var biometryType: LABiometryType {
         updateBiometrics()
         guard context.evaluatedPolicyDomainState != nil else { return .none }
@@ -71,6 +74,7 @@ class AppLockService: AppLockServiceProtocol {
         
         do {
             try keychainController.setPINCode(pinCode)
+            isEnabledSubject.send(true)
             return .success(())
         } catch {
             MXLog.error("Keychain access error: \(error)")
@@ -105,6 +109,7 @@ class AppLockService: AppLockServiceProtocol {
         keychainController.removePINCode()
         keychainController.removePINCodeBiometricState()
         appSettings.appLockNumberOfPINAttempts = 0
+        isEnabledSubject.send(false)
     }
     
     func applicationDidEnterBackground() {

--- a/ElementX/Sources/Services/AppLock/AppLockServiceProtocol.swift
+++ b/ElementX/Sources/Services/AppLock/AppLockServiceProtocol.swift
@@ -49,6 +49,9 @@ protocol AppLockServiceProtocol: AnyObject {
     /// The app has been configured to automatically lock with a PIN code.
     var isEnabled: Bool { get }
     
+    /// A publisher that advertises when the service has been enabled or disabled.
+    var isEnabledPublisher: AnyPublisher<Bool, Never> { get }
+    
     /// The type of biometric authentication supported by the device.
     var biometryType: LABiometryType { get }
     /// Whether or not the user has enabled unlock via TouchID, FaceID or (possibly) OpticID.

--- a/ElementX/Sources/Services/AppLock/AppLockServiceProtocol.swift
+++ b/ElementX/Sources/Services/AppLock/AppLockServiceProtocol.swift
@@ -30,6 +30,18 @@ enum AppLockServiceError: Error {
     case biometricUnlockNotSupported
 }
 
+/// The result of an attempt to unlock the app using Touch ID or Face ID.
+enum AppLockServiceBiometricResult {
+    /// Biometric lock was successful.
+    case unlocked
+    /// Biometric lock failed to authenticate the user. This represents any failure
+    /// other than the app being backgrounded during the authentication.
+    case failed
+    /// Biometric lock was interrupted by the system and did not complete. The expected
+    /// cause for this that the app was backgrounded whilst the request was in progress.
+    case interrupted
+}
+
 @MainActor
 protocol AppLockServiceProtocol: AnyObject {
     /// The use of a PIN code is mandatory for this device.
@@ -64,7 +76,7 @@ protocol AppLockServiceProtocol: AnyObject {
     /// Attempt to unlock the app with the supplied PIN code.
     func unlock(with pinCode: String) -> Bool
     /// Attempt to unlock the app using FaceID or TouchID.
-    func unlockWithBiometrics() async -> Bool
+    func unlockWithBiometrics() async -> AppLockServiceBiometricResult
     
     /// The number of attempts the user had made to unlock with a PIN code.
     ///

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -201,7 +201,8 @@ class MockScreen: Identifiable {
                 fatalError("Failed to start listening for notifications.")
             }
             
-            let coordinator = AppLockFlowCoordinator(appLockService: appLockService,
+            let coordinator = AppLockFlowCoordinator(initialState: .unlocked,
+                                                     appLockService: appLockService,
                                                      navigationCoordinator: navigationCoordinator,
                                                      notificationCenter: notificationCenter)
             

--- a/UnitTests/Sources/AppLock/AppLockServiceTests.swift
+++ b/UnitTests/Sources/AppLock/AppLockServiceTests.swift
@@ -207,7 +207,7 @@ class AppLockServiceTests: XCTestCase {
         XCTAssertEqual(service.biometryType, .touchID, "The biometry type should not change.")
         XCTAssertTrue(service.biometricUnlockEnabled, "Biometric unlock should now be enabled.")
         XCTAssertTrue(service.biometricUnlockTrusted, "Biometric unlock should now be trusted.")
-        guard await service.unlockWithBiometrics() else {
+        guard await service.unlockWithBiometrics() == .unlocked else {
             XCTFail("The biometric unlock should work.")
             return
         }

--- a/changelog.d/2134.bugfix
+++ b/changelog.d/2134.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where cancelling Face ID unlock would loop back round and present Face ID again. 


### PR DESCRIPTION
Previously, cancelling Face ID would loop back round and present the Face ID prompt again when becoming active. Fixing that revealed a few more edge cases one-by-one so I added a state machine to drive the flow instead.

https://github.com/vector-im/element-x-ios/assets/6060466/ba52e5cf-a561-4b5a-997d-1071322a7c8a
