### PR TITLE
Make the attachment menu an actual menu.

### DIFF
--- a/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarModels.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarModels.swift
@@ -32,11 +32,7 @@ enum ComposerToolbarVoiceMessageAction {
 
 enum ComposerToolbarViewModelAction {
     case sendMessage(plain: String, html: String?, mode: RoomScreenComposerMode, intentionalMentions: IntentionalMentions)
-    case displayCameraPicker
-    case displayMediaPicker
-    case displayDocumentPicker
-    case displayLocationPicker
-    case displayNewPollForm
+    case attach(ComposerAttachmentType)
 
     case handlePasteOrDrop(provider: NSItemProvider)
 
@@ -51,17 +47,21 @@ enum ComposerToolbarViewAction {
     case sendMessage
     case cancelReply
     case cancelEdit
-    case displayCameraPicker
-    case displayMediaPicker
-    case displayDocumentPicker
-    case displayLocationPicker
-    case displayNewPollForm
+    case attach(ComposerAttachmentType)
     case handlePasteOrDrop(provider: NSItemProvider)
     case enableTextFormatting
     case composerAction(action: ComposerAction)
     case selectedSuggestion(_ suggestion: SuggestionItem)
     
     case voiceMessage(ComposerToolbarVoiceMessageAction)
+}
+
+enum ComposerAttachmentType {
+    case camera
+    case photoLibrary
+    case file
+    case location
+    case poll
 }
 
 struct ComposerToolbarViewState: BindableState {
@@ -116,14 +116,6 @@ struct ComposerToolbarViewStateBindings {
     var composerExpanded = false
     var formatItems: [FormatItem] = .init()
     var alertInfo: AlertInfo<UUID>?
-
-    var showAttachmentPopover = false {
-        didSet {
-            if showAttachmentPopover {
-                composerFocused = false
-            }
-        }
-    }
 }
 
 /// An item in the toolbar

--- a/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/ComposerToolbarViewModel.swift
@@ -120,16 +120,9 @@ final class ComposerToolbarViewModel: ComposerToolbarViewModelType, ComposerTool
         case .cancelEdit:
             set(mode: .default)
             set(text: "")
-        case .displayCameraPicker:
-            actionsSubject.send(.displayCameraPicker)
-        case .displayMediaPicker:
-            actionsSubject.send(.displayMediaPicker)
-        case .displayDocumentPicker:
-            actionsSubject.send(.displayDocumentPicker)
-        case .displayLocationPicker:
-            actionsSubject.send(.displayLocationPicker)
-        case .displayNewPollForm:
-            actionsSubject.send(.displayNewPollForm)
+        case .attach(let attachment):
+            state.bindings.composerFocused = false
+            actionsSubject.send(.attach(attachment))
         case .handlePasteOrDrop(let provider):
             actionsSubject.send(.handlePasteOrDrop(provider: provider))
         case .enableTextFormatting:

--- a/ElementX/Sources/Screens/ComposerToolbar/View/RoomAttachmentPicker.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/RoomAttachmentPicker.swift
@@ -20,9 +20,6 @@ import WysiwygComposer
 
 struct RoomAttachmentPicker: View {
     @ObservedObject var context: ComposerToolbarViewModel.Context
-    @Environment(\.isPresented) var isPresented
-
-    @State private var sheetContentFrame: CGRect = .zero
     
     var body: some View {
         // Use a menu instead of the popover/sheet shown in Figma because overriding the colour scheme

--- a/ElementX/Sources/Screens/ComposerToolbar/View/RoomAttachmentPicker.swift
+++ b/ElementX/Sources/Screens/ComposerToolbar/View/RoomAttachmentPicker.swift
@@ -25,8 +25,10 @@ struct RoomAttachmentPicker: View {
     @State private var sheetContentFrame: CGRect = .zero
     
     var body: some View {
-        Button {
-            context.showAttachmentPopover = true
+        // Use a menu instead of the popover/sheet shown in Figma because overriding the colour scheme
+        // results in a rendering bug on 17.1: https://github.com/vector-im/element-x-ios/issues/2157
+        Menu {
+            menuContent
         } label: {
             CompoundIcon(asset: Asset.Images.composerAttachment, size: .custom(30), relativeTo: .title)
                 .scaledPadding(7, relativeTo: .title)
@@ -34,21 +36,12 @@ struct RoomAttachmentPicker: View {
         .buttonStyle(RoomAttachmentPickerButtonStyle())
         .accessibilityLabel(L10n.actionAddToTimeline)
         .accessibilityIdentifier(A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions)
-        .popover(isPresented: $context.showAttachmentPopover) {
-            menuContent
-                .padding(.top, isPresented ? 20 : 0)
-                .readFrame($sheetContentFrame)
-                .presentationDetents([.height(sheetContentFrame.height)])
-                .presentationBackground(.compound.bgCanvasDefault)
-                .presentationDragIndicator(.visible)
-        }
     }
     
     var menuContent: some View {
         VStack(alignment: .leading, spacing: 0.0) {
             Button {
-                context.showAttachmentPopover = false
-                context.send(viewAction: .displayMediaPicker)
+                context.send(viewAction: .attach(.photoLibrary))
             } label: {
                 Label(L10n.screenRoomAttachmentSourceGallery, icon: \.image)
                     .labelStyle(.menuSheet)
@@ -56,8 +49,7 @@ struct RoomAttachmentPicker: View {
             .accessibilityIdentifier(A11yIdentifiers.roomScreen.attachmentPickerPhotoLibrary)
             
             Button {
-                context.showAttachmentPopover = false
-                context.send(viewAction: .displayDocumentPicker)
+                context.send(viewAction: .attach(.file))
             } label: {
                 Label(L10n.screenRoomAttachmentSourceFiles, iconAsset: Asset.Images.attachment)
                     .labelStyle(.menuSheet)
@@ -65,8 +57,7 @@ struct RoomAttachmentPicker: View {
             .accessibilityIdentifier(A11yIdentifiers.roomScreen.attachmentPickerDocuments)
             
             Button {
-                context.showAttachmentPopover = false
-                context.send(viewAction: .displayCameraPicker)
+                context.send(viewAction: .attach(.camera))
             } label: {
                 Label(L10n.screenRoomAttachmentSourceCamera, iconAsset: Asset.Images.takePhoto)
                     .labelStyle(.menuSheet)
@@ -74,8 +65,7 @@ struct RoomAttachmentPicker: View {
             .accessibilityIdentifier(A11yIdentifiers.roomScreen.attachmentPickerCamera)
 
             Button {
-                context.showAttachmentPopover = false
-                context.send(viewAction: .displayLocationPicker)
+                context.send(viewAction: .attach(.location))
             } label: {
                 Label(L10n.screenRoomAttachmentSourceLocation, iconAsset: Asset.Images.addLocation)
                     .labelStyle(.menuSheet)
@@ -83,8 +73,7 @@ struct RoomAttachmentPicker: View {
             .accessibilityIdentifier(A11yIdentifiers.roomScreen.attachmentPickerLocation)
 
             Button {
-                context.showAttachmentPopover = false
-                context.send(viewAction: .displayNewPollForm)
+                context.send(viewAction: .attach(.poll))
             } label: {
                 Label(L10n.screenRoomAttachmentSourcePoll, iconAsset: Asset.Images.polls)
                     .labelStyle(.menuSheet)
@@ -93,7 +82,6 @@ struct RoomAttachmentPicker: View {
 
             if ServiceLocator.shared.settings.richTextEditorEnabled {
                 Button {
-                    context.showAttachmentPopover = false
                     context.send(viewAction: .enableTextFormatting)
                 } label: {
                     Label(L10n.screenRoomAttachmentTextFormatting, iconAsset: Asset.Images.textFormat)
@@ -109,10 +97,6 @@ private struct RoomAttachmentPickerButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundStyle(configuration.isPressed ? .compound.bgActionPrimaryPressed : .compound.bgActionPrimaryRest)
-            // Disable animations to fix a bug when the system is in Light mode but the app in Dark mode. For some
-            // reason the animation causes a glitch with sheet's colour scheme when there are presentation detents.
-            // https://github.com/vector-im/element-x-ios/issues/2157
-            .animation(.noAnimation, value: configuration.isPressed)
     }
 }
 

--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenViewModel.swift
@@ -180,16 +180,8 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
                                          mode: mode,
                                          intentionalMentions: intentionalMentions)
             }
-        case .displayCameraPicker:
-            actionsSubject.send(.displayCameraPicker)
-        case .displayMediaPicker:
-            actionsSubject.send(.displayMediaPicker)
-        case .displayDocumentPicker:
-            actionsSubject.send(.displayDocumentPicker)
-        case .displayLocationPicker:
-            actionsSubject.send(.displayLocationPicker)
-        case .displayNewPollForm:
-            actionsSubject.send(.displayPollForm(mode: .new))
+        case .attach(let attachment):
+            attach(attachment)
         case .handlePasteOrDrop(let provider):
             roomScreenInteractionHandler.handlePasteOrDrop(provider)
         case .composerModeChanged(mode: let mode):
@@ -202,6 +194,21 @@ class RoomScreenViewModel: RoomScreenViewModelType, RoomScreenViewModelProtocol 
     }
     
     // MARK: - Private
+    
+    private func attach(_ attachment: ComposerAttachmentType) {
+        switch attachment {
+        case .camera:
+            actionsSubject.send(.displayCameraPicker)
+        case .photoLibrary:
+            actionsSubject.send(.displayMediaPicker)
+        case .file:
+            actionsSubject.send(.displayDocumentPicker)
+        case .location:
+            actionsSubject.send(.displayLocationPicker)
+        case .poll:
+            actionsSubject.send(.displayPollForm(mode: .new))
+        }
+    }
     
     private func processPollAction(_ action: RoomScreenViewPollAction) {
         switch action {

--- a/IntegrationTests/Sources/UserFlowTests.swift
+++ b/IntegrationTests/Sources/UserFlowTests.swift
@@ -59,13 +59,13 @@ class UserFlowTests: XCTestCase {
         for identifier in [A11yIdentifiers.roomScreen.attachmentPickerPhotoLibrary,
                            A11yIdentifiers.roomScreen.attachmentPickerDocuments,
                            A11yIdentifiers.roomScreen.attachmentPickerLocation] {
-            tapOnButton(A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions)
+            tapOnMenu(A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions)
             tapOnButton(identifier)
             tapOnButton("Cancel")
         }
                 
         // Open attachments picker
-        tapOnButton(A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions)
+        tapOnMenu(A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions)
 
         // Open photo library picker
         tapOnButton(A11yIdentifiers.roomScreen.attachmentPickerPhotoLibrary)
@@ -167,6 +167,12 @@ class UserFlowTests: XCTestCase {
         let button = app.buttons[identifier]
         XCTAssertTrue(button.waitForExistence(timeout: 10.0))
         button.tap()
+    }
+    
+    private func tapOnMenu(_ identifier: String) {
+        let button = app.buttons[identifier]
+        XCTAssertTrue(button.waitForExistence(timeout: 10.0))
+        button.forceTap()
     }
     
     /// Taps on a back button that the system configured with a label but no identifier.

--- a/UITests/Sources/UserSessionScreenTests.swift
+++ b/UITests/Sources/UserSessionScreenTests.swift
@@ -29,7 +29,7 @@ class UserSessionScreenTests: XCTestCase {
         try await Task.sleep(for: .seconds(1))
         try await app.assertScreenshot(.userSessionScreen, step: 2)
 
-        app.buttons[A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions].tap()
+        app.buttons[A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions].forceTap()
         try await app.assertScreenshot(.userSessionScreen, step: 3)
     }
 
@@ -52,7 +52,7 @@ class UserSessionScreenTests: XCTestCase {
         XCTAssert(app.staticTexts[firstRoomName].waitForExistence(timeout: 5.0))
         try await Task.sleep(for: .seconds(1))
 
-        app.buttons[A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions].tap()
+        app.buttons[A11yIdentifiers.roomScreen.composerToolbar.openComposeOptions].forceTap()
         try await app.assertScreenshot(.userSessionScreenRTE, step: 1)
 
         app.buttons[A11yIdentifiers.roomScreen.attachmentPickerTextFormatting].tap()

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.userSessionScreen-3.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.userSessionScreen-3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:51572a32caa534f7da3120f69a8ab046e7f84c911a38bbfd714128364319a085
-size 512517
+oid sha256:aaefc3ed4e24c6efb98965c23b931566ad3e214df66beae06980d627078989a8
+size 676247

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.userSessionScreenRTE-1.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPad-9th-generation.userSessionScreenRTE-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1218fb8e4cfab37f2013282aedc84081c48b067d64d06f5533e8d6f6f76b9a9
-size 520169
+oid sha256:6dd40677ed718698138d9ef21feae07c4474f6e77d179a69549004933c502f0f
+size 723856

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.userSessionScreen-3.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.userSessionScreen-3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0fe47246cf49b033e4c47a3aa3aca3637d4023ed16affaf1338d3154b1cb2cbd
-size 283237
+oid sha256:8d81e5b309e74f8f5f37ea7d9929fae7ff54b3fd502eac1e5a5b322cc024cc98
+size 768968

--- a/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.userSessionScreenRTE-1.png
+++ b/UITests/Sources/__Snapshots__/Application/en-GB-iPhone-14.userSessionScreenRTE-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b74b75ca3a65c7e17a188e7bb06730fe408518679f6f2a1d99026025305d3166
-size 276022
+oid sha256:5a796e2a7131226e3d1a6eca09f1f3c144f605bb2f85d863fd5483b2acd76d9c
+size 851474

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.userSessionScreen-3.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.userSessionScreen-3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1994a582d2cfe62b69d4665bb847ac3c4f796b4cc9f8bd83f6bb231f84566db
-size 505029
+oid sha256:d2a14abaf3a46bfd09368bea8e5f21c5f98d541fc9ddf77eb603237928a2f44a
+size 711656

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.userSessionScreenRTE-1.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPad-9th-generation.userSessionScreenRTE-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b0e3e0f5368ac7e5c5563d5967f1dc224aedebe9b04d10141989ec8883922b6
-size 508387
+oid sha256:499cdf4bdbcef9f952c97cc519894100d5cf964254c31bfc7d9fceb67150eb18
+size 773160

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.userSessionScreen-3.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.userSessionScreen-3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e55c79a65f37a3340c716e6f79d304f26772aaa9aebbdf6f404d45808fea55c0
-size 281966
+oid sha256:0e0de41f6bd8aa6e09e97fa346590e68c7dc320bed218dac22619e95ece787df
+size 829018

--- a/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.userSessionScreenRTE-1.png
+++ b/UITests/Sources/__Snapshots__/Application/pseudo-iPhone-14.userSessionScreenRTE-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88f1c46520cc79be3b233a617af82b8ff88dbabf8ebd8ba441a1f5fd4d44857b
-size 284369
+oid sha256:468fb91896df309b60179b93f567c2bc9971dcb4d81514aa49d7a786f01704ab
+size 942085


### PR DESCRIPTION
A second attempt, fixes #2157, the root cause for which remains a mystery to us (we know that removing the frame reader and detents fixes it, but that isn't a desirable layout). Instead, this PR replaces the popover/sheet with the native menu component which does the right thing. (Discussed with @amshakal before making the change).

https://github.com/vector-im/element-x-ios/assets/6060466/f91596d9-e172-4071-abfd-29661ba8d69a

| Light mode |
| - |
| ![Simulator Screenshot - iPhone 14 - 2023-12-04 at 17 36 11](https://github.com/vector-im/element-x-ios/assets/6060466/8985bbcc-6bbe-4690-ada6-059708ce8040) |
