### PR TITLE
Fix: added sample rate conversion for recording voice messages

### DIFF
--- a/ElementX/Sources/Services/Audio/Recorder/AudioRecorderProtocol.swift
+++ b/ElementX/Sources/Services/Audio/Recorder/AudioRecorderProtocol.swift
@@ -18,6 +18,8 @@ import Combine
 import Foundation
 
 enum AudioRecorderError: Error, Equatable {
+    case unsupportedAudioFormat
+    case audioSessionFailure
     case audioEngineFailure
     case audioFileCreationFailure
     case interrupted

--- a/changelog.d/2184.bugfix
+++ b/changelog.d/2184.bugfix
@@ -1,0 +1,1 @@
+Fixed a crash when sending voice messages on some Apple devices.


### PR DESCRIPTION
This PR fixes #2184 

This crash was due to a sample rate (44100) that doesn't seem to be supported by `opus_encoder_create`.

The default sample rate has changed between iPhone X and iPhone 11. Since iPhone 11, the default sample rate when recording is `48000` (it was `44100`).

The fix is to use `AVAudioConverter` to convert the audio buffer to the correct sample rate (48000).

Recording and sending a voice message now works correctly:
- on iOS with a default recording sample rate of 44100
- on iOS with a default recording sample rate of 48000
