### PR TITLE
Fix Spacing

### DIFF
--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -172,6 +172,17 @@ struct AttributedStringBuilder: AttributedStringBuilderProtocol {
         while (attributedString.string as NSString).hasSuffixCharacter(from: .whitespacesAndNewlines) {
             attributedString.deleteCharacters(in: .init(location: attributedString.length - 1, length: 1))
         }
+        
+        attributedString.enumerateAttribute(.paragraphStyle, in: .init(location: 0, length: attributedString.length)) { value, range, _ in
+            guard let value = value as? NSParagraphStyle,
+                  let newValue = value.mutableCopy() as? NSMutableParagraphStyle else {
+                return
+            }
+            // Paragraph spacing is not applied to the first line, so we use paragraph spacing before instead, and set the paragraph spacing to 0
+            newValue.paragraphSpacingBefore = newValue.paragraphSpacing
+            newValue.paragraphSpacing = 0
+            attributedString.addAttribute(.paragraphStyle, value: newValue, range: range)
+        }
     }
     
     private func addLinksAndMentions(_ attributedString: NSMutableAttributedString) {

--- a/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
+++ b/ElementX/Sources/Other/HTMLParsing/AttributedStringBuilder.swift
@@ -172,17 +172,6 @@ struct AttributedStringBuilder: AttributedStringBuilderProtocol {
         while (attributedString.string as NSString).hasSuffixCharacter(from: .whitespacesAndNewlines) {
             attributedString.deleteCharacters(in: .init(location: attributedString.length - 1, length: 1))
         }
-        
-        attributedString.enumerateAttribute(.paragraphStyle, in: .init(location: 0, length: attributedString.length)) { value, range, _ in
-            guard let value = value as? NSParagraphStyle,
-                  let newValue = value.mutableCopy() as? NSMutableParagraphStyle else {
-                return
-            }
-            // Paragraph spacing is not applied to the first line, so we use paragraph spacing before instead, and set the paragraph spacing to 0
-            newValue.paragraphSpacingBefore = newValue.paragraphSpacing
-            newValue.paragraphSpacing = 0
-            attributedString.addAttribute(.paragraphStyle, value: newValue, range: range)
-        }
     }
     
     private func addLinksAndMentions(_ attributedString: NSMutableAttributedString) {

--- a/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
+++ b/ElementX/Sources/Screens/RoomScreen/View/Timeline/FormattedBodyText.swift
@@ -35,11 +35,6 @@ struct FormattedBodyText: View {
     private var attributedComponents: [AttributedStringBuilderComponent] {
         var adjustedAttributedString = attributedString + AttributedString(additionalWhitespacesSuffix)
         
-        // If this is not a list, force the writing direction by adding the correct unicode character.
-        if !String(attributedString.characters).starts(with: "\t") {
-            adjustedAttributedString = AttributedString(layoutDirection.isolateLayoutUnicodeString) + adjustedAttributedString
-        }
-        
         // Required to allow the underlying TextView to use  body font when no font is specifie in the AttributedString.
         adjustedAttributedString.mergeAttributes(defaultAttributesContainer, mergePolicy: .keepCurrent)
         
@@ -204,7 +199,8 @@ struct FormattedBodyText_Previews: PreviewProvider, TestablePreview {
             <code>Hello world</code>
             """,
             "<p>This is a list</p>\n<ul>\n<li>One</li>\n<li>Two</li>\n<li>And number 3</li>\n</ul>\n",
-            "<ul><li>First item</li><li>Second item</li><li>Third item</li></ul>"
+            "<ul><li>First item</li><li>Second item</li><li>Third item</li></ul>",
+            "<p>test</p>\n<p>test</p>\n<p>test</p>\n<p>test</p>"
         ]
         
         let attributedStringBuilder = AttributedStringBuilder(permalinkBaseURL: ServiceLocator.shared.settings.permalinkBaseURL, mentionBuilder: MentionBuilder())

--- a/UnitTests/__Snapshots__/PreviewTests/test_formRowLabelStyle.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_formRowLabelStyle.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91b35d6272d23ab9eeeae63aa99fddb5372405290242c20f64058082cb6b244a
-size 83860

--- a/UnitTests/__Snapshots__/PreviewTests/test_formattedBodyText.1.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_formattedBodyText.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8388baf6d6dff565d85ce4e75053f465a923e3e3216649e860f8103fe2bf2293
-size 212392
+oid sha256:311b4e77a2a7265817cd29745a402b28ff6d3dba1bf40c453111c524d9b123bd
+size 212545

--- a/UnitTests/__Snapshots__/PreviewTests/test_formattedBodyText.2.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_formattedBodyText.2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9995de3534f0a609805d432a56b687debebf954972982d32a4436c335ce66c7a
-size 185873
+oid sha256:2f251217b9825c7287653db7e1c0e98597f2af4671e7ebdf019a5cb8bad8cbfa
+size 190875

--- a/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Bubble-RTL.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Bubble-RTL.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:62ac756d6cc4079a8262196872a69fd954b7cb7c6c36d620ef673cb29e03a29a
-size 219583
+oid sha256:445d51c75b800433e6f3241280570fbcbfbc36d1b2331535a2edbf42f9987ce9
+size 219214

--- a/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Bubble.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Bubble.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e7164e0fbc6e603de32225e7a260caed819c7b081c6ce2c8c56db0776c85b7dc
-size 221052
+oid sha256:80fc354244524148c4babe004eb30ce0b0d1bbb486986055e9fd6ca682bb0e0a
+size 221015

--- a/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Plain-RTL.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_textRoomTimelineView.Plain-RTL.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:654156e7f84b79b3f593e9fc28fe73bfbc656d617302cf7428b45e5fc2b90099
-size 198632
+oid sha256:43219a04ef340ad9d6e160f5cd7e5538f3dbf0cc7905a820a0e48ff538fb9335
+size 198431

--- a/UnitTests/__Snapshots__/PreviewTests/test_timelineItemBubbledStylerView.Mock-Timeline-RTL.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_timelineItemBubbledStylerView.Mock-Timeline-RTL.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d9b24eabfe1a1e9b20e073a54b502fe2dd931888bbdfc0f9e3f80daf47da086
-size 340654
+oid sha256:fde1e3eff850632b0efcc9bffcdb6c40e51546f75f287a8db7a2d489425b3d8b
+size 340976

--- a/UnitTests/__Snapshots__/PreviewTests/test_timelineItemStyler.Bubbles-LTR-with-different-layout-languages.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_timelineItemStyler.Bubbles-LTR-with-different-layout-languages.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c935c6529a9f9a63915c3cab80dc9fc7df8723db6258c4d8c445df7c84296e65
-size 110159
+oid sha256:d259f4531bd82e119f808a9b24fede04cebfb7d5d81b22b13b0e0c4711feb2ca
+size 110235

--- a/UnitTests/__Snapshots__/PreviewTests/test_timelineItemStyler.Bubbles-RTL-with-different-layout-languages.png
+++ b/UnitTests/__Snapshots__/PreviewTests/test_timelineItemStyler.Bubbles-RTL-with-different-layout-languages.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ebec20c376958c8a4b10a4055f15963a27ed744e0ac594aae803b0e56c6477a2
-size 108424
+oid sha256:8a57b7699be0d42a7627b9749ac1920557764f9ef0df5d6200d0d87d6ccc0c73
+size 108105


### PR DESCRIPTION
This will probably end up breaking support for bidi text (text that contains both LTR and RTL at the same time) with the timestamp, but will make line spacing consistent