### PR TITLE
Fixed some issues with voice messages when sent from a bridge.

### DIFF
--- a/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
+++ b/ElementX/Sources/Mocks/Generated/GeneratedMocks.swift
@@ -438,6 +438,11 @@ class AudioPlayerMock: AudioPlayerProtocol {
     }
     var underlyingActions: AnyPublisher<AudioPlayerAction, Never>!
     var mediaSource: MediaSourceProxy?
+    var duration: TimeInterval {
+        get { return underlyingDuration }
+        set(value) { underlyingDuration = value }
+    }
+    var underlyingDuration: TimeInterval!
     var currentTime: TimeInterval {
         get { return underlyingCurrentTime }
         set(value) { underlyingCurrentTime = value }
@@ -1082,6 +1087,11 @@ class KeychainControllerMock: KeychainControllerProtocol {
 }
 class MediaPlayerMock: MediaPlayerProtocol {
     var mediaSource: MediaSourceProxy?
+    var duration: TimeInterval {
+        get { return underlyingDuration }
+        set(value) { underlyingDuration = value }
+    }
+    var underlyingDuration: TimeInterval!
     var currentTime: TimeInterval {
         get { return underlyingCurrentTime }
         set(value) { underlyingCurrentTime = value }

--- a/ElementX/Sources/Services/Audio/Player/AudioPlayerState.swift
+++ b/ElementX/Sources/Services/Audio/Player/AudioPlayerState.swift
@@ -34,7 +34,7 @@ enum AudioPlayerStateIdentifier {
 @MainActor
 class AudioPlayerState: ObservableObject, Identifiable {
     let id: AudioPlayerStateIdentifier
-    let duration: Double
+    private(set) var duration: Double
     let waveform: EstimatedWaveform
     @Published private(set) var playbackState: AudioPlayerPlaybackState
     /// It's similar to `playbackState`, with the a difference: `.loading`
@@ -134,8 +134,12 @@ class AudioPlayerState: ObservableObject, Identifiable {
         case .didStartLoading:
             playbackState = .loading
         case .didFinishLoading:
-            playbackState = .readyToPlay
+            if let audioPlayerDuration = audioPlayer?.duration, audioPlayerDuration != duration {
+                MXLog.info("updating duration: \(duration) -> \(audioPlayerDuration)")
+                duration = audioPlayerDuration
+            }
             fileURL = audioPlayer?.url
+            playbackState = .readyToPlay
         case .didStartPlaying:
             if let audioPlayer {
                 await restoreAudioPlayerState(audioPlayer: audioPlayer)

--- a/ElementX/Sources/Services/MediaPlayer/MediaPlayerProtocol.swift
+++ b/ElementX/Sources/Services/MediaPlayer/MediaPlayerProtocol.swift
@@ -26,7 +26,7 @@ enum MediaPlayerState {
 
 protocol MediaPlayerProtocol: AnyObject {
     var mediaSource: MediaSourceProxy? { get }
-    
+    var duration: TimeInterval { get }
     var currentTime: TimeInterval { get }
     var url: URL? { get }
     var state: MediaPlayerState { get }

--- a/ElementX/Sources/Services/VoiceMessage/VoiceMessageMediaManager.swift
+++ b/ElementX/Sources/Services/VoiceMessage/VoiceMessageMediaManager.swift
@@ -56,7 +56,7 @@ class VoiceMessageMediaManager: VoiceMessageMediaManagerProtocol {
         let loadFileBgTask = await backgroundTaskService?.startBackgroundTask(withName: "LoadFile: \(source.url.hashValue)")
         defer { loadFileBgTask?.stop() }
 
-        guard let mimeType = source.mimeType, mimeType == supportedVoiceMessageMimeType else {
+        guard let mimeType = source.mimeType, mimeType.starts(with: supportedVoiceMessageMimeType) else {
             throw VoiceMessageMediaManagerError.unsupportedMimeTye
         }
         

--- a/UnitTests/Sources/AudioPlayerStateTests.swift
+++ b/UnitTests/Sources/AudioPlayerStateTests.swift
@@ -171,8 +171,9 @@ class AudioPlayerStateTests: XCTestCase {
     }
 
     func testHandlingAudioPlayerActionDidFinishLoading() async throws {
-        let originalStateProgress = 0.4
-        await audioPlayerState.updateState(progress: originalStateProgress)
+        audioPlayerMock.duration = 10.0
+        
+        audioPlayerState = AudioPlayerState(id: .timelineItemIdentifier(.random), duration: 0)
         audioPlayerState.attachAudioPlayer(audioPlayerMock)
 
         let deferred = deferFulfillment(audioPlayerState.$playbackState) { action in
@@ -189,6 +190,8 @@ class AudioPlayerStateTests: XCTestCase {
         
         // The state is expected to be .readyToPlay
         XCTAssertEqual(audioPlayerState.playbackState, .readyToPlay)
+        // The duration should have been updated with the player's duration
+        XCTAssertEqual(audioPlayerState.duration, audioPlayerMock.duration)
     }
     
     func testHandlingAudioPlayerActionDidStartPlaying() async throws {

--- a/UnitTests/Sources/VoiceMessageMediaManagerTests.swift
+++ b/UnitTests/Sources/VoiceMessageMediaManagerTests.swift
@@ -52,6 +52,29 @@ class VoiceMessageMediaManagerTests: XCTestCase {
         }
     }
     
+    func testLoadVoiceMessageFromSourceMimeTypeWithParameters() async throws {
+        // URL representing the file loaded by the media provider
+        let loadedFile = URL("/some/url/loaded_file.ogg")
+        // URL representing the final cached file
+        let cachedConvertedFileURL = URL("/some/url/cached_converted_file.m4a")
+        
+        voiceMessageCache.fileURLForReturnValue = nil
+        let mediaSource = MediaSourceProxy(url: someURL, mimeType: "audio/ogg; codecs=opus")
+        mediaProvider.loadFileFromSourceReturnValue = MediaFileHandleProxy.unmanaged(url: loadedFile)
+        voiceMessageCache.cacheMediaSourceUsingMoveReturnValue = .success(cachedConvertedFileURL)
+        
+        voiceMessageMediaManager = VoiceMessageMediaManager(mediaProvider: mediaProvider,
+                                                            voiceMessageCache: voiceMessageCache,
+                                                            audioConverter: AudioConverterMock(),
+                                                            backgroundTaskService: MockBackgroundTaskService())
+        
+        do {
+            _ = try await voiceMessageMediaManager.loadVoiceMessageFromSource(mediaSource, body: nil)
+        } catch {
+            XCTFail("An unexpected error has occured: \(error)")
+        }
+    }
+    
     func testLoadVoiceMessageFromSourceAlreadyCached() async throws {
         // Check if the file is already present in cache
         voiceMessageCache.fileURLForReturnValue = URL("/converted_file/url")

--- a/changelog.d/2006.bugfix
+++ b/changelog.d/2006.bugfix
@@ -1,0 +1,1 @@
+Fixed some issues with voice messages when sent from a bridge.


### PR DESCRIPTION
This PR fixes some issues related to #2006 

- [mautrix-signal](https://github.com/mautrix/signal) bridge doesn't provide `org.matrix.msc1767.audio`
If the duration is missing from the voice message event, the `AudioPlayerState` updates its duration once the audio file is loaded.
This will not fix the "0:00" duration in the timeline if the audio file has not been loaded (which only happens the first time a voice message is played). The bridge itself needs to be fixed to add the missing audio field.

- [mautrix-whatsapp](https://github.com/mautrix/whatsapp) send `"audio/ogg; codecs=opus"` as mime type, which is correct but was not handled by EX.  With this PR, mime type with parameters will work as expected.

