### PR TITLE
Replace searchable modifiers with a custom implementation using UISearchController.

### DIFF
--- a/ElementX/Sources/Other/SwiftUI/Search.swift
+++ b/ElementX/Sources/Other/SwiftUI/Search.swift
@@ -26,18 +26,18 @@ extension View {
     /// - Parameters:
     ///   - query: The current or starting search text.
     ///   - placeholder: The string to display when there’s no other text in the text field.
-    ///   - hidesNavigationBarDuringPresentation: A Boolean indicating whether to hide the navigation bar when searching.
-    ///   - automaticallyShowsCancelButton: A Boolean indicating whether the search controller manages the visibility of the search bar’s cancel button.
+    ///   - hidesNavigationBar: A Boolean indicating whether to hide the navigation bar when searching.
+    ///   - showsCancelButton: A Boolean indicating whether the search controller manages the visibility of the search bar’s cancel button.
     ///   - disablesInteractiveDismiss: Whether or not interactive dismiss is disabled whilst the user is searching.
     func searchController(query: Binding<String>,
                           placeholder: String? = nil,
-                          hidesNavigationBarDuringPresentation: Bool = false,
-                          automaticallyShowsCancelButton: Bool = true,
+                          hidesNavigationBar: Bool = false,
+                          showsCancelButton: Bool = true,
                           disablesInteractiveDismiss: Bool = false) -> some View {
         modifier(SearchControllerModifier(searchQuery: query,
                                           placeholder: placeholder,
-                                          hidesNavigationBarDuringPresentation: hidesNavigationBarDuringPresentation,
-                                          automaticallyShowsCancelButton: automaticallyShowsCancelButton,
+                                          hidesNavigationBar: hidesNavigationBar,
+                                          showsCancelButton: showsCancelButton,
                                           disablesInteractiveDismiss: disablesInteractiveDismiss))
     }
 }
@@ -46,8 +46,8 @@ private struct SearchControllerModifier: ViewModifier {
     @Binding var searchQuery: String
     
     let placeholder: String?
-    let hidesNavigationBarDuringPresentation: Bool
-    let automaticallyShowsCancelButton: Bool
+    let hidesNavigationBar: Bool
+    let showsCancelButton: Bool
     let disablesInteractiveDismiss: Bool
     
     /// Whether or not the user is currently searching. When ``automaticallyShowsCancelButton``
@@ -60,8 +60,9 @@ private struct SearchControllerModifier: ViewModifier {
             .background {
                 SearchController(searchQuery: $searchQuery,
                                  placeholder: placeholder,
-                                 hidesNavigationBarDuringPresentation: hidesNavigationBarDuringPresentation,
-                                 automaticallyShowsCancelButton: automaticallyShowsCancelButton,
+                                 hidesNavigationBar: hidesNavigationBar,
+                                 showsCancelButton: showsCancelButton,
+                                 hidesSearchBarWhenScrolling: false,
                                  isSearching: $isSearching)
             }
             .onDisappear {
@@ -76,10 +77,10 @@ private struct SearchControllerModifier: ViewModifier {
 private struct SearchController: UIViewControllerRepresentable {
     @Binding var searchQuery: String
     
-    var placeholder: String?
-    var hidesNavigationBarDuringPresentation = false
-    var automaticallyShowsCancelButton = true
-    var hidesSearchBarWhenScrolling = false
+    let placeholder: String?
+    let hidesNavigationBar: Bool
+    let showsCancelButton: Bool
+    let hidesSearchBarWhenScrolling: Bool
     
     @Binding var isSearching: Bool
     
@@ -91,11 +92,11 @@ private struct SearchController: UIViewControllerRepresentable {
     func updateUIViewController(_ viewController: SearchInjectionViewController, context: Context) {
         let searchController = viewController.searchController
         searchController.searchBar.text = searchQuery
-        searchController.hidesNavigationBarDuringPresentation = hidesNavigationBarDuringPresentation
-        searchController.automaticallyShowsCancelButton = automaticallyShowsCancelButton
+        searchController.hidesNavigationBarDuringPresentation = hidesNavigationBar
+        searchController.automaticallyShowsCancelButton = showsCancelButton
         
         if searchController.isActive, !isSearching {
-            DispatchQueue.main.async { searchController.isActive = isSearching }
+            DispatchQueue.main.async { searchController.isActive = false }
         } else if !searchController.isActive, isSearching {
             DispatchQueue.main.async { searchController.isActive = true }
         }

--- a/ElementX/Sources/Other/SwiftUI/Search.swift
+++ b/ElementX/Sources/Other/SwiftUI/Search.swift
@@ -22,6 +22,7 @@ extension View {
     ///
     /// Whilst we originally used introspect to configure parameters such as preventing the navigation bar from hiding
     /// during a search, this proved unreliable from iOS 17.1 onwards. This implementation avoids all of those shenanigans.
+    /// **Note:** For some reason the font size is incorrect in the PreviewTests, buts its fine in UI tests and within the app.
     ///
     /// - Parameters:
     ///   - query: The current or starting search text.

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -33,8 +33,7 @@ struct InviteUsersScreen: View {
             .toolbar { toolbar }
             .disableInteractiveDismissOnSearch()
             .dismissSearchOnDisappear()
-            .searchable(text: $context.searchQuery, placement: .navigationBarDrawer(displayMode: .always), prompt: L10n.commonSearchForSomeone)
-            .searchableConfiguration(hidesNavigationBar: false)
+            .searchController(query: $context.searchQuery, automaticallyShowsCancelButton: false)
             .compoundSearchField()
             .alert(item: $context.alertInfo)
     }

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -32,7 +32,7 @@ struct InviteUsersScreen: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { toolbar }
             .searchController(query: $context.searchQuery,
-                              automaticallyShowsCancelButton: false,
+                              showsCancelButton: false,
                               disablesInteractiveDismiss: true)
             .compoundSearchField()
             .alert(item: $context.alertInfo)

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -31,9 +31,9 @@ struct InviteUsersScreen: View {
             .navigationTitle(L10n.screenCreateRoomAddPeopleTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { toolbar }
-            .disableInteractiveDismissOnSearch()
-            .dismissSearchOnDisappear()
-            .searchController(query: $context.searchQuery, automaticallyShowsCancelButton: false)
+            .searchController(query: $context.searchQuery,
+                              automaticallyShowsCancelButton: false,
+                              disablesInteractiveDismiss: true)
             .compoundSearchField()
             .alert(item: $context.alertInfo)
     }

--- a/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
+++ b/ElementX/Sources/Screens/InviteUsersScreen/View/InviteUsersScreen.swift
@@ -32,6 +32,7 @@ struct InviteUsersScreen: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { toolbar }
             .searchController(query: $context.searchQuery,
+                              placeholder: L10n.commonSearchForSomeone,
                               showsCancelButton: false,
                               disablesInteractiveDismiss: true)
             .compoundSearchField()

--- a/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
@@ -57,8 +57,7 @@ struct MessageForwardingScreen: View {
                 .disabled(context.viewState.selectedRoomID == nil)
             }
         }
-        .searchable(text: $context.searchQuery, placement: .navigationBarDrawer(displayMode: .always))
-        .searchableConfiguration(hidesNavigationBar: false)
+        .searchController(query: $context.searchQuery, automaticallyShowsCancelButton: false)
         .compoundSearchField()
         .disableAutocorrection(true)
     }

--- a/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
+++ b/ElementX/Sources/Screens/MessageForwardingScreen/View/MessageForwardingScreen.swift
@@ -57,7 +57,7 @@ struct MessageForwardingScreen: View {
                 .disabled(context.viewState.selectedRoomID == nil)
             }
         }
-        .searchController(query: $context.searchQuery, automaticallyShowsCancelButton: false)
+        .searchController(query: $context.searchQuery, showsCancelButton: false)
         .compoundSearchField()
         .disableAutocorrection(true)
     }

--- a/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
+++ b/ElementX/Sources/Screens/Settings/NotificationSettingsScreen/View/NotificationSettingsScreen.swift
@@ -260,9 +260,9 @@ struct NotificationSettingsScreen_Previews: PreviewProvider, TestablePreview {
 
     static var previews: some View {
         NotificationSettingsScreen(context: viewModel.context)
-            .snapshot(delay: 0.1)
+            .snapshot(delay: 2.0)
         NotificationSettingsScreen(context: viewModelConfigurationMismatch.context)
-            .snapshot(delay: 0.1)
+            .snapshot(delay: 2.0)
             .previewDisplayName("Configuration mismatch")
     }
 }

--- a/ElementX/Sources/Screens/StartChatScreen/View/StartChatScreen.swift
+++ b/ElementX/Sources/Screens/StartChatScreen/View/StartChatScreen.swift
@@ -36,7 +36,7 @@ struct StartChatScreen: View {
         .toolbar { toolbar }
         .searchController(query: $context.searchQuery,
                           placeholder: L10n.commonSearchForSomeone,
-                          automaticallyShowsCancelButton: false,
+                          showsCancelButton: false,
                           disablesInteractiveDismiss: true)
         .compoundSearchField()
         .alert(item: $context.alertInfo)

--- a/ElementX/Sources/Screens/StartChatScreen/View/StartChatScreen.swift
+++ b/ElementX/Sources/Screens/StartChatScreen/View/StartChatScreen.swift
@@ -36,8 +36,7 @@ struct StartChatScreen: View {
         .toolbar { toolbar }
         .disableInteractiveDismissOnSearch()
         .dismissSearchOnDisappear()
-        .searchable(text: $context.searchQuery, placement: .navigationBarDrawer(displayMode: .always), prompt: L10n.commonSearchForSomeone)
-        .searchableConfiguration(hidesNavigationBar: false)
+        .searchController(query: $context.searchQuery, placeholder: L10n.commonSearchForSomeone, automaticallyShowsCancelButton: false)
         .compoundSearchField()
         .alert(item: $context.alertInfo)
     }

--- a/ElementX/Sources/Screens/StartChatScreen/View/StartChatScreen.swift
+++ b/ElementX/Sources/Screens/StartChatScreen/View/StartChatScreen.swift
@@ -34,9 +34,10 @@ struct StartChatScreen: View {
         .navigationTitle(L10n.actionStartChat)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { toolbar }
-        .disableInteractiveDismissOnSearch()
-        .dismissSearchOnDisappear()
-        .searchController(query: $context.searchQuery, placeholder: L10n.commonSearchForSomeone, automaticallyShowsCancelButton: false)
+        .searchController(query: $context.searchQuery,
+                          placeholder: L10n.commonSearchForSomeone,
+                          automaticallyShowsCancelButton: false,
+                          disablesInteractiveDismiss: true)
         .compoundSearchField()
         .alert(item: $context.alertInfo)
     }

--- a/UnitTests/__Snapshots__/PreviewTests/test_inviteUsersScreen.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_inviteUsersScreen.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:630f7168d3ed6a7e1a9d8084af15ab794ba79ece4c63e7147e127a36fb853ce2
-size 78972
+oid sha256:da7a4e7370b3955ed4ff24dfda68a2e911dc5c22c6a05891cb40850935b5fac0
+size 79353

--- a/UnitTests/__Snapshots__/PreviewTests/test_messageForwardingScreen.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_messageForwardingScreen.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9eafc4604f3d3dabdbf85d97ca643be13cb83111ad98def8cc383108067a0269
-size 181066
+oid sha256:56af9ef188080e0fbbc542599c150c2e923be8fa1895b5262662e86b6ff8e8ad
+size 181373

--- a/UnitTests/__Snapshots__/PreviewTests/test_startChatScreen.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_startChatScreen.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33495c3c814ac0162bb8759acc1c6225271aa62dcbbd43f3076e77ffdae1d879
-size 96134
+oid sha256:c7e0c6e4e771ecfe02d50767c3c09740219de4a2aa75d298073e0db1a58e3df7
+size 96770


### PR DESCRIPTION
From iOS 17.1 the search configuration was unreliable (see #2189, #2191). Instead of introspecting the search field, this PR adds a custom implementation that covers what `searchable` plus `searchableConfiguration`, `disableInteractiveDismissOnSearch` and `dismissSearchOnDisappear` provided. This is used in the start chat flow and message forwarding screen with the same configuration as originally used for iOS 16 (showing the nav bar and hiding the cancel button).