### PR TITLE
Access direct messages directly from the member details screen

### DIFF
--- a/ElementX/Resources/Localizations/en.lproj/Localizable.strings
+++ b/ElementX/Resources/Localizations/en.lproj/Localizable.strings
@@ -108,6 +108,7 @@
 "common_dark" = "Dark";
 "common_decryption_error" = "Decryption error";
 "common_developer_options" = "Developer options";
+"common_direct_chat" = "Direct chat";
 "common_edited_suffix" = "(edited)";
 "common_editing" = "Editing";
 "common_emote" = "* %1$@ %2$@";

--- a/ElementX/Sources/Application/AppCoordinatorStateMachine.swift
+++ b/ElementX/Sources/Application/AppCoordinatorStateMachine.swift
@@ -104,8 +104,8 @@ class AppCoordinatorStateMachine {
 
         // Transitions with associated values need to be handled through `addRouteMapping`
         stateMachine.addRouteMapping { event, fromState, _ in
-            switch (event, fromState) {
-            case (.signOut(let isSoft, let disableAppLock), _):
+            switch (fromState, event) {
+            case (_, .signOut(let isSoft, let disableAppLock)):
                 return .signingOut(isSoft: isSoft, disableAppLock: disableAppLock)
             default:
                 return nil

--- a/ElementX/Sources/FlowCoordinators/AppLockSetupFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/AppLockSetupFlowCoordinator.swift
@@ -111,17 +111,17 @@ class AppLockSetupFlowCoordinator: FlowCoordinatorProtocol {
         stateMachine.addRouteMapping { [weak self] event, fromState, _ in
             guard let self else { return nil }
             
-            switch (event, fromState) {
-            case (.start, .initial):
+            switch (fromState, event) {
+            case (.initial, .start):
                 if presentingFlow == .onboarding { return .createPIN(replacingExitingPIN: false) }
                 return appLockService.isEnabled ? .unlock : .createPIN(replacingExitingPIN: false)
-            case (.pinEntered, .unlock):
+            case (.unlock, .pinEntered):
                 return .settings
-            case (.cancel, .unlock):
+            case (.unlock, .cancel):
                 return .complete
-            case (.forceLogout, .unlock):
+            case (.unlock, .forceLogout):
                 return .loggingOut
-            case (.pinEntered, .createPIN(let replacingExitingPIN)):
+            case (.createPIN(let replacingExitingPIN), .pinEntered):
                 if presentingFlow == .onboarding {
                     return appLockService.biometryType != .none ? .biometricsPrompt : .complete
                 } else if !replacingExitingPIN {
@@ -129,13 +129,13 @@ class AppLockSetupFlowCoordinator: FlowCoordinatorProtocol {
                 } else {
                     return .settings
                 }
-            case (.cancel, .createPIN(let replacingExitingPIN)):
+            case (.createPIN(let replacingExitingPIN), .cancel):
                 return replacingExitingPIN ? .settings : .complete
-            case (.biometricsSet, .biometricsPrompt):
+            case (.biometricsPrompt, .biometricsSet):
                 return presentingFlow == .settings ? .settings : .complete
-            case (.changePIN, .settings):
+            case (.settings, .changePIN):
                 return .createPIN(replacingExitingPIN: true)
-            case (.appLockDisabled, .settings):
+            case (.settings, .appLockDisabled):
                 return .complete
             default:
                 return nil

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -124,92 +124,92 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     // swiftlint:disable:next function_body_length
     private func setupStateMachine() {
         stateMachine.addRouteMapping { event, fromState, _ in
-            switch (event, fromState) {
-            case (.presentRoom(let roomID), _):
+            switch (fromState, event) {
+            case (_, .presentRoom(let roomID)):
                 return .room(roomID: roomID)
-            case (.dismissRoom, .room):
+            case (.room, .dismissRoom):
                 return .initial
                 
-            case (.presentRoomDetails(let roomID), .initial):
+            case (.initial, .presentRoomDetails(let roomID)):
                 return .roomDetails(roomID: roomID, isRoot: true)
-            case (.presentRoomDetails(let roomID), .room(let currentRoomID)):
+            case (.room(let currentRoomID), .presentRoomDetails(let roomID)):
                 return .roomDetails(roomID: roomID, isRoot: roomID != currentRoomID)
-            case (.presentRoomDetails(let roomID), .roomDetails(let currentRoomID, _)):
+            case (.roomDetails(let currentRoomID, _), .presentRoomDetails(let roomID)):
                 return .roomDetails(roomID: roomID, isRoot: roomID != currentRoomID)
-            case (.dismissRoomDetails, .roomDetails(let roomID, _)):
+            case (.roomDetails(let roomID, _), .dismissRoomDetails):
                 return .room(roomID: roomID)
-            case (.dismissRoom, .roomDetails):
+            case (.roomDetails, .dismissRoom):
                 return .initial
                 
-            case (.presentRoomDetailsEditScreen, .roomDetails(let roomID, _)):
+            case (.roomDetails(let roomID, _), .presentRoomDetailsEditScreen):
                 return .roomDetailsEditScreen(roomID: roomID)
-            case (.dismissRoomDetailsEditScreen, .roomDetailsEditScreen(let roomID)):
+            case (.roomDetailsEditScreen(let roomID), .dismissRoomDetailsEditScreen):
                 return .roomDetails(roomID: roomID, isRoot: false)
                 
-            case (.presentNotificationSettingsScreen, .roomDetails(let roomID, _)):
+            case (.roomDetails(let roomID, _), .presentNotificationSettingsScreen):
                 return .notificationSettings(roomID: roomID)
-            case (.dismissNotificationSettingsScreen, .notificationSettings(let roomID)):
+            case (.notificationSettings(let roomID), .dismissNotificationSettingsScreen):
                 return .roomDetails(roomID: roomID, isRoot: false)
                 
-            case (.presentGlobalNotificationSettingsScreen, .notificationSettings(let roomID)):
+            case (.notificationSettings(let roomID), .presentGlobalNotificationSettingsScreen):
                 return .globalNotificationSettings(roomID: roomID)
-            case (.dismissGlobalNotificationSettingsScreen, .globalNotificationSettings(let roomID)):
+            case (.globalNotificationSettings(let roomID), .dismissGlobalNotificationSettingsScreen):
                 return .notificationSettings(roomID: roomID)
                 
-            case (.presentRoomMembersList, .roomDetails(let roomID, _)):
+            case (.roomDetails(let roomID, _), .presentRoomMembersList):
                 return .roomMembersList(roomID: roomID)
-            case (.dismissRoomMembersList, .roomMembersList(let roomID)):
+            case (.roomMembersList(let roomID), .dismissRoomMembersList):
                 return .roomDetails(roomID: roomID, isRoot: false)
 
-            case (.presentRoomMemberDetails(let member), .room(let roomID)):
+            case (.room(let roomID), .presentRoomMemberDetails(let member)):
                 return .roomMemberDetails(roomID: roomID, member: member, fromRoomMembersList: false)
-            case (.presentRoomMemberDetails(let member), .roomMembersList(let roomID)):
+            case (.roomMembersList(let roomID), .presentRoomMemberDetails(let member)):
                 return .roomMemberDetails(roomID: roomID, member: member, fromRoomMembersList: true)
-            case (.dismissRoomMemberDetails, .roomMemberDetails(let roomID, _, let fromRoomMembersList)):
+            case (.roomMemberDetails(let roomID, _, let fromRoomMembersList), .dismissRoomMemberDetails):
                 return fromRoomMembersList ? .roomMembersList(roomID: roomID) : .room(roomID: roomID)
                 
-            case (.presentInviteUsersScreen, .roomDetails(let roomID, _)):
+            case (.roomDetails(let roomID, _), .presentInviteUsersScreen):
                 return .inviteUsersScreen(roomID: roomID, fromRoomMembersList: false)
-            case (.presentInviteUsersScreen, .roomMembersList(let roomID)):
+            case (.roomMembersList(let roomID), .presentInviteUsersScreen):
                 return .inviteUsersScreen(roomID: roomID, fromRoomMembersList: true)
-            case (.dismissInviteUsersScreen, .inviteUsersScreen(let roomID, let fromRoomMembersList)):
+            case (.inviteUsersScreen(let roomID, let fromRoomMembersList), .dismissInviteUsersScreen):
                 return fromRoomMembersList ? .roomMembersList(roomID: roomID) : .roomDetails(roomID: roomID, isRoot: false)
                 
-            case (.presentReportContent(let itemID, let senderID), .room(let roomID)):
+            case (.room(let roomID), .presentReportContent(let itemID, let senderID)):
                 return .reportContent(roomID: roomID, itemID: itemID, senderID: senderID)
-            case (.dismissReportContent, .reportContent(let roomID, _, _)):
+            case (.reportContent(let roomID, _, _), .dismissReportContent):
                 return .room(roomID: roomID)
                 
-            case (.presentMediaUploadPicker(let source), .room(let roomID)):
+            case (.room(let roomID), .presentMediaUploadPicker(let source)):
                 return .mediaUploadPicker(roomID: roomID, source: source)
-            case (.dismissMediaUploadPicker, .mediaUploadPicker(let roomID, _)):
+            case (.mediaUploadPicker(let roomID, _), .dismissMediaUploadPicker):
                 return .room(roomID: roomID)
                 
-            case (.presentMediaUploadPreview(let fileURL), .mediaUploadPicker(let roomID, _)):
+            case (.mediaUploadPicker(let roomID, _), .presentMediaUploadPreview(let fileURL)):
                 return .mediaUploadPreview(roomID: roomID, fileURL: fileURL)
-            case (.presentMediaUploadPreview(let fileURL), .room(let roomID)):
+            case (.room(let roomID), .presentMediaUploadPreview(let fileURL)):
                 return .mediaUploadPreview(roomID: roomID, fileURL: fileURL)
-            case (.dismissMediaUploadPreview, .mediaUploadPreview(let roomID, _)):
+            case (.mediaUploadPreview(let roomID, _), .dismissMediaUploadPreview):
                 return .room(roomID: roomID)
                 
-            case (.presentEmojiPicker(let itemID, let selectedEmoji), .room(let roomID)):
+            case (.room(let roomID), .presentEmojiPicker(let itemID, let selectedEmoji)):
                 return .emojiPicker(roomID: roomID, itemID: itemID, selectedEmojis: selectedEmoji)
-            case (.dismissEmojiPicker, .emojiPicker(let roomID, _, _)):
+            case (.emojiPicker(let roomID, _, _), .dismissEmojiPicker):
                 return .room(roomID: roomID)
 
-            case (.presentMessageForwarding(let itemID), .room(let roomID)):
+            case (.room(let roomID), .presentMessageForwarding(let itemID)):
                 return .messageForwarding(roomID: roomID, itemID: itemID)
-            case (.dismissMessageForwarding, .messageForwarding(let roomID, _)):
+            case (.messageForwarding(let roomID, _), .dismissMessageForwarding):
                 return .room(roomID: roomID)
 
-            case (.presentMapNavigator, .room(let roomID)):
+            case (.room(let roomID), .presentMapNavigator):
                 return .mapNavigator(roomID: roomID)
-            case (.dismissMapNavigator, .mapNavigator(let roomID)):
+            case (.mapNavigator(let roomID), .dismissMapNavigator):
                 return .room(roomID: roomID)
 
-            case (.presentPollForm, .room(let roomID)):
+            case (.room(let roomID), .presentPollForm):
                 return .pollForm(roomID: roomID)
-            case (.dismissPollForm, .pollForm(let roomID)):
+            case (.pollForm(let roomID), .dismissPollForm):
                 return .room(roomID: roomID)
 
             default:

--- a/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
+++ b/ElementX/Sources/FlowCoordinators/RoomFlowCoordinator.swift
@@ -86,8 +86,8 @@ class RoomFlowCoordinator: FlowCoordinatorProtocol {
     func handleAppRoute(_ appRoute: AppRoute, animated: Bool) {
         switch appRoute {
         case .room(let roomID):
-            if case .room(let roomID) = stateMachine.state,
-               roomID == roomID {
+            if case .room(let identifier) = stateMachine.state,
+               roomID == identifier {
                 return
             }
             

--- a/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
+++ b/ElementX/Sources/FlowCoordinators/UserSessionFlowCoordinatorStateMachine.swift
@@ -130,50 +130,50 @@ class UserSessionFlowCoordinatorStateMachine {
         stateMachine.addRoutes(event: .dismissedWelcomeScreen, transitions: [.welcomeScreen => .roomList(selectedRoomID: nil)])
 
         stateMachine.addRouteMapping { event, fromState, _ in
-            switch (event, fromState) {
-            case (.selectRoom(let roomID), .roomList):
+            switch (fromState, event) {
+            case (.roomList, .selectRoom(let roomID)):
                 return .roomList(selectedRoomID: roomID)
-            case (.selectRoom(let roomID), .invitesScreen):
+            case (.invitesScreen, .selectRoom(let roomID)):
                 return .invitesScreen(selectedRoomID: roomID)
-            case (.deselectRoom, .roomList):
+            case (.roomList, .deselectRoom):
                 return .roomList(selectedRoomID: nil)
-            case (.deselectRoom, .invitesScreen):
+            case (.invitesScreen, .deselectRoom):
                 return .invitesScreen(selectedRoomID: nil)
 
-            case (.showSettingsScreen, .roomList(let selectedRoomID)):
+            case (.roomList(let selectedRoomID), .showSettingsScreen):
                 return .settingsScreen(selectedRoomID: selectedRoomID)
-            case (.dismissedSettingsScreen, .settingsScreen(let selectedRoomID)):
+            case (.settingsScreen(let selectedRoomID), .dismissedSettingsScreen):
                 return .roomList(selectedRoomID: selectedRoomID)
                 
-            case (.feedbackScreen, .roomList(let selectedRoomID)):
+            case (.roomList(let selectedRoomID), .feedbackScreen):
                 return .feedbackScreen(selectedRoomID: selectedRoomID)
-            case (.dismissedFeedbackScreen, .feedbackScreen(let selectedRoomID)):
+            case (.feedbackScreen(let selectedRoomID), .dismissedFeedbackScreen):
                 return .roomList(selectedRoomID: selectedRoomID)
                 
-            case (.showSessionVerificationScreen, .roomList(let selectedRoomID)):
+            case (.roomList(let selectedRoomID), .showSessionVerificationScreen):
                 return .sessionVerificationScreen(selectedRoomID: selectedRoomID)
-            case (.dismissedSessionVerificationScreen, .sessionVerificationScreen(let selectedRoomID)):
+            case (.sessionVerificationScreen(let selectedRoomID), .dismissedSessionVerificationScreen):
                 return .roomList(selectedRoomID: selectedRoomID)
                 
-            case (.showStartChatScreen, .roomList(let selectedRoomID)):
+            case (.roomList(let selectedRoomID), .showStartChatScreen):
                 return .startChatScreen(selectedRoomID: selectedRoomID)
-            case (.dismissedStartChatScreen, .startChatScreen(let selectedRoomID)):
+            case (.startChatScreen(let selectedRoomID), .dismissedStartChatScreen):
                 return .roomList(selectedRoomID: selectedRoomID)
             
-            case (.showInvitesScreen, .roomList(let selectedRoomID)):
+            case (.roomList(let selectedRoomID), .showInvitesScreen):
                 return .invitesScreen(selectedRoomID: selectedRoomID)
-            case (.showInvitesScreen, .invitesScreen(let selectedRoomID)):
+            case (.invitesScreen(let selectedRoomID), .showInvitesScreen):
                 return .invitesScreen(selectedRoomID: selectedRoomID)
 
-            case (.dismissedInvitesScreen, .invitesScreen(let selectedRoomID)):
+            case (.invitesScreen(let selectedRoomID), .dismissedInvitesScreen):
                 return .roomList(selectedRoomID: selectedRoomID)
 
-            case (.presentWelcomeScreen, .roomList):
+            case (.roomList, .presentWelcomeScreen):
                 return .welcomeScreen
                 
-            case (.showLogoutConfirmationScreen, .roomList(let selectedRoomID)):
+            case (.roomList(let selectedRoomID), .showLogoutConfirmationScreen):
                 return .logoutConfirmationScreen(selectedRoomID: selectedRoomID)
-            case (.dismissedLogoutConfirmationScreen, .logoutConfirmationScreen(let selectedRoomID)):
+            case (.logoutConfirmationScreen(let selectedRoomID), .dismissedLogoutConfirmationScreen):
                 return .roomList(selectedRoomID: selectedRoomID)
                 
             default:

--- a/ElementX/Sources/Generated/Strings.swift
+++ b/ElementX/Sources/Generated/Strings.swift
@@ -250,6 +250,8 @@ public enum L10n {
   public static var commonDecryptionError: String { return L10n.tr("Localizable", "common_decryption_error") }
   /// Developer options
   public static var commonDeveloperOptions: String { return L10n.tr("Localizable", "common_developer_options") }
+  /// Direct chat
+  public static var commonDirectChat: String { return L10n.tr("Localizable", "common_direct_chat") }
   /// (edited)
   public static var commonEditedSuffix: String { return L10n.tr("Localizable", "common_edited_suffix") }
   /// Editing

--- a/ElementX/Sources/Other/AccessibilityIdentifiers.swift
+++ b/ElementX/Sources/Other/AccessibilityIdentifiers.swift
@@ -175,6 +175,7 @@ enum A11yIdentifiers {
     struct RoomMemberDetailsScreen {
         let ignore = "room_member_details-ignore"
         let unignore = "room_member_details-unignore"
+        let directChat = "room_member_details-direct_chat"
     }
     
     struct RoomNotificationSettingsScreen {

--- a/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomDetailsScreen/RoomDetailsScreenCoordinator.swift
@@ -19,26 +19,23 @@ import SwiftUI
 
 struct RoomDetailsScreenCoordinatorParameters {
     let accountUserID: String
-    weak var navigationStackCoordinator: NavigationStackCoordinator?
     let roomProxy: RoomProxyProtocol
     let mediaProvider: MediaProviderProtocol
-    let userDiscoveryService: UserDiscoveryServiceProtocol
     let userIndicatorController: UserIndicatorControllerProtocol
     let notificationSettings: NotificationSettingsProxyProtocol
 }
 
 enum RoomDetailsScreenCoordinatorAction {
     case leftRoom
+    case presentRoomMembersList
+    case presentRoomDetailsEditScreen(accountOwner: RoomMemberProxyProtocol)
     case presentNotificationSettingsScreen
+    case presentInviteUsersScreen
 }
 
 final class RoomDetailsScreenCoordinator: CoordinatorProtocol {
     private let parameters: RoomDetailsScreenCoordinatorParameters
     private var viewModel: RoomDetailsScreenViewModelProtocol
-    private let selectedUsers: CurrentValueSubject<[UserProfileProxy], Never> = .init([])
-    private var navigationStackCoordinator: NavigationStackCoordinator? {
-        parameters.navigationStackCoordinator
-    }
     
     private let actionsSubject: PassthroughSubject<RoomDetailsScreenCoordinatorAction, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
@@ -66,15 +63,15 @@ final class RoomDetailsScreenCoordinator: CoordinatorProtocol {
                 
                 switch action {
                 case .requestMemberDetailsPresentation:
-                    presentRoomMembersList()
+                    actionsSubject.send(.presentRoomMembersList)
                 case .requestInvitePeoplePresentation:
-                    presentInviteUsersScreen()
+                    actionsSubject.send(.presentInviteUsersScreen)
                 case .leftRoom:
                     actionsSubject.send(.leftRoom)
                 case .requestEditDetailsPresentation(let accountOwner):
-                    presentRoomDetailsEditScreen(accountOwner: accountOwner)
+                    actionsSubject.send(.presentRoomDetailsEditScreen(accountOwner: accountOwner))
                 case .requestNotificationSettingsPresentation:
-                    presentNotificationSettings()
+                    actionsSubject.send(.presentNotificationSettingsScreen)
                 }
             }
             .store(in: &cancellables)
@@ -86,145 +83,5 @@ final class RoomDetailsScreenCoordinator: CoordinatorProtocol {
     
     func toPresentable() -> AnyView {
         AnyView(RoomDetailsScreen(context: viewModel.context))
-    }
-    
-    // MARK: - Private
-    
-    private func presentRoomMembersList() {
-        let params = RoomMembersListScreenCoordinatorParameters(navigationStackCoordinator: navigationStackCoordinator,
-                                                                mediaProvider: parameters.mediaProvider,
-                                                                roomProxy: parameters.roomProxy)
-        let coordinator = RoomMembersListScreenCoordinator(parameters: params)
-        
-        coordinator.actions
-            .sink { [weak self] action in
-                guard let self else { return }
-                
-                switch action {
-                case .invite:
-                    presentInviteUsersScreen()
-                }
-            }
-            .store(in: &cancellables)
-        
-        navigationStackCoordinator?.push(coordinator)
-    }
-    
-    private func presentInviteUsersScreen() {
-        let inviteUsersStackCoordinator = NavigationStackCoordinator()
-        let inviteParameters = InviteUsersScreenCoordinatorParameters(selectedUsers: .init(selectedUsers),
-                                                                      roomType: .room(roomProxy: parameters.roomProxy),
-                                                                      mediaProvider: parameters.mediaProvider,
-                                                                      userDiscoveryService: parameters.userDiscoveryService,
-                                                                      userIndicatorController: parameters.userIndicatorController)
-        
-        let coordinator = InviteUsersScreenCoordinator(parameters: inviteParameters)
-        inviteUsersStackCoordinator.setRootCoordinator(coordinator)
-        
-        coordinator.actions.sink { [weak self] action in
-            guard let self else { return }
-            
-            switch action {
-            case .cancel:
-                navigationStackCoordinator?.setSheetCoordinator(nil)
-            case .proceed:
-                break
-            case .invite(let users):
-                self.inviteUsers(users, in: parameters.roomProxy)
-            case .toggleUser(let user):
-                self.toggleUser(user)
-            }
-        }
-        .store(in: &cancellables)
-        
-        navigationStackCoordinator?.setSheetCoordinator(inviteUsersStackCoordinator) { [weak self] in
-            self?.selectedUsers.value = []
-        }
-    }
-    
-    private func presentRoomDetailsEditScreen(accountOwner: RoomMemberProxyProtocol) {
-        let navigationStackCoordinator = NavigationStackCoordinator()
-        
-        let roomDetailsEditParameters = RoomDetailsEditScreenCoordinatorParameters(accountOwner: accountOwner,
-                                                                                   mediaProvider: parameters.mediaProvider,
-                                                                                   navigationStackCoordinator: navigationStackCoordinator,
-                                                                                   roomProxy: parameters.roomProxy,
-                                                                                   userIndicatorController: parameters.userIndicatorController)
-        let roomDetailsEditCoordinator = RoomDetailsEditScreenCoordinator(parameters: roomDetailsEditParameters)
-        
-        roomDetailsEditCoordinator.actions.sink { [weak self] action in
-            switch action {
-            case .dismiss:
-                self?.navigationStackCoordinator?.setSheetCoordinator(nil)
-            }
-        }
-        .store(in: &cancellables)
-        
-        navigationStackCoordinator.setRootCoordinator(roomDetailsEditCoordinator)
-        
-        self.navigationStackCoordinator?.setSheetCoordinator(navigationStackCoordinator)
-    }
-    
-    private func toggleUser(_ user: UserProfileProxy) {
-        var selectedUsers = selectedUsers.value
-        if let index = selectedUsers.firstIndex(where: { $0.userID == user.userID }) {
-            selectedUsers.remove(at: index)
-        } else {
-            selectedUsers.append(user)
-        }
-        self.selectedUsers.send(selectedUsers)
-    }
-    
-    private func inviteUsers(_ users: [String], in room: RoomProxyProtocol) {
-        navigationStackCoordinator?.setSheetCoordinator(nil)
-        
-        Task {
-            let result: Result<Void, RoomProxyError> = await withTaskGroup(of: Result<Void, RoomProxyError>.self) { group in
-                for user in users {
-                    group.addTask {
-                        await room.invite(userID: user)
-                    }
-                }
-                
-                return await group.first { inviteResult in
-                    inviteResult.isFailure
-                } ?? .success(())
-            }
-            
-            guard case .failure = result else {
-                return
-            }
-            
-            parameters.userIndicatorController.alertInfo = .init(id: .init(),
-                                                                 title: L10n.commonUnableToInviteTitle,
-                                                                 message: L10n.commonUnableToInviteMessage)
-        }
-    }
-    
-    private func presentNotificationSettings() {
-        let roomNotificationSettingsParameters = RoomNotificationSettingsScreenCoordinatorParameters(navigationStackCoordinator: parameters.navigationStackCoordinator,
-                                                                                                     notificationSettingsProxy: parameters.notificationSettings,
-                                                                                                     roomProxy: parameters.roomProxy,
-                                                                                                     displayAsUserDefinedRoomSettings: false)
-        let roomNotificationSettingsCoordinator = RoomNotificationSettingsScreenCoordinator(parameters: roomNotificationSettingsParameters)
-        roomNotificationSettingsCoordinator.actions.sink { [weak self] actions in
-            switch actions {
-            case .presentNotificationSettingsScreen:
-                self?.actionsSubject.send(.presentNotificationSettingsScreen)
-            }
-        }
-        .store(in: &cancellables)
-        navigationStackCoordinator?.push(roomNotificationSettingsCoordinator)
-    }
-}
-
-private extension Result {
-    var isFailure: Bool {
-        switch self {
-        case .success:
-            return false
-        case .failure:
-            return true
-        }
     }
 }

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenCoordinator.swift
@@ -24,7 +24,9 @@ struct RoomMemberDetailsScreenCoordinatorParameters {
     let userIndicatorController: UserIndicatorControllerProtocol
 }
 
-enum RoomMemberDetailsScreenCoordinatorAction { }
+enum RoomMemberDetailsScreenCoordinatorAction {
+    case openDirectChat
+}
 
 final class RoomMemberDetailsScreenCoordinator: CoordinatorProtocol {
     private let parameters: RoomMemberDetailsScreenCoordinatorParameters
@@ -45,8 +47,18 @@ final class RoomMemberDetailsScreenCoordinator: CoordinatorProtocol {
                                                      mediaProvider: parameters.mediaProvider,
                                                      userIndicatorController: parameters.userIndicatorController)
     }
-
-    func start() { }
+    
+    func start() {
+        viewModel.actions.sink { [weak self] action in
+            guard let self else { return }
+            
+            switch action {
+            case .openDirectChat:
+                actionsSubject.send(.openDirectChat)
+            }
+        }
+        .store(in: &cancellables)
+    }
     
     func stop() { viewModel.stop() }
 

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenModels.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenModels.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 
-enum RoomMemberDetailsScreenViewModelAction { }
+enum RoomMemberDetailsScreenViewModelAction {
+    case openDirectChat
+}
 
 struct RoomMemberDetailsScreenViewState: BindableState {
     var details: RoomMemberDetails
@@ -77,6 +79,7 @@ enum RoomMemberDetailsScreenViewAction {
     case ignoreConfirmed
     case unignoreConfirmed
     case displayAvatar
+    case openDirectChat
 }
 
 enum RoomMemberDetailsScreenError: Hashable {

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/RoomMemberDetailsScreenViewModel.swift
@@ -65,6 +65,8 @@ class RoomMemberDetailsScreenViewModel: RoomMemberDetailsScreenViewModelType, Ro
             Task { await unignoreUser() }
         case .displayAvatar:
             displayFullScreenAvatar()
+        case .openDirectChat:
+            actionsSubject.send(.openDirectChat)
         }
     }
 

--- a/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
+++ b/ElementX/Sources/Screens/RoomMemberDetailsScreen/View/RoomMemberDetailsScreen.swift
@@ -25,6 +25,7 @@ struct RoomMemberDetailsScreen: View {
             headerSection
 
             if !context.viewState.details.isAccountOwner {
+                directChatSection
                 blockUserSection
             }
         }
@@ -56,6 +57,17 @@ struct RoomMemberDetailsScreen: View {
                 }
                 .padding(.top, 32)
             }
+        }
+    }
+    
+    private var directChatSection: some View {
+        Section {
+            ListRow(label: .default(title: L10n.commonDirectChat,
+                                    icon: \.chat),
+                    kind: .button {
+                        context.send(viewAction: .openDirectChat)
+                    })
+                    .accessibilityIdentifier(A11yIdentifiers.roomMemberDetailsScreen.directChat)
         }
     }
 

--- a/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomMemberListScreen/RoomMembersListScreenCoordinator.swift
@@ -18,21 +18,18 @@ import Combine
 import SwiftUI
 
 struct RoomMembersListScreenCoordinatorParameters {
-    weak var navigationStackCoordinator: NavigationStackCoordinator?
     let mediaProvider: MediaProviderProtocol
     let roomProxy: RoomProxyProtocol
 }
 
 enum RoomMembersListScreenCoordinatorAction {
     case invite
+    case selectedMember(RoomMemberProxyProtocol)
 }
 
 final class RoomMembersListScreenCoordinator: CoordinatorProtocol {
     private let parameters: RoomMembersListScreenCoordinatorParameters
     private var viewModel: RoomMembersListScreenViewModelProtocol
-    private var navigationStackCoordinator: NavigationStackCoordinator? {
-        parameters.navigationStackCoordinator
-    }
     
     private let actionsSubject: PassthroughSubject<RoomMembersListScreenCoordinatorAction, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
@@ -56,7 +53,7 @@ final class RoomMembersListScreenCoordinator: CoordinatorProtocol {
                 
                 switch action {
                 case let .selectMember(member):
-                    selectMember(member)
+                    actionsSubject.send(.selectedMember(member))
                 case .invite:
                     actionsSubject.send(.invite)
                 }
@@ -66,17 +63,5 @@ final class RoomMembersListScreenCoordinator: CoordinatorProtocol {
         
     func toPresentable() -> AnyView {
         AnyView(RoomMembersListScreen(context: viewModel.context))
-    }
-
-    // MARK: - Private
-
-    private func selectMember(_ member: RoomMemberProxyProtocol) {
-        let parameters = RoomMemberDetailsScreenCoordinatorParameters(roomProxy: parameters.roomProxy,
-                                                                      roomMemberProxy: member,
-                                                                      mediaProvider: parameters.mediaProvider,
-                                                                      userIndicatorController: ServiceLocator.shared.userIndicatorController)
-        let coordinator = RoomMemberDetailsScreenCoordinator(parameters: parameters)
-
-        navigationStackCoordinator?.push(coordinator)
     }
 }

--- a/ElementX/Sources/Screens/RoomNotificationSettingsScreen/RoomNotificationSettingsScreenCoordinator.swift
+++ b/ElementX/Sources/Screens/RoomNotificationSettingsScreen/RoomNotificationSettingsScreenCoordinator.swift
@@ -25,7 +25,7 @@ struct RoomNotificationSettingsScreenCoordinatorParameters {
 }
 
 enum RoomNotificationSettingsScreenCoordinatorAction {
-    case presentNotificationSettingsScreen
+    case presentGlobalNotificationSettingsScreen
 }
 
 final class RoomNotificationSettingsScreenCoordinator: CoordinatorProtocol {
@@ -54,7 +54,7 @@ final class RoomNotificationSettingsScreenCoordinator: CoordinatorProtocol {
         viewModel.actions.sink { [weak self] action in
             switch action {
             case .openGlobalSettings:
-                self?.actionsSubject.send(.presentNotificationSettingsScreen)
+                self?.actionsSubject.send(.presentGlobalNotificationSettingsScreen)
             case .dismiss:
                 self?.parameters.navigationStackCoordinator?.pop(animated: true)
             }

--- a/ElementX/Sources/Screens/SessionVerificationScreen/SessionVerificationScreenStateMachine.swift
+++ b/ElementX/Sources/Screens/SessionVerificationScreen/SessionVerificationScreenStateMachine.swift
@@ -92,28 +92,28 @@ class SessionVerificationScreenStateMachine {
         
         // Transitions with associated values need to be handled through `addRouteMapping`
         stateMachine.addRouteMapping { event, fromState, _ in
-            switch (event, fromState) {
-            case (.didStartSasVerification, _):
+            switch (fromState, event) {
+            case (_, .didStartSasVerification):
                 return .sasVerificationStarted
                 
-            case (.didReceiveChallenge(let emojis), .sasVerificationStarted):
+            case (.sasVerificationStarted, .didReceiveChallenge(let emojis)):
                 return .showingChallenge(emojis: emojis)
-            case (.acceptChallenge, .showingChallenge(let emojis)):
+            case (.showingChallenge(let emojis), .acceptChallenge):
                 return .acceptingChallenge(emojis: emojis)
-            case (.didFail, .acceptingChallenge(let emojis)):
+            case (.acceptingChallenge(let emojis), .didFail):
                 return .showingChallenge(emojis: emojis)
                 
-            case (.didAcceptChallenge, .acceptingChallenge):
+            case (.acceptingChallenge, .didAcceptChallenge):
                 return .verified
                 
-            case (.declineChallenge, .showingChallenge(let emojis)):
+            case (.showingChallenge(let emojis), .declineChallenge):
                 return .decliningChallenge(emojis: emojis)
-            case (.didFail, .decliningChallenge(let emojis)):
+            case (.decliningChallenge(let emojis), .didFail):
                 return .showingChallenge(emojis: emojis)
                 
-            case (.cancel, _):
+            case (_, .cancel):
                 return .cancelling
-            case (.didCancel, _):
+            case (_, .didCancel):
                 return .cancelled
                 
             default:

--- a/ElementX/Sources/UITests/UITestsAppCoordinator.swift
+++ b/ElementX/Sources/UITests/UITestsAppCoordinator.swift
@@ -586,10 +586,8 @@ class MockScreen: Identifiable {
                                                       memberForID: .mockOwner(allowedStateEvents: [], canInviteUsers: false),
                                                       activeMembersCount: members.count))
             let coordinator = RoomDetailsScreenCoordinator(parameters: .init(accountUserID: "@owner:somewhere.com",
-                                                                             navigationStackCoordinator: navigationStackCoordinator,
                                                                              roomProxy: roomProxy,
                                                                              mediaProvider: MockMediaProvider(),
-                                                                             userDiscoveryService: UserDiscoveryServiceMock(),
                                                                              userIndicatorController: ServiceLocator.shared.userIndicatorController,
                                                                              notificationSettings: NotificationSettingsProxyMock(with: .init())))
             navigationStackCoordinator.setRootCoordinator(coordinator)
@@ -607,10 +605,8 @@ class MockScreen: Identifiable {
                                                       memberForID: .mockOwner(allowedStateEvents: [], canInviteUsers: false),
                                                       activeMembersCount: members.count))
             let coordinator = RoomDetailsScreenCoordinator(parameters: .init(accountUserID: "@owner:somewhere.com",
-                                                                             navigationStackCoordinator: navigationStackCoordinator,
                                                                              roomProxy: roomProxy,
                                                                              mediaProvider: MockMediaProvider(),
-                                                                             userDiscoveryService: UserDiscoveryServiceMock(),
                                                                              userIndicatorController: ServiceLocator.shared.userIndicatorController,
                                                                              notificationSettings: NotificationSettingsProxyMock(with: .init())))
             navigationStackCoordinator.setRootCoordinator(coordinator)
@@ -630,10 +626,8 @@ class MockScreen: Identifiable {
                                                       memberForID: owner,
                                                       activeMembersCount: members.count))
             let coordinator = RoomDetailsScreenCoordinator(parameters: .init(accountUserID: "@owner:somewhere.com",
-                                                                             navigationStackCoordinator: navigationStackCoordinator,
                                                                              roomProxy: roomProxy,
                                                                              mediaProvider: MockMediaProvider(),
-                                                                             userDiscoveryService: UserDiscoveryServiceMock(),
                                                                              userIndicatorController: ServiceLocator.shared.userIndicatorController,
                                                                              notificationSettings: NotificationSettingsProxyMock(with: .init())))
             navigationStackCoordinator.setRootCoordinator(coordinator)
@@ -649,10 +643,8 @@ class MockScreen: Identifiable {
                                                       memberForID: owner,
                                                       activeMembersCount: members.count))
             let coordinator = RoomDetailsScreenCoordinator(parameters: .init(accountUserID: "@owner:somewhere.com",
-                                                                             navigationStackCoordinator: navigationStackCoordinator,
                                                                              roomProxy: roomProxy,
                                                                              mediaProvider: MockMediaProvider(),
-                                                                             userDiscoveryService: UserDiscoveryServiceMock(),
                                                                              userIndicatorController: ServiceLocator.shared.userIndicatorController,
                                                                              notificationSettings: NotificationSettingsProxyMock(with: .init())))
             navigationStackCoordinator.setRootCoordinator(coordinator)
@@ -669,10 +661,8 @@ class MockScreen: Identifiable {
                                                       memberForID: .mockOwner(allowedStateEvents: [], canInviteUsers: false),
                                                       activeMembersCount: members.count))
             let coordinator = RoomDetailsScreenCoordinator(parameters: .init(accountUserID: "@owner:somewhere.com",
-                                                                             navigationStackCoordinator: navigationStackCoordinator,
                                                                              roomProxy: roomProxy,
                                                                              mediaProvider: MockMediaProvider(),
-                                                                             userDiscoveryService: UserDiscoveryServiceMock(),
                                                                              userIndicatorController: ServiceLocator.shared.userIndicatorController,
                                                                              notificationSettings: NotificationSettingsProxyMock(with: .init())))
             navigationStackCoordinator.setRootCoordinator(coordinator)
@@ -695,16 +685,14 @@ class MockScreen: Identifiable {
         case .roomMembersListScreen:
             let navigationStackCoordinator = NavigationStackCoordinator()
             let members: [RoomMemberProxyMock] = [.mockAlice, .mockBob, .mockCharlie]
-            let coordinator = RoomMembersListScreenCoordinator(parameters: .init(navigationStackCoordinator: navigationStackCoordinator,
-                                                                                 mediaProvider: MockMediaProvider(),
+            let coordinator = RoomMembersListScreenCoordinator(parameters: .init(mediaProvider: MockMediaProvider(),
                                                                                  roomProxy: RoomProxyMock(with: .init(displayName: "test", members: members))))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator
         case .roomMembersListScreenPendingInvites:
             let navigationStackCoordinator = NavigationStackCoordinator()
             let members: [RoomMemberProxyMock] = [.mockInvitedAlice, .mockBob, .mockCharlie]
-            let coordinator = RoomMembersListScreenCoordinator(parameters: .init(navigationStackCoordinator: navigationStackCoordinator,
-                                                                                 mediaProvider: MockMediaProvider(),
+            let coordinator = RoomMembersListScreenCoordinator(parameters: .init(mediaProvider: MockMediaProvider(),
                                                                                  roomProxy: RoomProxyMock(with: .init(displayName: "test", members: members))))
             navigationStackCoordinator.setRootCoordinator(coordinator)
             return navigationStackCoordinator

--- a/UnitTests/__Snapshots__/PreviewTests/test_roomMemberDetailsScreen.Account-Owner.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_roomMemberDetailsScreen.Account-Owner.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:610691a13e03beff0d88785f9ac7e80d6aa09bc68c20f6cc4ea91aec7159eb46
-size 127526
+oid sha256:dadbed9642ee3ff23df20aa86cf9d90ffe8a629fead453235de93ffac573c7c3
+size 127652

--- a/UnitTests/__Snapshots__/PreviewTests/test_roomMemberDetailsScreen.Ignored-User.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_roomMemberDetailsScreen.Ignored-User.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:142dee5459592cd3b21a5fa089d160c7af682f639e443172cd634e1e124b8531
-size 100514
+oid sha256:b664834d021eb811ddaaf392c7dbbf039398ba94bacf4b855d9fb121cf035019
+size 108437

--- a/UnitTests/__Snapshots__/PreviewTests/test_roomMemberDetailsScreen.Other-User.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_roomMemberDetailsScreen.Other-User.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb98ad72d36f6204a0c5b80a82faa0346c7ca507393291f9983089bbab003a6e
-size 140051
+oid sha256:fc2d8177c1e175c6948e4243f0fb0067a7c6b0ba3e69ab9d3ef1bcbeb7c5d247
+size 148276

--- a/changelog.d/2179.feature
+++ b/changelog.d/2179.feature
@@ -1,0 +1,1 @@
+Open direct chat directly from the room member details screen


### PR DESCRIPTION
This PR adds a button on the room member's detail screen to open an existing direct message (or create it). In order to do so and not break the navigation coordination a lot of methods have been moved from the room detiail screen coordinator and into the RoomFlowCoordinator.

This PR can and should be reviewed commit by commit