### PR TITLE
Expand all sections on the view source screen by default.

### DIFF
--- a/ElementX/Sources/Screens/RoomScreen/RoomScreenInteractionHandler.swift
+++ b/ElementX/Sources/Screens/RoomScreen/RoomScreenInteractionHandler.swift
@@ -228,7 +228,7 @@ class RoomScreenInteractionHandler {
             actionsSubject.send(.displayMessageForwarding(itemID: itemID))
         case .viewSource:
             let debugInfo = timelineController.debugInfo(for: eventTimelineItem.id)
-            MXLog.info(debugInfo)
+            MXLog.info("Showing debug info for \(eventTimelineItem.id)")
             actionsSubject.send(.showDebugInfo(debugInfo))
         case .retryDecryption(let sessionID):
             Task {

--- a/ElementX/Sources/Screens/RoomScreen/View/TimelineItemDebugView.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/TimelineItemDebugView.swift
@@ -25,7 +25,7 @@ struct TimelineItemDebugView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 8) {
-                    TimelineItemInfoDisclosureGroup(title: "Model", text: info.model, isInitiallyExpanded: true)
+                    TimelineItemInfoDisclosureGroup(title: "Model", text: info.model)
                     
                     if let originalJSONInfo = info.originalJSON {
                         TimelineItemInfoDisclosureGroup(title: "Original JSON", text: originalJSONInfo)
@@ -58,16 +58,10 @@ struct TimelineItemDebugView: View {
     // MARK: - Private
     
     private struct TimelineItemInfoDisclosureGroup: View {
-        @State private var isExpanded: Bool
+        @State private var isExpanded = true
         
         let title: String
         let text: String
-        
-        init(title: String, text: String, isInitiallyExpanded: Bool = false) {
-            self.title = title
-            self.text = text
-            isExpanded = isInitiallyExpanded
-        }
         
         var body: some View {
             VStack(spacing: 0.0) {


### PR DESCRIPTION
When you wanted to look at the JSON it was annoying to have to scroll down, expand the section and then scroll again to see it.