### PR TITLE
Revert "Search bar new room invite screen now always shows the nav bar on top"

### DIFF
--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -30,7 +30,7 @@ struct InviteUsersScreen: View {
             .disableInteractiveDismissOnSearch()
             .dismissSearchOnDisappear()
             .searchable(text: $context.searchQuery, placement: .navigationBarDrawer(displayMode: .always), prompt: L10n.commonSearchForSomeone)
-            .searchableConfiguration(hidesNavigationBar: false, showsCancelButton: false)
+            .searchableConfiguration(hidesNavigationBar: false)
             .compoundSearchField()
             .alert(item: $context.alertInfo)
             .readFrame($frame)

--- a/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
@@ -55,7 +55,7 @@ struct MessageForwardingScreen: View {
             }
         }
         .searchable(text: $context.searchQuery, placement: .navigationBarDrawer(displayMode: .always))
-        .searchableConfiguration(hidesNavigationBar: false, showsCancelButton: false)
+        .searchableConfiguration(hidesNavigationBar: false)
         .compoundSearchField()
         .disableAutocorrection(true)
     }

--- a/ElementX/Sources/Screens/StartChatScreen/View/StartChatScreen.swift
+++ b/ElementX/Sources/Screens/StartChatScreen/View/StartChatScreen.swift
@@ -37,7 +37,6 @@ struct StartChatScreen: View {
         .disableInteractiveDismissOnSearch()
         .dismissSearchOnDisappear()
         .searchable(text: $context.searchQuery, placement: .navigationBarDrawer(displayMode: .always), prompt: L10n.commonSearchForSomeone)
-        .searchableConfiguration(hidesNavigationBar: false, showsCancelButton: false)
         .compoundSearchField()
         .alert(item: $context.alertInfo)
     }

--- a/changelog.d/pr-2182.bugfix
+++ b/changelog.d/pr-2182.bugfix
@@ -1,1 +1,0 @@
-Fix for the search bar not appearing always in the invite to new room screen.


### PR DESCRIPTION
Reverts vector-im/element-x-ios#2182

While the fix works fine on iOS 16.4 and iOS 17.0.1, sadly on iOS 17.1.1 this fix creates a scrambled screen.
Reverting this for now in the hope that the next iOS version will have this issue fixed

![IMG_0881](https://github.com/vector-im/element-x-ios/assets/34335419/60659f93-3b04-4bca-9747-2f662facb05c)
